### PR TITLE
gox: go build tags support

### DIFF
--- a/gox/go-build-tags.diff
+++ b/gox/go-build-tags.diff
@@ -1,0 +1,58 @@
+diff --git a/go.go b/go.go
+index 0105749..cb7a3f5 100644
+--- a/go.go
++++ b/go.go
+@@ -19,7 +19,7 @@ type OutputTemplateData struct {
+ }
+ 
+ // GoCrossCompile
+-func GoCrossCompile(dir string, platform Platform, outputTpl string, ldflags string) error {
++func GoCrossCompile(dir string, platform Platform, outputTpl string, ldflags string, tags string) error {
+ 	env := append(os.Environ(),
+ 		"GOOS="+platform.OS,
+ 		"GOARCH="+platform.Arch)
+@@ -44,6 +44,7 @@ func GoCrossCompile(dir string, platform Platform, outputTpl string, ldflags str
+ 
+ 	_, err = execGo(env, "build",
+ 		"-ldflags", ldflags,
++		"-tags", tags,
+ 		"-o", outputPath.String(),
+ 		dir)
+ 	return err
+diff --git a/main.go b/main.go
+index dc2f9bc..5d4fb4f 100644
+--- a/main.go
++++ b/main.go
+@@ -21,6 +21,7 @@ func realMain() int {
+ 	var outputTpl string
+ 	var parallel int
+ 	var platformFlag PlatformFlag
++	var tags string
+ 	var verbose bool
+ 	flags := flag.NewFlagSet("gox", flag.ExitOnError)
+ 	flags.Usage = func() { printUsage() }
+@@ -28,6 +29,7 @@ func realMain() int {
+ 	flags.Var(platformFlag.OSArchFlagValue(), "osarch", "os/arch pairs to build for or skip")
+ 	flags.Var(platformFlag.OSFlagValue(), "os", "os to build for or skip")
+ 	flags.StringVar(&ldflags, "ldflags", "", "linker flags")
++	flags.StringVar(&tags, "tags", "", "go build tags")
+ 	flags.StringVar(&outputTpl, "output", "{{.Dir}}_{{.OS}}_{{.Arch}}", "output path")
+ 	flags.IntVar(&parallel, "parallel", -1, "parallelization factor")
+ 	flags.BoolVar(&buildToolchain, "build-toolchain", false, "build toolchain")
+@@ -89,7 +91,7 @@ func realMain() int {
+ 				defer wg.Done()
+ 				semaphore <- 1
+ 				fmt.Printf("--> %15s: %s\n", platform.String(), path)
+-				if err := GoCrossCompile(path, platform, outputTpl, ldflags); err != nil {
++				if err := GoCrossCompile(path, platform, outputTpl, ldflags, tags); err != nil {
+ 					errorLock.Lock()
+ 					defer errorLock.Unlock()
+ 					errors = append(errors,
+@@ -128,6 +130,7 @@ Options:
+   -arch=""            Space-separated list of architectures to build for
+   -build-toolchain    Build cross-compilation toolchain
+   -ldflags=""         Additional '-ldflags' value to pass to go build
++  -tags=""            Additional '-tags' value to pass to go build
+   -os=""              Space-separated list of operating systems to build for
+   -osarch=""          Space-separated list of os/arch pairs to build for
+   -output="foo"       Output path template. See below for more info


### PR DESCRIPTION
Adapted to apply to the gox 0.3.0 release tag, but otherwise equivalent to
upstream commit "Allow go build tags to be passed as well":
https://github.com/mitchellh/gox/commit/e557cfcb6e3c7f63c3abdae5dd354931814b0bdb