### PR TITLE
python: issue10910 workaround for 2.7.12

### DIFF
--- a/python/issue10910-workaround-for-2.7.12.diff
+++ b/python/issue10910-workaround-for-2.7.12.diff
@@ -1,0 +1,25 @@
+diff --git a/Include/pyport.h b/Include/pyport.h
+index 85e852f..c0a1bb9 100644
+--- a/Include/pyport.h
++++ b/Include/pyport.h
+@@ -713,6 +713,12 @@ extern int fdatasync(int);
+ #endif
+ 
+ #ifdef _PY_PORT_CTYPE_UTF8_ISSUE
++#ifndef __cplusplus
++   /* The workaround below is unsafe in C++ because
++    * the <locale> defines these symbols as real functions,
++    * with a slightly different signature.
++    * See issue #10910
++    */
+ #include <ctype.h>
+ #include <wctype.h>
+ #undef isalnum
+@@ -730,6 +736,7 @@ extern int fdatasync(int);
+ #undef toupper
+ #define toupper(c) towupper(btowc(c))
+ #endif
++#endif
+ 
+ 
+ /* Declarations for symbol visibility.


### PR DESCRIPTION
Same patch for stable doesn't apply cleanly to 2.7.12-rc1:
https://bugs.python.org/file30805/issue10910-workaround.txt