### PR TITLE
fltk: add upstream CGLineCap fix for 10.11 SDK

### DIFF
--- a/fltk/patch-CGLineCap.patch
+++ b/fltk/patch-CGLineCap.patch
@@ -1,0 +1,37 @@
+From 7767f015258942f1ea8ebec322ee7e218903a6b8 Mon Sep 17 00:00:00 2001
+From: manolo <manolo@ea41ed52-d2ee-0310-a9c1-e6b18d33e121>
+Date: Fri, 17 Jul 2015 16:16:09 +0000
+Subject: [PATCH] Fix compilation errors with Mac OS 10.11 that no longer
+ accepts   enum CGLineCap but wants   CGLineCap as type name.
+
+---
+ src/fl_line_style.cxx | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/src/fl_line_style.cxx b/src/fl_line_style.cxx
+index 947f01a..40274d3 100644
+--- a/src/fl_line_style.cxx
++++ b/src/fl_line_style.cxx
+@@ -35,8 +35,8 @@ int fl_line_width_ = 0;
+ 
+ #ifdef __APPLE_QUARTZ__
+ float fl_quartz_line_width_ = 1.0f;
+-static enum CGLineCap fl_quartz_line_cap_ = kCGLineCapButt;
+-static enum CGLineJoin fl_quartz_line_join_ = kCGLineJoinMiter;
++static /*enum*/ CGLineCap fl_quartz_line_cap_ = kCGLineCapButt;
++static /*enum*/ CGLineJoin fl_quartz_line_join_ = kCGLineJoinMiter;
+ static CGFloat *fl_quartz_line_pattern = 0;
+ static int fl_quartz_line_pattern_size = 0;
+ void fl_quartz_restore_line_style_() {
+@@ -110,9 +110,9 @@ void Fl_Graphics_Driver::line_style(int style, int width, char* dashes) {
+   DeleteObject(fl_current_xmap->pen);
+   fl_current_xmap->pen = newpen;
+ #elif defined(__APPLE_QUARTZ__)
+-  static enum CGLineCap Cap[4] = { kCGLineCapButt, kCGLineCapButt, 
++  static /*enum*/ CGLineCap Cap[4] = { kCGLineCapButt, kCGLineCapButt,
+                                    kCGLineCapRound, kCGLineCapSquare };
+-  static enum CGLineJoin Join[4] = { kCGLineJoinMiter, kCGLineJoinMiter, 
++  static /*enum*/ CGLineJoin Join[4] = { kCGLineJoinMiter, kCGLineJoinMiter, 
+                                     kCGLineJoinRound, kCGLineJoinBevel };
+   if (width<1) width = 1;
+   fl_quartz_line_width_ = (float)width; 


### PR DESCRIPTION
svn: http://seriss.com/public/fltk/fltk/branches/branch-1.3@10794

Upstream commit: "Fix compilation errors with Mac OS 10.11 that no
longer accepts enum CGLineCap but wants CGLineCap as type name."