### PR TITLE
prettyping: Add patch to fix IPv6 parsing

### DIFF
--- a/prettyping/ipv6.patch
+++ b/prettyping/ipv6.patch
@@ -1,0 +1,21 @@
+diff --git a/prettyping b/prettyping
+index 6470f04..484e12e 100755
+--- a/prettyping
++++ b/prettyping
+@@ -750,14 +750,14 @@ BEGIN {
+ {
+ 	# Sample line:
+ 	# 64 bytes from 8.8.8.8: icmp_seq=1 ttl=49 time=184 ms
+-	if( $0 ~ /^[0-9]+ bytes from .*: icmp_[rs]eq=[0-9]+ ttl=[0-9]+ time=[0-9.]+ *ms/ ) {
++	if( $0 ~ /^[0-9]+ bytes from .*[:,] icmp_[rs]eq=[0-9]+ (ttl|hlim)=[0-9]+ time=[0-9.]+ *ms/ ) {
+ 		if( other_line_times >= 2 ) {
+ 			other_line_finished_repeating()
+ 		}
+ 
+ 		# $1 = useless prefix string
+ 		# $2 = icmp_seq
+-		# $3 = ttl
++		# $3 = ttl/hlim
+ 		# $4 = time
+ 
+ 		# This must be called before incrementing the last_seq variable!


### PR DESCRIPTION
OS X/BSD ping has slightly different output when doing IPv6 compared to GNU/ping.

This is a partial from denilsonsa/prettyping#11.