### PR TITLE
gnu-apl: clang fixes

### DIFF
--- a/gnu-apl/clang-fixes.patch
+++ b/gnu-apl/clang-fixes.patch
@@ -1,0 +1,12258 @@
+From 23dd9084c6227a2f4c01857d5c03e5f6988b8645 Mon Sep 17 00:00:00 2001
+From: j_sauermann <j_sauermann@bd74f7bd-1a55-4bac-9fab-68015b139e80>
+Date: Mon, 30 Mar 2015 13:27:11 +0000
+Subject: [PATCH 1/7] =?UTF-8?q?fixed=20dyadic=20=E2=8A=83=20problem?=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+---
+ src/PrimitiveFunction.cc |  5 +++--
+ src/Value.cc             | 20 ++++++++++++++++++--
+ src/buildtag.hh          |  2 +-
+ 3 files changed, 22 insertions(+), 5 deletions(-)
+
+diff --git a/src/PrimitiveFunction.cc b/src/PrimitiveFunction.cc
+index 525c873..6c63678 100644
+--- a/src/PrimitiveFunction.cc
++++ b/src/PrimitiveFunction.cc
+@@ -2196,8 +2196,9 @@ const Cell * cB = &B->get_ravel(c);
+         Cell * cell = cB->get_lval_value();
+         if (cell->is_pointer_cell())
+            {
+-             Value_P sub = cell->get_pointer_value();
+-             return sub->get_cellrefs(LOC);
++             Value_P sub(LOC);
++             new (sub->next_ravel())   LvalCell(cell, cell_owner);
++             return sub;
+            }
+ 
+         Value_P Z(LOC);
+diff --git a/src/Value.cc b/src/Value.cc
+index f900f8d..eee6bfb 100644
+--- a/src/Value.cc
++++ b/src/Value.cc
+@@ -984,9 +984,25 @@ const ShapeItem ec_z = Z->element_count();
+ Value_P
+ Value::index(Value_P X) const
+ {
+-   if (get_rank() != 1)   RANK_ERROR;
++   if (get_rank() != 1)
++      {
++        // this is either an error, or a selective assignment
++        //
++        if (get_rank() == 0 &&
++            get_ravel(0).is_lval_cell())   // selective assignment
++           {
++             const Cell & ptr = *get_ravel(0).get_lval_value();
++             if (ptr.is_pointer_cell())
++                {
++                  Value_P dest = ptr.get_pointer_value()->get_cellrefs(LOC);
++                  return dest->index(X);
++                }
++           }
++
++         RANK_ERROR;
++      }
+ 
+-   if (!X)   return clone(LOC);
++   if (!X)   return clone(LOC);   // elided index
+ 
+ const Shape shape_Z(X->get_shape());
+ Value_P Z(shape_Z, LOC);
+diff --git a/src/buildtag.hh b/src/buildtag.hh
+index c28cfca..2dd9f19 100644
+--- a/src/buildtag.hh
++++ b/src/buildtag.hh
+@@ -1,3 +1,3 @@
+ #include "Common.hh"
+-#define BUILDTAG PACKAGE_NAME, PACKAGE_VERSION " / 9529", "2015-03-29 16:51:57 UTC", "Linux 3.13.0-37-generic i686", ""
++#define BUILDTAG PACKAGE_NAME, PACKAGE_VERSION " / 9538", "2015-03-30 13:24:26 UTC", "Linux 3.13.0-37-generic i686", "'--enable-maintainer-mode' 'DEVELOP_WANTED=yes'"
+ #define ARCHIVE_SVN  9479
+
+From d3b5ce9f4a079af8f03c664d6f455cb8eb7f722f Mon Sep 17 00:00:00 2001
+From: j_sauermann <j_sauermann@bd74f7bd-1a55-4bac-9fab-68015b139e80>
+Date: Mon, 30 Mar 2015 15:07:27 +0000
+Subject: [PATCH 2/7] removed auto-generated files
+
+---
+ src/configure_args.cc | 2 --
+ src/makefile.h        | 9 ---------
+ 2 files changed, 11 deletions(-)
+ delete mode 100644 src/configure_args.cc
+ delete mode 100644 src/makefile.h
+
+diff --git a/src/configure_args.cc b/src/configure_args.cc
+deleted file mode 100644
+index 187ee63..0000000
+--- a/src/configure_args.cc
++++ /dev/null
+@@ -1,2 +0,0 @@
+-extern const char * configure_args;
+-const char * configure_args = "./configure  '--host=i686-pc-linux-gnu' '--build=i686-pc-linux-gnu' '--program-prefix=' '--disable-dependency-tracking' '--prefix=/usr' '--exec-prefix=/usr' '--bindir=/usr/bin' '--sbindir=/usr/sbin' '--sysconfdir=/etc' '--datadir=/usr/share' '--includedir=/usr/include' '--libdir=/usr/lib' '--libexecdir=/usr/lib/i386-linux-gnu' '--localstatedir=/var' '--sharedstatedir=/usr/com' '--mandir=/usr/share/man' '--infodir=/usr/share/info' 'build_alias=i686-pc-linux-gnu' 'host_alias=i686-pc-linux-gnu' 'CFLAGS=-O2 -g -march=i486' 'CXXFLAGS=-O2 -g -march=i486'";
+diff --git a/src/makefile.h b/src/makefile.h
+deleted file mode 100644
+index 97df236..0000000
+--- a/src/makefile.h
++++ /dev/null
+@@ -1,9 +0,0 @@
+-// some strings exported from Makefile
+-//
+-#define Makefile__bindir     "/usr/bin"
+-#define Makefile__docdir     "/usr/share/doc/apl"
+-#define Makefile__sysconfdir "/etc"
+-#define Makefile__pkglibdir  "/usr/lib/apl"
+-#define Makefile__localedir  "/usr/share/locale"
+-#define Makefile__srcdir     "/home/eedjsa/projects/juergen/apl-1.5/src"
+-
+
+From d69d4ba3774ccc7e9f351a6cc5dd82762e5b9bef Mon Sep 17 00:00:00 2001
+From: j_sauermann <j_sauermann@bd74f7bd-1a55-4bac-9fab-68015b139e80>
+Date: Tue, 31 Mar 2015 14:08:27 +0000
+Subject: [PATCH 3/7] fixed clang compile issues
+
+---
+ Makefile.am               |   2 +
+ Makefile.in               |   2 +
+ src/APL_types.hh          |   4 +-
+ src/APs/AP210.cc          |   6 +--
+ src/APs/APmain.cc         |  14 +++---
+ src/APs/APserver.cc       |  60 +++++++++++++-------------
+ src/APs/Makefile.am       |   5 ++-
+ src/APs/Makefile.in       |  13 +++---
+ src/APs/Svar_DB_server.cc |  16 +++----
+ src/Archive.cc            |  49 ++++++++++-----------
+ src/Archive.hh            |   2 +-
+ src/Bif_F12_FORMAT.cc     |   4 +-
+ src/Bif_F12_FORMAT.hh     |   6 +--
+ src/Command.cc            |  22 ++++------
+ src/Common.hh             |  18 ++++----
+ src/Executable.cc         |   2 +-
+ src/IndexExpr.hh          |   2 +-
+ src/IndexIterator.cc      |   2 +-
+ src/InputFile.cc          |   2 +-
+ src/IntCell.cc            |   6 +--
+ src/LibPaths.cc           |  14 +++---
+ src/LineInput.cc          |  10 ++---
+ src/LineInput.hh          |   4 +-
+ src/Makefile.am           |  13 ++----
+ src/Makefile.in           |  15 ++-----
+ src/Nabla.cc              |   6 +--
+ src/NumericCell.cc        |   6 +--
+ src/Parallel.cc           |   4 +-
+ src/PrimitiveFunction.cc  |   2 +-
+ src/PrintBuffer.cc        |  14 +++---
+ src/PrintBuffer.hh        |  12 +++---
+ src/ProcessorID.cc        |   2 +-
+ src/QuadFunction.cc       |   8 ++--
+ src/Quad_RL.hh            |   2 +-
+ src/Quad_SVx.cc           |  27 ++++++------
+ src/Simple_string.hh      |  28 ++++++------
+ src/Svar_DB.cc            |  14 +++---
+ src/Svar_signals.hh       |  10 ++---
+ src/SymbolTable.cc        |   9 +++-
+ src/SystemVariable.def    | 108 +++++++++++++++++++++++-----------------------
+ src/UCS_string.cc         |  12 +++---
+ src/UCS_string.hh         |  10 ++---
+ src/UserFunction.cc       |   6 +--
+ src/UserPreferences.cc    |  20 ++++-----
+ src/Value.cc              |   2 +-
+ src/Workspace.cc          |  20 ++++-----
+ src/Workspace.hh          |  16 +++----
+ src/buildtag.hh           |   4 +-
+ src/configure_args.cc     |   2 +
+ src/main.cc               |   4 --
+ src/makefile.h            |   9 ++++
+ src/native/Makefile.am    |   3 +-
+ src/native/Makefile.in    |   3 +-
+ src/native/file_io.cc     |  29 +++++++------
+ src/tcp_signal.m4         |   8 ++--
+ 55 files changed, 341 insertions(+), 352 deletions(-)
+ create mode 100644 src/configure_args.cc
+ create mode 100644 src/makefile.h
+
+diff --git a/Makefile.am b/Makefile.am
+index a24c682..22fcd0c 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -125,6 +125,8 @@ parallel1:
+ .PHONY:	SYNC
+ SYNC:	DIST
+ 	tar xvzf apl-$(VERSION).tar.gz
++	rm -f apl-$(VERSION)/trunk/src/makefile.h
++	rm -f apl-$(VERSION)/trunk/src/configure_args.cc
+ 	cp -a apl-$(VERSION)/* ../savannah-repo-apl/trunk/
+ 	rm -Rf apl-$(VERSION)
+ 	cd ../savannah-repo-apl ; svn add . --force -q
+diff --git a/Makefile.in b/Makefile.in
+index b45edfe..b72f4d2 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -1030,6 +1030,8 @@ parallel1:
+ .PHONY:	SYNC
+ SYNC:	DIST
+ 	tar xvzf apl-$(VERSION).tar.gz
++	rm -f apl-$(VERSION)/trunk/src/makefile.h
++	rm -f apl-$(VERSION)/trunk/src/configure_args.cc
+ 	cp -a apl-$(VERSION)/* ../savannah-repo-apl/trunk/
+ 	rm -Rf apl-$(VERSION)
+ 	cd ../savannah-repo-apl ; svn add . --force -q
+diff --git a/src/APL_types.hh b/src/APL_types.hh
+index da65bc9..5f08552 100644
+--- a/src/APL_types.hh
++++ b/src/APL_types.hh
+@@ -415,7 +415,9 @@ enum AP_num
+   AP_GENERAL    = 0,      ///< AP for generic offers
+   AP_FIRST_USER = 1001,   ///< the first AP for APL interpreters
+ };
+-
++//-----------------------------------------------------------------------------
++/// longest filename
++enum {  APL_PATH_MAX = 4096 };
+ //////////////////////////////////////////////////////////////
+ // C structs           i                                    //
+ //////////////////////////////////////////////////////////////
+diff --git a/src/APs/AP210.cc b/src/APs/AP210.cc
+index aa14e79..d9e6f4a 100644
+--- a/src/APs/AP210.cc
++++ b/src/APs/AP210.cc
+@@ -235,7 +235,7 @@ const CDR_string & cdr = *var_D.data;
+       {
+         const int len = cdr.header().get_nb();
+         const uint8_t * data = cdr.get_items();
+-        const size_t written = fwrite(data, len, 1, file);
++        const int written = fwrite(data, len, 1, file);
+         if (written == len)   return -48;   // partial write
+ 
+         ++filepos;
+@@ -645,7 +645,7 @@ const uint32_t * varname = Svar_DB::get_varname(var.key);
+ SV_key key_D = Svar_DB::find_pairing_key(var.key);
+    if (key_D == 0)   { error_loc = LOC;   return E_VALUE_ERROR; }
+ Coupled_var * var_D = 0;
+-   for (int c = 0; c < coupled_vars.size(); ++c)
++   for (size_t c = 0; c < coupled_vars.size(); ++c)
+        {
+          if (coupled_vars[c].key == key_D)
+             {
+@@ -656,7 +656,7 @@ Coupled_var * var_D = 0;
+    if (var_D == 0)
+       {
+         get_CERR() << "key_D = " << (key_D & 0xFFFF) << endl;
+-        for (int c = 0; c < coupled_vars.size(); ++c)
++        for (size_t c = 0; c < coupled_vars.size(); ++c)
+             get_CERR() << "key = " << (coupled_vars[c].key & 0xFFFF) << endl;
+ 
+         error_loc = LOC;   return E_VALUE_ERROR;
+diff --git a/src/APs/APmain.cc b/src/APs/APmain.cc
+index e096bcd..4b07d6c 100644
+--- a/src/APs/APmain.cc
++++ b/src/APs/APmain.cc
+@@ -92,7 +92,7 @@ uint64_t ret = current.tv_sec;
+ bool
+ add_var(SV_key key)
+ {
+-   for (int c = 0; c < coupled_vars.size(); ++c)
++   for (size_t c = 0; c < coupled_vars.size(); ++c)
+        {
+          Coupled_var & cv = coupled_vars[c];
+          if (key == cv.key)   return true;   // key already exists
+@@ -110,7 +110,7 @@ Coupled_var cv = { key, 0, 0 };
+ void
+ print_vars(ostream & out)
+ {
+-   for (int c = 0; c < coupled_vars.size(); ++c)
++   for (size_t c = 0; c < coupled_vars.size(); ++c)
+        {
+          Coupled_var & cv = coupled_vars[c];
+          get_CERR() << "   key: 0x" << hex << cv.key << dec << " ";
+@@ -143,8 +143,6 @@ AP_num3 this_proc = ProcessorID::get_id();
+    if (verbose)   get_CERR() << pref << " unregistering processor "
+                        << this_proc << endl;
+ 
+-const TCP_socket tcp = Svar_DB::get_DB_tcp();
+-
+    if (verbose)   get_CERR() << pref << " done (got ^C)" << endl;
+ 
+    exit(0);
+@@ -262,8 +260,6 @@ const TCP_socket tcp = Svar_DB::get_DB_tcp();
+         return 3;
+       }
+ 
+-const int nfds = 1 + tcp2;
+-
+ string progname(prog_name());
+ 
+       { REGISTER_PROCESSOR_c request(tcp, this_proc.id.proc,
+@@ -344,7 +340,7 @@ cerr << "APnnn got " << signal->get_sigName() << endl;
+                                        << " got RETRACT_OFFER" << endl;
+                  {
+                    const SV_key key = signal->get__RETRACT_OFFER__key();
+-                   for (int c = 0; c < coupled_vars.size(); ++c)
++                   for (size_t c = 0; c < coupled_vars.size(); ++c)
+                        {
+                          Coupled_var & cv = coupled_vars[c];
+                          if (key == cv.key)
+@@ -374,7 +370,7 @@ cerr << "APnnn got " << signal->get_sigName() << endl;
+                    APL_error_code error = E_VALUE_ERROR;
+                    bool found = false;
+                    string data;
+-                   for (int c = 0; c < coupled_vars.size(); ++c)
++                   for (size_t c = 0; c < coupled_vars.size(); ++c)
+                        {
+                          Coupled_var & cv = coupled_vars[c];
+                          if (key == cv.key)
+@@ -405,7 +401,7 @@ cerr << "APnnn got " << signal->get_sigName() << endl;
+                    const SV_key key = signal->get__ASSIGN_VALUE__key();
+                    APL_error_code error = E_VALUE_ERROR;
+                    bool found = false;
+-                   for (int c = 0; c < coupled_vars.size(); ++c)
++                   for (size_t c = 0; c < coupled_vars.size(); ++c)
+                        {
+                          Coupled_var & cv = coupled_vars[c];
+                          if (key == cv.key)
+diff --git a/src/APs/APserver.cc b/src/APs/APserver.cc
+index 1653d40..a375c3f 100644
+--- a/src/APs/APserver.cc
++++ b/src/APs/APserver.cc
+@@ -116,7 +116,7 @@ extern TCP_socket get_tcp_fd_for_id(const AP_num3 & id);
+ TCP_socket
+ get_tcp_fd_for_id(const AP_num3 & id)
+ {
+-   for (int j = 0; j < connected_procs.size(); ++j)
++   for (size_t j = 0; j < connected_procs.size(); ++j)
+        {
+          if (id == connected_procs[j].ap3)   return connected_procs[j].fd;
+        }
+@@ -128,7 +128,7 @@ extern TCP_socket get_tcp_fd2_for_id(const AP_num3 & id);
+ TCP_socket
+ get_tcp_fd2_for_id(const AP_num3 & id)
+ {
+-   for (int j = 0; j < connected_procs.size(); ++j)
++   for (size_t j = 0; j < connected_procs.size(); ++j)
+        {
+          if (id == connected_procs[j].ap3 &&
+              connected_procs[j].fd2 != NO_TCP_SOCKET)
+@@ -141,7 +141,7 @@ get_tcp_fd2_for_id(const AP_num3 & id)
+ static
+ AP_num3 fd_to_id(TCP_socket fd)
+ {
+-   for (int j = 0; j < connected_procs.size(); ++j)
++   for (size_t j = 0; j < connected_procs.size(); ++j)
+        {
+          if (fd == connected_procs[j].fd)    return connected_procs[j].ap3;
+          if (fd == connected_procs[j].fd2)   return connected_procs[j].ap3;
+@@ -156,7 +156,7 @@ get_TCP_for_key(SV_key key)
+ Svar_record * svar = db.find_var(key, LOC);
+    if (!svar)   goto not_found;
+ 
+-   for (int j = 0; j < connected_procs.size(); ++j)
++   for (size_t j = 0; j < connected_procs.size(); ++j)
+        {
+          if (connected_procs[j].fd2 == NO_TCP_SOCKET)   continue;
+ 
+@@ -250,39 +250,39 @@ maybe_start_AP(const AP_num3 & id)
+ 
+    if (id.proc >= AP_FIRST_USER)   return;   // not  an AP
+ 
+-   for (int j = 0; j < connected_procs.size(); ++j)
++   for (size_t j = 0; j < connected_procs.size(); ++j)
+        {
+          if (connected_procs[j].ap3 == id)   return;   // already running
+        }
+ 
+-char AP_progname[PATH_MAX + 1];
++char AP_progname[APL_PATH_MAX + 1];
+    snprintf(AP_progname, sizeof(AP_progname), "%s", prog);
+ 
+ char * bslash = strrchr(AP_progname, '/');
+    if (bslash)
+       {
+         const int offset = bslash - AP_progname;
+-        snprintf(bslash + 1, PATH_MAX - offset - 1, "AP%u", id.proc);
++        snprintf(bslash + 1, APL_PATH_MAX - offset - 1, "AP%u", id.proc);
+       }
+    else
+       {
+-        snprintf(AP_progname, PATH_MAX, "AP%u", id.proc);
++        snprintf(AP_progname, APL_PATH_MAX, "AP%u", id.proc);
+       }
+    
+-   AP_progname[PATH_MAX] = 0;
++   AP_progname[APL_PATH_MAX] = 0;
+ 
+    debug && *debug << "*** starting " << AP_progname << endl;
+ 
+-char popen_arg[PATH_MAX + 1];
++char popen_arg[APL_PATH_MAX + 1];
+    if (debug)
+       {
+-        snprintf(popen_arg, PATH_MAX,
++        snprintf(popen_arg, APL_PATH_MAX,
+                  "%s --id %u --par %u --gra %u --auto -v",
+                  AP_progname, id.proc, id.parent, id.grand);
+       }
+    else
+       {
+-        snprintf(popen_arg, PATH_MAX,
++        snprintf(popen_arg, APL_PATH_MAX,
+                  "%s --id %u --par %u --gra %u --auto",
+                  AP_progname, id.proc, id.parent, id.grand);
+       }
+@@ -312,7 +312,7 @@ AP_num3 removed_AP;
+ bool found_fd = false;
+ TCP_socket removed_fd2 = NO_TCP_SOCKET;
+ 
+-   for (int j = 0; j < connected_procs.size(); ++j)
++   for (size_t j = 0; j < connected_procs.size(); ++j)
+        {
+          if (fd == connected_procs[j].fd)
+             {
+@@ -354,7 +354,7 @@ TCP_socket removed_fd2 = NO_TCP_SOCKET;
+ 
+    // retract offers made by the removed processor
+    //
+-   for (int o = 0; o < db.offered_vars.size(); ++o)
++   for (size_t o = 0; o < db.offered_vars.size(); ++o)
+        {
+          Svar_record & svar = db.offered_vars[o];
+ 
+@@ -373,7 +373,7 @@ TCP_socket removed_fd2 = NO_TCP_SOCKET;
+       {
+         if (removed_AP.parent)   // removed_AP is proc.parent.0
+            {
+-             for (int j = 0; j < connected_procs.size(); ++j)
++             for (size_t j = 0; j < connected_procs.size(); ++j)
+                  {
+                    if (connected_procs[j].ap3.parent == removed_AP.proc &&
+                        connected_procs[j].ap3.grand  == removed_AP.parent)
+@@ -388,7 +388,7 @@ TCP_socket removed_fd2 = NO_TCP_SOCKET;
+            }
+         else                     // removed_AP is proc.0.0
+            {
+-             for (int j = 0; j < connected_procs.size(); ++j)
++             for (size_t j = 0; j < connected_procs.size(); ++j)
+                  {
+                    if (connected_procs[j].ap3.parent == removed_AP.proc &&
+                        connected_procs[j].ap3.grand == 0)
+@@ -437,7 +437,7 @@ do_signal(TCP_socket fd, Signal_base * request)
+    // impersonate that processor
+    //
+ AP3_fd * ap_fd = 0;
+-   for (int j = 0; j < connected_procs.size(); ++j)
++   for (size_t j = 0; j < connected_procs.size(); ++j)
+        {
+          if (connected_procs[j].fd == fd)
+             {
+@@ -491,7 +491,7 @@ AP3_fd * ap_fd = 0;
+ 
+                if (evconn)
+                   {
+-                    for (int j = 0; j < connected_procs.size(); ++j)
++                    for (size_t j = 0; j < connected_procs.size(); ++j)
+                         {
+                           AP3_fd & ap_fd1 = connected_procs[j];
+                           if (ap_fd1.ap3 == ap3)
+@@ -582,7 +582,7 @@ AP3_fd * ap_fd = 0;
+                const int grand  = request->get__IS_REGISTERED_ID__grand();
+                const AP_num3 ap3((AP_num)proc, (AP_num)parent, (AP_num)grand);
+                int is_registered = 0;
+-               for (int p = 0; p < connected_procs.size(); ++p)
++               for (size_t p = 0; p < connected_procs.size(); ++p)
+                    {
+                      const AP3_fd & pro = connected_procs[p];
+                      if (pro.ap3 == ap3)
+@@ -654,7 +654,7 @@ AP3_fd * ap_fd = 0;
+                                << hex << key << dec << endl;
+ 
+                bool existing = false;
+-               for (int vv = 0; vv < var_values.size(); ++vv)
++               for (size_t vv = 0; vv < var_values.size(); ++vv)
+                    {
+                      if (var_values[vv].key == key)
+                         {
+@@ -689,12 +689,10 @@ AP3_fd * ap_fd = 0;
+                debug && *debug << "reading var data for key 0x"
+                                << hex << key << dec << endl;
+ 
+-               bool existing = false;
+-               for (int vv = 0; vv < var_values.size(); ++vv)
++               for (size_t vv = 0; vv < var_values.size(); ++vv)
+                    {
+                      if (var_values[vv].key == key)
+                         {
+-                          existing = true;
+                           WSWS_VALUE_IS_c(fd, var_values[vv].var_value);
+ 
+                           Svar_record * svar = db.find_var(key, LOC);
+@@ -770,7 +768,7 @@ AP3_fd * ap_fd = 0;
+                if (allowed && svar && svar->is_ws_to_ws())
+                   {
+                     bool have_value = false;
+-                    for (int vv = 0; vv < var_values.size(); ++vv)
++                    for (size_t vv = 0; vv < var_values.size(); ++vv)
+                         {
+                           if (var_values[vv].key == key)
+                              {
+@@ -980,7 +978,7 @@ const char * listen_name = APSERVER_PATH;
+ bool got_path = false;
+ bool got_port = false;
+ bool auto_start = false;
+-int janitor = 0;
++size_t janitor = 0;
+ 
+    for (int a = 1; a < argc; )
+        {
+@@ -1153,7 +1151,7 @@ int max_fd = listen_sock;
+ #else // use select()
+ 
+         FD_SET(listen_sock, &read_fds);
+-        for (int j = 0; j < connected_procs.size(); ++j)
++        for (size_t j = 0; j < connected_procs.size(); ++j)
+             {
+               TCP_socket fd = connected_procs[j].fd;
+               if (fd != NO_TCP_SOCKET)
+@@ -1193,14 +1191,14 @@ int max_fd = listen_sock;
+              int jfd = connected_procs[janitor].fd;
+              if (jfd != NO_TCP_SOCKET)
+                 {
+-                  const ssize_t result = ::recv(jfd, 0, 0, MSG_DONTWAIT);
++                  ::recv(jfd, 0, 0, MSG_DONTWAIT);
+                   cerr << "janitor got " << errno << " on fd " << jfd << endl;
+                 }
+ 
+              jfd = connected_procs[janitor].fd2;
+              if (jfd != NO_TCP_SOCKET)
+                 {
+-                  const ssize_t result = ::recv(jfd, 0, 0, MSG_DONTWAIT);
++                  ::recv(jfd, 0, 0, MSG_DONTWAIT);
+                   cerr << "janitor got " << errno << " on fd " << jfd << endl;
+                 }
+              
+@@ -1236,7 +1234,7 @@ int max_fd = listen_sock;
+ 
+         // connections readable
+         //
+-        for (int j = 0; j < connected_procs.size(); ++j)
++        for (size_t j = 0; j < connected_procs.size(); ++j)
+             {
+               const TCP_socket fd = connected_procs[j].fd;
+               if (FD_ISSET(fd, &read_fds))   connection_readable(fd);
+@@ -1252,7 +1250,7 @@ print_db(ostream & out)
+    out << "╔══════════════════════┬════════┬══════════════════─═══╗" << endl
+        << "║ Processor            │ fd fd2 │ Program              ║" << endl
+        << "╠══════════════════════╪════════╪══════════════════════╣" << endl;
+-   for (int p = 0; p < connected_procs.size(); ++p)
++   for (size_t p = 0; p < connected_procs.size(); ++p)
+        {
+          const AP3_fd & pro = connected_procs[p];
+          char cc[100];
+@@ -1285,7 +1283,7 @@ print_db(ostream & out)
+ "║     │ ║ Offering  │   │  ║ Accepting │   │  ║OAOA│          ║\n"
+ "║ Seq │C║ Proc,par  │Fd2│Fl║ Proc,par  │Fd2│Fl║SSUU│ Varname  ║\n"
+ "╠═════╪═╬═══════════╪═══╪══╬═══════════╪═══╪══╬════╪══════════╣\n";
+-   for (int o = 0; o < db.offered_vars.size(); ++o)
++   for (size_t o = 0; o < db.offered_vars.size(); ++o)
+        {
+          const Svar_record & svar = db.offered_vars[o];
+          if (svar.valid())   svar.print(out);
+diff --git a/src/APs/Makefile.am b/src/APs/Makefile.am
+index 2ad7118..798a4e0 100644
+--- a/src/APs/Makefile.am
++++ b/src/APs/Makefile.am
+@@ -21,8 +21,9 @@ APserver_CXXFLAGS = -I .. -g -O2
+ AM_CXXFLAGS = $(CXX_RDYNAMIC)
+ 
+ if DEVELOP
+-   AM_CXXFLAGS += -Werror -Wall
+-   AM_CXXFLAGS += -Wno-sign-compare -Wno-strict-aliasing
++   AP100_CXXFLAGS    += -Werror -Wall -Wno-strict-aliasing
++   AP210_CXXFLAGS    += -Werror -Wall -Wno-strict-aliasing
++   APserver_CXXFLAGS += -Werror -Wall -Wno-strict-aliasing
+ endif
+ 
+ AM_MAKEFLAGS = -j 8
+diff --git a/src/APs/Makefile.in b/src/APs/Makefile.in
+index 92e6ef7..ceda5e5 100644
+--- a/src/APs/Makefile.in
++++ b/src/APs/Makefile.in
+@@ -79,8 +79,9 @@ POST_UNINSTALL = :
+ build_triplet = @build@
+ host_triplet = @host@
+ bin_PROGRAMS = AP100$(EXEEXT) AP210$(EXEEXT) APserver$(EXEEXT)
+-@DEVELOP_TRUE@am__append_1 = -Werror -Wall -Wno-sign-compare \
+-@DEVELOP_TRUE@	-Wno-strict-aliasing
++@DEVELOP_TRUE@am__append_1 = -Werror -Wall -Wno-strict-aliasing
++@DEVELOP_TRUE@am__append_2 = -Werror -Wall -Wno-strict-aliasing
++@DEVELOP_TRUE@am__append_3 = -Werror -Wall -Wno-strict-aliasing
+ subdir = src/APs
+ DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
+ 	$(top_srcdir)/depcomp
+@@ -368,10 +369,10 @@ APserver_SOURCES = APserver.cc				\
+ 		Svar_DB_server.cc Svar_DB_server.hh	\
+ 		../Svar_record.cc ../Svar_record.hh
+ 
+-AP100_CXXFLAGS = -I .. -g -O2 -DAP_NUM=100
+-AP210_CXXFLAGS = -I .. -g -O2 -DAP_NUM=210
+-APserver_CXXFLAGS = -I .. -g -O2
+-AM_CXXFLAGS = $(CXX_RDYNAMIC) $(am__append_1)
++AP100_CXXFLAGS = -I .. -g -O2 -DAP_NUM=100 $(am__append_1)
++AP210_CXXFLAGS = -I .. -g -O2 -DAP_NUM=210 $(am__append_2)
++APserver_CXXFLAGS = -I .. -g -O2 $(am__append_3)
++AM_CXXFLAGS = $(CXX_RDYNAMIC)
+ AM_MAKEFLAGS = -j 8
+ all: all-am
+ 
+diff --git a/src/APs/Svar_DB_server.cc b/src/APs/Svar_DB_server.cc
+index 4c7e7e8..3297f9e 100644
+--- a/src/APs/Svar_DB_server.cc
++++ b/src/APs/Svar_DB_server.cc
+@@ -50,7 +50,7 @@ int ret = SVE_NO_EVENTS;
+ 
+    // clear event bit in all shared variables
+    //
+-   for (int o = 0; o < offered_vars.size(); ++o)
++   for (size_t o = 0; o < offered_vars.size(); ++o)
+        {
+          Svar_record & svar = offered_vars[o];
+          if (id == svar.offering.id)
+@@ -73,7 +73,7 @@ Svar_DB_server::get_events(Svar_event & events, AP_num3 proc) const
+ {
+    // return the first key with an event for proc (if any)
+    //
+-   for (int o = 0; o < offered_vars.size(); ++o)
++   for (size_t o = 0; o < offered_vars.size(); ++o)
+        {
+          const Svar_record & svar = offered_vars[o];
+          if (proc == svar.offering.id)
+@@ -116,7 +116,7 @@ Svar_DB_server::find_pairing_key(SV_key key) const
+ const Svar_record * svar1 = find_var(key, LOC);
+    if (svar1 == 0)   return 0;
+ 
+-   for (int o = 0; o < offered_vars.size(); ++o)
++   for (size_t o = 0; o < offered_vars.size(); ++o)
+        {
+          const Svar_record & svar2 = offered_vars[o];
+          if (!svar2.valid())     continue;
+@@ -137,7 +137,7 @@ Svar_DB_server::find_var(SV_key key, const char * loc) const
+         return 0;
+       }
+ 
+-   for (int o = 0; o < offered_vars.size(); ++o)
++   for (size_t o = 0; o < offered_vars.size(); ++o)
+        {
+          const Svar_record & svar = offered_vars[o];
+          if (key == svar.key)   return (Svar_record *)&svar;
+@@ -167,7 +167,7 @@ vector<AP_num> procs;
+ 
+    // return pending AND matched offers, general or to to_proc
+    //
+-   for (int o = 0; o < offered_vars.size(); ++o)
++   for (size_t o = 0; o < offered_vars.size(); ++o)
+        {
+          Svar_record & svar = offered_vars[o];
+          if (!svar.valid())         continue;
+@@ -186,7 +186,7 @@ vector<AP_num> procs;
+           // find smallest proc, append it to the result, and remove it
+           //
+           AP_num smallest = procs[0];
+-          for (int p = 1; p < procs.size(); ++p)
++          for (size_t p = 1; p < procs.size(); ++p)
+               {
+                 if (smallest > procs[p])   smallest = procs[p];
+               }
+@@ -214,7 +214,7 @@ Svar_DB_server::get_offered_variables(AP_num to_proc, AP_num from_proc,
+ {
+    // return pending variables but not matched offers, general or to to_proc
+    //
+-   for (int o = 0; o < offered_vars.size(); ++o)
++   for (size_t o = 0; o < offered_vars.size(); ++o)
+        {
+          const Svar_record & svar = offered_vars[o];
+          if (!svar.valid())         continue;
+@@ -309,7 +309,7 @@ Svar_DB_server::match_pending_offer(const uint32_t * UCS_varname,
+ {
+ Svar_record * pending_offer = 0;
+ 
+-   for (int o = 0; o < offered_vars.size(); ++o)
++   for (size_t o = 0; o < offered_vars.size(); ++o)
+        {
+          Svar_record & svar = offered_vars[o];
+          if (svar.get_coupling() != SV_OFFERED)                       continue;
+diff --git a/src/Archive.cc b/src/Archive.cc
+index cdb79a0..1bb44fe 100644
+--- a/src/Archive.cc
++++ b/src/Archive.cc
+@@ -52,8 +52,8 @@ using namespace std;
+ 
+ /// if there is less than x chars left on the current line then leave
+ /// char mode and start a new line indented.
+-#define NEED(x)   if (space < (x))   { leave_char_mode();   out << "\n";   \
+-                                       space = do_indent(); } out
++#define NEED(x)   if (space < (int)(x))   { leave_char_mode();   out << "\n"; \
++                                            space = do_indent(); } out
+ 
+ //-----------------------------------------------------------------------------
+ bool
+@@ -159,8 +159,8 @@ char cc[80];
+                  v.get_flags(), vid);
+    out << cc;
+ 
+-const unsigned int sub_vid = find_vid(v);
+-   Assert(sub_vid < values.size());
++const int sub_vid = find_vid(v);
++   Assert(sub_vid < (int)values.size());
+ unsigned int parent_vid = -1;
+ 
+    if (&values[sub_vid]._par)   parent_vid = find_vid(values[sub_vid]._par);
+@@ -478,7 +478,7 @@ XML_Saving_Archive::emit_token_val(const Token & tok)
+                        break;
+ 
+         case TV_INDEX: { const IndexExpr & idx = tok.get_index_val();
+-                         const size_t rank = idx.value_count();
++                         const int rank = idx.value_count();
+                          out << " index=\"";
+                          loop(i, rank)
+                              {
+@@ -712,8 +712,8 @@ const int offset = Workspace::get_v_Quad_TZ().get_offset();   // timezone offset
+                  {
+                    const Value & sub = *cP->get_pointer_value().get();
+                    Assert1(&sub);
+-                   unsigned int sub_idx = find_vid(sub);
+-                   Assert(sub_idx < values.size());
++                   const int sub_idx = find_vid(sub);
++                   Assert(sub_idx < (int)values.size());
+                    Assert(!&values[sub_idx]._par);
+                    values[sub_idx] = _val_par(values[sub_idx]._val,  parent);
+                  }
+@@ -727,11 +727,11 @@ CERR << "LVAL CELL in " << p << " at " LOC << endl;
+ 
+    // save all values (without their ravel)
+    //
+-   for (vid = 0; vid < values.size(); ++vid)   save_shape(values[vid]._val);
++   for (vid = 0; vid < (int)values.size(); ++vid)  save_shape(values[vid]._val);
+ 
+    // save ravels of all values
+    //
+-   for (vid = 0; vid < values.size(); ++vid)   save_ravel(values[vid]._val);
++   for (vid = 0; vid < (int)values.size(); ++vid)   save_ravel(values[vid]._val);
+ 
+    // save user defined symbols
+    //
+@@ -739,8 +739,8 @@ CERR << "LVAL CELL in " << p << " at " LOC << endl;
+ 
+    // save certain system variables
+    //
+-#define rw_sv_def(x, txt) save_symbol(Workspace::get_v_ ## x());
+-#define ro_sv_def(x, txt) save_symbol(Workspace::get_v_ ## x());
++#define rw_sv_def(x, _txt) save_symbol(Workspace::get_v_ ## x());
++#define ro_sv_def(x, _txt) save_symbol(Workspace::get_v_ ## x());
+ #include "SystemVariable.def"
+ 
+    // save state indicator
+@@ -1250,7 +1250,7 @@ bool no_copy = false;   // assume the value is needed
+         int parent = vid;
+         for (;;)
+             {
+-              Assert(parent < parents.size());
++              Assert(parent < (int)parents.size());
+               if (parents[parent] == -1)   break;   // topmost owner found
+               parent = parents[parent];
+             }
+@@ -1272,7 +1272,7 @@ bool no_copy = false;   // assume the value is needed
+       }
+    else
+       {
+-        Assert(vid == values.size());
++        Assert(vid == (int)values.size());
+ 
+         Value_P val(sh_value, LOC);
+         values.push_back(val);
+@@ -1344,7 +1344,7 @@ const Unicode type = UTF8_string::toUni(first, len);
+                char * end = 0;
+                const int vid = strtol((const char *)first, &end, 10);
+                Assert(vid >= 0);
+-               Assert(vid < values.size());
++               Assert(vid < (int)values.size());
+                new (C++) PointerCell(values[vid], C_owner);
+                first = (const UTF8 *)end;
+              }
+@@ -1356,7 +1356,7 @@ const Unicode type = UTF8_string::toUni(first, len);
+                char * end = 0;
+                const int vid = strtol((const char *)first, &end, 16);
+                Assert(vid >= 0);
+-               Assert(vid < values.size());
++               Assert(vid < (int)values.size());
+                Assert(*end == '[');   ++end;
+                const ShapeItem offset = strtoll(end, &end, 16);
+                Assert(*end == ']');   ++end;
+@@ -1441,7 +1441,7 @@ const UTF8 * cells = find_attr("cells", false);
+ 
+    Log(LOG_archive)   CERR << "    read_Ravel() vid=" << vid << endl;
+ 
+-   Assert(vid < values.size());
++   Assert(vid < (int)values.size());
+ Value_P val = values[vid];
+ 
+    if (!val)   // )COPY with vids_COPY or static value
+@@ -1485,8 +1485,8 @@ XML_Loading_Archive::read_unused_name(int d, Symbol & symbol)
+ void
+ XML_Loading_Archive::read_Variable(int d, Symbol & symbol)
+ {
+-const unsigned int vid = find_int_attr("vid", false, 10);
+-   Assert(vid < values.size());
++const int vid = find_int_attr("vid", false, 10);
++   Assert(vid < (int)values.size());
+ 
+    Log(LOG_archive)   CERR << "      read_Variable() vid=" << vid
+                            << " name=" << symbol.get_name() << endl;
+@@ -1639,7 +1639,8 @@ UCS_string name_ucs;
+ 
+    // ⎕NLT was removed, but could lurk around in old workspaces.
+    //
+-   if (name_ucs == UCS_string(UTF8_string("⎕NLT")))
++   if (name_ucs == UCS_string(UTF8_string("⎕NLT")) ||
++       name_ucs == UCS_string(UTF8_string("⎕PT")))
+       {
+         Log(LOG_archive)   CERR << "        skipped at " << LOC << endl;
+         skip_to_tag("/Symbol");
+@@ -1678,7 +1679,7 @@ bool no_copy = is_protected || (have_allowed_objects && !is_selected);
+         next_tag(LOC);
+         if (is_tag("Variable"))
+            {
+-             const unsigned int vid = find_int_attr("vid", false, 10);
++             const int vid = find_int_attr("vid", false, 10);
+              vids_COPY.push_back(vid);
+            }
+         skip_to_tag("/Symbol");
+@@ -1965,8 +1966,8 @@ const TokenTag tag = TokenTag(find_int_attr("tag", false, 16));
+ 
+         case TV_VAL:   
+              {
+-               const unsigned int vid = find_int_attr("vid", false, 10);
+-               Assert(vid < values.size());
++               const int vid = find_int_attr("vid", false, 10);
++               Assert(vid < (int)values.size());
+                new (&tloc.tok) Token(tag, values[vid]);
+              }
+              break;
+@@ -1988,8 +1989,8 @@ const TokenTag tag = TokenTag(find_int_attr("tag", false, 16));
+                          Assert1(*vids == 'i');   ++vids;
+                          Assert1(*vids == 'd');   ++vids;
+                          Assert1(*vids == '_');   ++vids;
+-                         const unsigned int vid = strtol(vids, &vids, 10);
+-                         Assert(vid < values.size());
++                         const int vid = strtol(vids, &vids, 10);
++                         Assert(vid < (int)values.size());
+                          idx.add(values[vid]);
+                        }
+                   }
+diff --git a/src/Archive.hh b/src/Archive.hh
+index f0b4e47..7e4ed76 100644
+--- a/src/Archive.hh
++++ b/src/Archive.hh
+@@ -334,7 +334,7 @@ protected:
+    bool reading_vids;
+ 
+    /// the vids to be copied (empty if all)
+-   vector<unsigned int> vids_COPY;
++   vector<int> vids_COPY;
+ 
+    /// the names of objects (empty if all)
+    vector<UCS_string> allowed_objects;
+diff --git a/src/Bif_F12_FORMAT.cc b/src/Bif_F12_FORMAT.cc
+index ceb0ce6..1e599a9 100644
+--- a/src/Bif_F12_FORMAT.cc
++++ b/src/Bif_F12_FORMAT.cc
+@@ -649,7 +649,7 @@ char * fract_end = 0;
+         //
+         const int flen = snprintf(format, sizeof(format), "%%.%luE",
+                                   (unsigned long)fract_part.size());
+-        Assert(flen < sizeof(format));   // format was big enough.
++        Assert(flen < (int)sizeof(format));   // format was big enough.
+ 
+         const int dlen = snprintf(&data_buf[0], data_buf_len, format, value);
+         Assert(dlen < data_buf_len);
+@@ -672,7 +672,7 @@ char * fract_end = 0;
+       {
+         const int flen = snprintf(format, sizeof(format), "%%.%luf",
+                                   (unsigned long)fract_part.size());
+-        Assert(flen < sizeof(format));   // assume no snprintf() overflow
++        Assert(flen < (int)sizeof(format));   // assume no snprintf() overflow
+ 
+         const int dlen = snprintf(&data_buf[0], data_buf_len, format, value);
+         data_buf[data_buf_len - 1] = 0;
+diff --git a/src/Bif_F12_FORMAT.hh b/src/Bif_F12_FORMAT.hh
+index f5c2db8..ac59163 100644
+--- a/src/Bif_F12_FORMAT.hh
++++ b/src/Bif_F12_FORMAT.hh
+@@ -41,7 +41,7 @@ struct Format_sub
+    int             min_len;        ///< the minimum length in the output
+ 
+    /// return the number of characters in \b format
+-   size_t size() const
++   int size() const
+       { return format.size(); }
+ 
+    /// set flt_mask according to the digits in member \b format
+@@ -101,12 +101,12 @@ public:
+         Format_LIFER(UCS_string fmt);
+ 
+         /// return the size of the format
+-        size_t format_size() const
++        int format_size() const
+            { return left_deco.size() + int_part.size() + fract_part.size()
+                   + expo_deco.size() + exponent.size() + right_deco.size(); }
+ 
+         /// return the size of the output
+-        size_t out_size() const
++        int out_size() const
+            { return left_deco.out_len + int_part.out_len + fract_part.out_len
+                   + expo_deco.out_len + exponent.out_len + right_deco.out_len; }
+ 
+diff --git a/src/Command.cc b/src/Command.cc
+index 3d714e7..7a18122 100644
+--- a/src/Command.cc
++++ b/src/Command.cc
+@@ -47,10 +47,6 @@
+ #include "Value.icc"
+ #include "Workspace.hh"
+ 
+-#ifndef PATH_MAX
+-#define PATH_MAX 4096
+-#endif
+-
+ int Command::boxing_format = -1;
+ 
+ vector<Command::user_command> Command::user_commands;
+@@ -670,10 +666,10 @@ Command::cmd_HELP(ostream & out)
+    out << endl << "System variables:" << endl;
+ #define ro_sv_def(x, txt)                                           \
+    { const UCS_string & ucs = Workspace::get_v_ ## x().get_name();  \
+-        out << "      " << setw(8) << ucs << #txt << endl; }
++        out << "      " << setw(8) << ucs << txt << endl; }
+ #define rw_sv_def(x, txt)                                           \
+    { const UCS_string & ucs = Workspace::get_v_ ## x().get_name();  \
+-        out << "      " << setw(8) << ucs << #txt << endl; }
++        out << "      " << setw(8) << ucs << txt << endl; }
+ #include "SystemVariable.def"
+ 
+    out << endl << "System functions:" << endl;
+@@ -681,7 +677,7 @@ Command::cmd_HELP(ostream & out)
+ #define rw_sv_def(x, txt)
+ #define sf_def(q, txt) { const char * qu = #q;                      \
+    if (!strncmp(qu, "Quad_", 5))                                    \
+-        out << "      ⎕" << setw(8) << UCS_string(qu + 5) << #txt << endl; }
++        out << "      ⎕" << setw(8) << UCS_string(qu + 5) << txt << endl; }
+ #include "SystemVariable.def"
+ }
+ //-----------------------------------------------------------------------------
+@@ -1016,14 +1012,14 @@ int count = 0;
+ 
+    for (int a = 0, x = 0;;)
+        {
+-         if (a >= apl_files.size())   // end of apl_files reached
++         if (a >= (int)apl_files.size())   // end of apl_files reached
+             {
+               loop(xx, xml_files.size() - x)
+                   filenames[count++] = xml_filenames[x + xx];
+               break;
+             }
+ 
+-         if (x >= xml_files.size())   // end of xml_files reached
++         if (x >= (int)xml_files.size())   // end of xml_files reached
+             {
+               loop(aa, apl_files.size() - a)
+                   filenames[count++] = apl_filenames[a + aa];
+@@ -1057,7 +1053,7 @@ vector<int> col_width;
+ 
+    loop(c, count)
+       {
+-        const int col = c % col_width.size();
++        const size_t col = c % col_width.size();
+         out << *filenames[c];
+         if (col == (col_width.size() - 1) || c == (count - 1))
+            {
+@@ -1951,15 +1947,15 @@ int qpos = -1;
+         UCS_string qxx(user, qpos, user.size() - qpos);
+         vector<UCS_string>matches;
+ 
+-#define ro_sv_def(q, txt) { const char * qu = #q;                  \
++#define ro_sv_def(q, _txt) { const char * qu = #q;                  \
+    if (!strncmp(qu, "Quad_", 5)) { UCS_string ustr(qu + 5);   \
+         if (ustr.starts_iwith(qxx)) matches.push_back(ustr); } }
+ 
+-#define rw_sv_def(q, txt) { const char * qu = #q;                  \
++#define rw_sv_def(q, _txt) { const char * qu = #q;                  \
+    if (!strncmp(qu, "Quad_", 5)) { UCS_string ustr(qu + 5);   \
+         if (ustr.starts_iwith(qxx)) matches.push_back(ustr); } }
+ 
+-#define sf_def(q, txt) { const char * qu = #q;                  \
++#define sf_def(q, _txt) { const char * qu = #q;                  \
+    if (!strncmp(qu, "Quad_", 5)) { UCS_string ustr(qu + 5);   \
+         if (ustr.starts_iwith(qxx)) matches.push_back(ustr); } }
+ 
+diff --git a/src/Common.hh b/src/Common.hh
+index aca859f..fd7e283 100644
+--- a/src/Common.hh
++++ b/src/Common.hh
+@@ -101,7 +101,7 @@ APL_time_us now();
+ #if HAVE_RDTSC
+ inline uint64_t cycle_counter()
+ {
+-unsigned int lo, hi;
++uint32_t lo, hi;
+    __asm__ __volatile__ ("rdtsc" : "=a" (lo), "=d" (hi));
+    return ((uint64_t)hi << 32) | lo;
+ }
+@@ -139,7 +139,7 @@ public:
+ 
+    /// init the p'th probe
+    static int init(int p)
+-      { if ((unsigned int)p >= (unsigned int)PROBE_COUNT)   return -3;
++      { if (p >= (int)PROBE_COUNT)   return -3;
+         probes[p].init();
+         return 0;
+       }
+@@ -184,7 +184,7 @@ public:
+ 
+    /// get the m'th time (from P1 to P2) of this probe
+    int64_t get_time(int m) const
+-      { if ((unsigned int)m >= (unsigned int)idx)   return -1;
++      { if (m >= idx)   return -1;
+         const int64_t diff = measurements[m].cycles_to
+                            - measurements[m].cycles_from;
+         if (diff < 0)   return -2;
+@@ -193,37 +193,37 @@ public:
+ 
+    /// get the m'th time of the p'th probe
+    static int get_time(int p, int m)
+-      { if ((unsigned int)p >= (unsigned int)PROBE_COUNT)   return -3;
++      { if (p >= PROBE_COUNT)   return -3;
+         return probes[p].get_time(m);
+       }
+ 
+    /// get the m'th start time of this probe
+    int64_t get_start(int m) const
+-      { if ((unsigned int)m >= (unsigned int)idx)   return -1;
++      { if (m >= idx)   return -1;
+         return measurements[m].cycles_from;
+       }
+ 
+    /// get the m'th start time of the p'th probe
+    static int get_start(int p, int m)
+-      { if ((unsigned int)p >= (unsigned int)PROBE_COUNT)   return -3;
++      { if (p >= PROBE_COUNT)   return -3;
+         return probes[p].get_start(m);
+       }
+ 
+    /// get the m'th stop time of this probe
+    int64_t get_stop(int m) const
+-      { if ((unsigned int)m >= (unsigned int)idx)   return -1;
++      { if (m >= idx)   return -1;
+         return measurements[m].cycles_to;
+       }
+ 
+    /// get the m'th stop time of the p'th probe
+    static int get_stop(int p, int m)
+-      { if ((unsigned int)p >= (unsigned int)PROBE_COUNT)   return -3;
++      { if (p >= PROBE_COUNT)   return -3;
+         return probes[p].get_stop(m);
+       }
+ 
+    /// get the number of times int the p'th probe
+    static int get_length(int p)
+-      { if ((unsigned int)p >= (unsigned int)PROBE_COUNT)   return -3;
++      { if (p >= PROBE_COUNT)   return -3;
+         return probes[p].idx;
+       }
+ 
+diff --git a/src/Executable.cc b/src/Executable.cc
+index 5544134..4d70073 100644
+--- a/src/Executable.cc
++++ b/src/Executable.cc
+@@ -690,7 +690,7 @@ UCS_string lambda_text;
+ int level = 0;   // {/} nesting level
+ bool copying = false;
+ 
+-int tidx = 0;
++size_t tidx = 0;
+ int tcol = 0;
+ 
+    // skip over the first skip lambdas and copy the next one to lambda_text
+diff --git a/src/IndexExpr.hh b/src/IndexExpr.hh
+index 3d9581a..a333450 100644
+--- a/src/IndexExpr.hh
++++ b/src/IndexExpr.hh
+@@ -50,7 +50,7 @@ public:
+         values[rank++] = val; }
+ 
+    /// return the number of values (= number of semicolons + 1)
+-   size_t value_count() const   { return rank; }
++   Rank value_count() const   { return rank; }
+ 
+    /// return true iff the number of dimensions is 1 (i.e. no ; and non-empty)
+    bool is_axis() const   { return rank == 1; }
+diff --git a/src/IndexIterator.cc b/src/IndexIterator.cc
+index f8f3af1..75e86b3 100644
+--- a/src/IndexIterator.cc
++++ b/src/IndexIterator.cc
+@@ -74,7 +74,7 @@ const ShapeItem vlen = value->element_count();
+ 
+         // instead of testing signed < 0 and >= max, we test unsigned >= max.
+         //
+-        if (idx >= (uint64_t)max_idx)   INDEX_ERROR;
++        if (idx >= max_idx)   INDEX_ERROR;
+ 
+         indices.push_back(idx*w);
+       }
+diff --git a/src/InputFile.cc b/src/InputFile.cc
+index e837b7d..384eb92 100644
+--- a/src/InputFile.cc
++++ b/src/InputFile.cc
+@@ -85,7 +85,7 @@ InputFile::randomize_files()
+            }
+       }
+ 
+-   for (int done = 0; done < 4*files_todo.size();)
++   for (size_t done = 0; done < 4*files_todo.size();)
+        {
+          const int n1 = random() % files_todo.size();
+          const int n2 = random() % files_todo.size();
+diff --git a/src/IntCell.cc b/src/IntCell.cc
+index 86d3ca8..85496d4 100644
+--- a/src/IntCell.cc
++++ b/src/IntCell.cc
+@@ -363,7 +363,7 @@ IntCell::bif_conjugate(Cell * Z) const
+ ErrorCode
+ IntCell::bif_negative(Cell * Z) const
+ {
+-   if (value.ival == 0x8000000000000000LL)   // integer overflow
++   if ((uint64_t)value.ival == 0x8000000000000000LL)   // integer overflow
+       new (Z) FloatCell(- value.ival);
+    else
+       new (Z) IntCell(- value.ival);
+@@ -625,7 +625,7 @@ const bool invert_Z = b < 0;
+            {
+              if (b1 & 1)
+                 {
+-                  if (zi >= 0x7FFFFFFFFFFFFFFFULL / a_2_n)
++                  if ((uint64_t)zi >= 0x7FFFFFFFFFFFFFFFULL / a_2_n)
+                      {
+                        overflow = true;
+                        break;
+@@ -634,7 +634,7 @@ const bool invert_Z = b < 0;
+                   if (b1 == 1)   break;
+                 }
+ 
+-             if (a_2_n >= 100000000ULL)
++             if (a_2_n >= 100000000LL)
+                 {
+                   overflow = true;
+                   break;
+diff --git a/src/LibPaths.cc b/src/LibPaths.cc
+index 2da24ab..f9416ae 100644
+--- a/src/LibPaths.cc
++++ b/src/LibPaths.cc
+@@ -28,16 +28,12 @@
+ #include "LibPaths.hh"
+ #include "PrintOperator.hh"
+ 
+-#ifndef PATH_MAX
+-#define PATH_MAX 4096
+-#endif
+-
+ bool LibPaths::root_from_env = false;
+ bool LibPaths::root_from_pwd = false;
+ 
+-char LibPaths::APL_bin_path[PATH_MAX + 1] = "";
++char LibPaths::APL_bin_path[APL_PATH_MAX + 1] = "";
+ const char * LibPaths::APL_bin_name = LibPaths::APL_bin_path;
+-char LibPaths::APL_lib_root[PATH_MAX + 10] = "";
++char LibPaths::APL_lib_root[APL_PATH_MAX + 10] = "";
+ 
+ LibPaths::LibDir LibPaths::lib_dirs[LIB_MAX];
+ 
+@@ -120,7 +116,7 @@ LibPaths::compute_bin_path(const char * argv0, bool logit)
+       }
+ 
+    unused = realpath(argv0, APL_bin_path);
+-   APL_bin_path[PATH_MAX] = 0;
++   APL_bin_path[APL_PATH_MAX] = 0;
+    {
+      char * slash =   strrchr(APL_bin_path, '/');
+      if (slash)   { *slash = 0;   APL_bin_name = slash + 1; }
+@@ -154,7 +150,7 @@ LibPaths::compute_bin_path(const char * argv0, bool logit)
+ bool
+ LibPaths::is_lib_root(const char * dir)
+ {
+-char filename[PATH_MAX + 1];
++char filename[APL_PATH_MAX + 1];
+ 
+    snprintf(filename, sizeof(filename), "%s/workspaces", dir);
+    if (access(filename, F_OK))   return false;
+@@ -178,7 +174,7 @@ const char * path = getenv("APL_LIB_ROOT");
+ 
+    // search from "." to "/" for  a valid lib-root
+    //
+-int last_len = 2*PATH_MAX;
++int last_len = 2*APL_PATH_MAX;
+    APL_lib_root[0] = '.';
+    APL_lib_root[1] = 0;
+    for (;;)
+diff --git a/src/LineInput.cc b/src/LineInput.cc
+index b0ede76..cb89e08 100644
+--- a/src/LineInput.cc
++++ b/src/LineInput.cc
+@@ -195,7 +195,7 @@ ofstream outf(filename);
+       }
+ 
+ int count = 0;
+-   for (int p = put + 1; p < hist_lines.size(); ++p)
++   for (size_t p = put + 1; p < hist_lines.size(); ++p)
+       {
+         outf << hist_lines[p] << endl;
+         ++count;
+@@ -223,7 +223,7 @@ UCS_string u("xxx");
+ void
+ LineHistory::print_history(ostream & out)
+ {
+-   for (int p = put + 1; p < hist_lines.size(); ++p)
++   for (size_t p = put + 1; p < hist_lines.size(); ++p)
+       {
+         out << "      " << hist_lines[p] << endl;
+       }
+@@ -238,14 +238,14 @@ LineHistory::add_line(const UCS_string & line)
+ {
+    if (!line.has_black())   return;
+ 
+-   if (hist_lines.size() < max_lines)   // append
++   if ((int)hist_lines.size() < max_lines)   // append
+       {
+         hist_lines.push_back(line);
+         put = 0;
+       }
+    else                            // override
+       {
+-        if (put >= hist_lines.size())   put = 0;   // wrap
++        if (put >= (int)hist_lines.size())   put = 0;   // wrap
+         hist_lines[put++] = line;
+       }
+ 
+@@ -278,7 +278,7 @@ LineHistory::down()
+    if (current_line == put)   return 0;
+ 
+ int new_current_line = current_line + 1;
+-   if (new_current_line >= hist_lines.size())   new_current_line = 0;   // wrap
++   if (new_current_line >= (int)hist_lines.size())   new_current_line = 0;   // wrap
+    if (new_current_line == put)   return 0;
+ 
+    return &hist_lines[current_line = new_current_line];
+diff --git a/src/LineInput.hh b/src/LineInput.hh
+index b365e6f..9c82e6d 100644
+--- a/src/LineInput.hh
++++ b/src/LineInput.hh
+@@ -65,8 +65,8 @@ public:
+    /// start a new up/down sequence
+    void next()
+       { current_line = put;
+-        if (current_line < 0)   current_line += hist_lines.size();    // wrap
+-        if (current_line >= hist_lines.size())   current_line = 0;    // wrap
++        if (current_line < 0)   current_line += hist_lines.size();       // wrap
++        if (current_line >= (int)hist_lines.size())   current_line = 0;  // wrap
+       }
+ 
+    /// move to next older entry
+diff --git a/src/Makefile.am b/src/Makefile.am
+index c0d3a07..6e7f135 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -137,10 +137,8 @@ apl_CXXFLAGS = $(GPROF_WANTED) $(CXX_RDYNAMIC)
+ libapl_la_CXXFLAGS = $(GPROF_WANTED) $(CXX_RDYNAMIC)
+ 
+ if DEVELOP
+-   apl_CXXFLAGS += -Werror -Wall
+-   apl_CXXFLAGS += -Wno-sign-compare -Wno-strict-aliasing
+-   libapl_la_CXXFLAGS += -Werror -Wall
+-   libapl_la_CXXFLAGS += -Wno-sign-compare -Wno-strict-aliasing
++   apl_CXXFLAGS       += -Werror -Wall -Wno-strict-aliasing
++   libapl_la_CXXFLAGS += -Werror -Wall -Wno-strict-aliasing
+ endif
+ 
+ apl_LDADD = $(LIBS)
+@@ -200,9 +198,6 @@ help:
+ 	@echo "    make update-svar_signals     - remake Svar_signals.hh"
+ 	@echo ""
+ 
+-libapl.html: libapl.texi
+-	$(MAKEINFOHTML) libapl.texi -o $@ --no-split || touch $@
+-
+-libapl.info: libapl.texi
+-	$(MAKEINFO) libapl.texi -o $@ --no-split || touch $@
++clean:
++	rm -f makefile.h
+ 
+diff --git a/src/Makefile.in b/src/Makefile.in
+index 660467c..cfc9f9d 100644
+--- a/src/Makefile.in
++++ b/src/Makefile.in
+@@ -83,10 +83,8 @@ host_triplet = @host@
+ @WANT_ANDROID_FALSE@am__append_1 = APs emacs_mode sql workspaces
+ @WANT_LIBAPL_TRUE@am__append_2 = libapl.la
+ @WANT_LIBAPL_FALSE@bin_PROGRAMS = apl$(EXEEXT)
+-@DEVELOP_TRUE@am__append_3 = -Werror -Wall -Wno-sign-compare \
+-@DEVELOP_TRUE@	-Wno-strict-aliasing
+-@DEVELOP_TRUE@am__append_4 = -Werror -Wall -Wno-sign-compare \
+-@DEVELOP_TRUE@	-Wno-strict-aliasing
++@DEVELOP_TRUE@am__append_3 = -Werror -Wall -Wno-strict-aliasing
++@DEVELOP_TRUE@am__append_4 = -Werror -Wall -Wno-strict-aliasing
+ subdir = src
+ DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
+ 	$(top_srcdir)/depcomp $(am__pkginclude_HEADERS_DIST) \
+@@ -2897,8 +2895,6 @@ distclean-generic:
+ maintainer-clean-generic:
+ 	@echo "This command is intended for maintainers to use"
+ 	@echo "it deletes files that may require special tools to rebuild."
+-clean: clean-recursive
+-
+ clean-am: clean-binPROGRAMS clean-generic clean-libtool \
+ 	clean-pkglibLTLIBRARIES mostlyclean-am
+ 
+@@ -3052,11 +3048,8 @@ help:
+ 	@echo "    make update-svar_signals     - remake Svar_signals.hh"
+ 	@echo ""
+ 
+-libapl.html: libapl.texi
+-	$(MAKEINFOHTML) libapl.texi -o $@ --no-split || touch $@
+-
+-libapl.info: libapl.texi
+-	$(MAKEINFO) libapl.texi -o $@ --no-split || touch $@
++clean:
++	rm -f makefile.h
+ 
+ # Tell versions [3.59,3.63) of GNU make to not export all variables.
+ # Otherwise a system limit (for SysV at least) may be exceeded.
+diff --git a/src/Nabla.cc b/src/Nabla.cc
+index e04e8b0..2d85766 100644
+--- a/src/Nabla.cc
++++ b/src/Nabla.cc
+@@ -161,7 +161,7 @@ UCS_string fun_text;
+ 
+         }
+ 
+-        for (int l = 1; l < lines.size(); ++l)
++        for (size_t l = 1; l < lines.size(); ++l)
+             {
+               UCS_string line_l("[");
+               line_l.append_number(l);
+@@ -694,7 +694,7 @@ const LineLabel user_edit_to = edit_to;
+ 
+    if (idx_from == 0)   COUT << "    ∇" << endl;               // if header line
+    for (int e = idx_from; e <= idx_to; ++e)   lines[e].print(COUT);
+-   if (idx_to == lines.size() - 1)   COUT << "    ∇" << endl;  // if last line
++   if ((size_t)idx_to == lines.size() - 1)   COUT << "    ∇" << endl;  // if last line
+ 
+    if (user_edit_to.valid())   // eg. [⎕42] or [2⎕42]
+       {
+@@ -836,7 +836,7 @@ const int idx_from = find_line(edit_from);
+         // find the largest label before edit_from (if any)
+         //
+         int before_idx = -1;
+-        for (int i = 0; i < lines.size(); ++i)
++        for (size_t i = 0; i < lines.size(); ++i)
+             {
+               if (lines[i].label < edit_from)   before_idx = i;
+               else                                 break;
+diff --git a/src/NumericCell.cc b/src/NumericCell.cc
+index 534ece9..0e2ffb1 100644
+--- a/src/NumericCell.cc
++++ b/src/NumericCell.cc
+@@ -1322,7 +1322,7 @@ NumericCell::do_binomial(Cell * Z, APL_Integer K, APL_Integer N, bool negate)
+ 
+         // the first element in the table is the max. N (including) for K
+         //
+-        if (N <= table_K[0])
++        if ((uint64_t)N <= table_K[0])
+            {
+              const APL_Integer z = table_K[1 + (N - K)];
+              if (negate)   new (Z) IntCell(-z);
+@@ -1580,8 +1580,8 @@ APL_Complex z;
+ ErrorCode
+ NumericCell::int_gcd(APL_Integer & z, APL_Integer a, APL_Integer b)
+ {
+-   if (a == 0x8000000000000000ULL)   return E_DOMAIN_ERROR;
+-   if (b == 0x8000000000000000ULL)   return E_DOMAIN_ERROR;
++   if ((uint64_t)a == 0x8000000000000000ULL)   return E_DOMAIN_ERROR;
++   if ((uint64_t)b == 0x8000000000000000ULL)   return E_DOMAIN_ERROR;
+ 
+    if (a < 0)   a = - a;
+    if (b < 0)   b = - b;
+diff --git a/src/Parallel.cc b/src/Parallel.cc
+index e333cab..60bcaed 100644
+--- a/src/Parallel.cc
++++ b/src/Parallel.cc
+@@ -310,7 +310,7 @@ const int err = pthread_getaffinity_np(pthread_self(), sizeof(CPUs), &CPUs);
+            if (CPU_ISSET(c, &CPUs))
+               {
+                 all_CPUs.push_back((CPU_Number)c);
+-                if (all_CPUs.size() == CPU_count)   break;   // all CPUs found
++                if ((int)all_CPUs.size() == CPU_count)   break;   // all CPUs found
+               }
+          }
+    }
+@@ -329,7 +329,7 @@ const int err = pthread_getaffinity_np(pthread_self(), sizeof(CPUs), &CPUs);
+    if (count < 0)   count = all_CPUs.size();
+ 
+    // if there are more CPUs than requested then limit all_CPUs accordingly
+-   if (all_CPUs.size() > count)   all_CPUs.resize(count);
++   if ((int)all_CPUs.size() > count)   all_CPUs.resize(count);
+ 
+    Log(LOG_Parallel || logit)
+       {
+diff --git a/src/PrimitiveFunction.cc b/src/PrimitiveFunction.cc
+index 6c63678..ff973b3 100644
+--- a/src/PrimitiveFunction.cc
++++ b/src/PrimitiveFunction.cc
+@@ -2602,7 +2602,7 @@ bool seen[MAX_RANK];
+    loop(r, len_X)
+        {
+          const APL_Integer a = A->get_ravel(r).get_near_int();
+-         const uint32_t x = X->get_ravel(r).get_near_int() - qio;
++         const APL_Integer x = X->get_ravel(r).get_near_int() - qio;
+ 
+          if (x >= B->get_rank())   INDEX_ERROR;
+          if (seen[x])              INDEX_ERROR;
+diff --git a/src/PrintBuffer.cc b/src/PrintBuffer.cc
+index 6a89676..a820550 100644
+--- a/src/PrintBuffer.cc
++++ b/src/PrintBuffer.cc
+@@ -566,18 +566,18 @@ ShapeItem ret = 0;
+ }
+ //-----------------------------------------------------------------------------
+ Unicode
+-PrintBuffer::get_char(uint32_t x, uint32_t y) const
++PrintBuffer::get_char(int x, int y) const
+ { 
+-   Assert(y < buffer.size());
+-   Assert(x < buffer[y].size());
++   Assert(y < (int)buffer.size());
++   Assert(x < (int)buffer[y].size());
+    return buffer[y][x];
+ }
+ //-----------------------------------------------------------------------------
+ void
+-PrintBuffer::set_char(uint32_t x, uint32_t y, Unicode uc)
++PrintBuffer::set_char(int x, int y, Unicode uc)
+ {
+-   Assert(y < buffer.size());
+-   Assert(x < buffer[y].size());
++   Assert(y < (int)buffer.size());
++   Assert(x < (int)buffer[y].size());
+    buffer[y][x] = uc;
+ }
+ //-----------------------------------------------------------------------------
+@@ -660,7 +660,7 @@ PrintBuffer::get_frame_chars(PrintStyle pst,
+ }
+ //-----------------------------------------------------------------------------
+ void
+-PrintBuffer::add_frame(PrintStyle style, const Shape & shape, uint32_t depth)
++PrintBuffer::add_frame(PrintStyle style, const Shape & shape, int depth)
+ {
+    Assert(is_rectangular());
+ 
+diff --git a/src/PrintBuffer.hh b/src/PrintBuffer.hh
+index 526daa5..fee59ec 100644
+--- a/src/PrintBuffer.hh
++++ b/src/PrintBuffer.hh
+@@ -106,7 +106,7 @@ public:
+                         PrintStyle outer_style);
+ 
+    /// return the number of rows
+-   size_t get_height() const
++   int get_height() const
+       { return buffer.size(); }
+ 
+    /// return the first (and only) line
+@@ -114,22 +114,22 @@ public:
+       { Assert (get_height() == 1);   return buffer[0]; }
+ 
+    /// return line y
+-   UCS_string get_line(size_t y) const
++   UCS_string get_line(int y) const
+       { Assert (y < get_height());   return buffer[y]; }
+ 
+    /// print this buffer, interruptible with ^C
+    void print_interruptible(ostream & out, Rank rank, int quad_pw);
+ 
+    /// return the number of columns.
+-   uint32_t get_width(uint32_t y) const
++   int get_width(int y) const
+       { if (get_height() == 0)   return 0;
+         Assert(y < get_height());   return buffer[y].size(); }
+ 
+    /// Set the char in column x and row y to uc.
+-   void set_char(uint32_t x, uint32_t y, Unicode uc);
++   void set_char(int x, int y, Unicode uc);
+ 
+    /// Return the char in column x and row y.
+-   Unicode get_char(uint32_t x, uint32_t y) const;
++   Unicode get_char(int x, int y) const;
+ 
+    /// prepend buffer with \b count characters \b pad
+    void pad_l(Unicode pad, ShapeItem count);
+@@ -141,7 +141,7 @@ public:
+    void pad_height(Unicode pad, ShapeItem height);
+ 
+    /// add a decorator frame around this buffer
+-   void add_frame(PrintStyle style, const Shape & shape, uint32_t depth);
++   void add_frame(PrintStyle style, const Shape & shape, int depth);
+ 
+    /// add an outer frame around this buffer
+    void add_outer_frame(PrintStyle style);
+diff --git a/src/ProcessorID.cc b/src/ProcessorID.cc
+index 619b113..f119321 100644
+--- a/src/ProcessorID.cc
++++ b/src/ProcessorID.cc
+@@ -173,7 +173,7 @@ const char * loc = 0;
+          if (!strcmp(s, ":userid,"))
+             {
+               s += 8;
+-              for (int u = 1; u < sizeof(svopid.user); ++u)
++              for (int u = 1; u < (int)sizeof(svopid.user); ++u)
+                   {
+                     if (*s < ' ')   break;
+                     svopid.user[u - 1] = *s++;
+diff --git a/src/QuadFunction.cc b/src/QuadFunction.cc
+index b848503..811e516 100644
+--- a/src/QuadFunction.cc
++++ b/src/QuadFunction.cc
+@@ -1002,7 +1002,7 @@ const APL_time_us start = now();
+ 
+ const APL_time_us end = start + 1000000 * B->get_ravel(0).get_real_value();
+    if (end < start)                            DOMAIN_ERROR;
+-   if (end > start + 31*24*60*60*1000000ULL)   DOMAIN_ERROR;   // > 1 month
++   if (end > start + 31*24*60*60*1000000LL)   DOMAIN_ERROR;   // > 1 month
+ 
+    for (;;)
+        {
+@@ -2065,17 +2065,17 @@ vector<UCS_string> names;
+    //
+    if (first_chars.size() == 0 || first_chars.contains(UNI_Quad_Quad))
+       {
+-#define ro_sv_def(x, txt)                                   \
++#define ro_sv_def(x, _txt)                                   \
+    { Symbol * symbol = &Workspace::get_v_ ## x();           \
+      if ((requested_NCs & 1 << 5) && symbol->get_nc() != 0) \
+         names.push_back(symbol->get_name()); }
+ 
+-#define rw_sv_def(x, txt)                                   \
++#define rw_sv_def(x, _txt)                                   \
+    { Symbol * symbol = &Workspace::get_v_ ## x();           \
+      if ((requested_NCs & 1 << 5) && symbol->get_nc() != 0) \
+         names.push_back(symbol->get_name()); }
+ 
+-#define sf_def(x, txt)                                      \
++#define sf_def(x, _txt)                                      \
+    { if (requested_NCs & 1 << 6)   names.push_back((x::fun->get_name())); }
+ #include "SystemVariable.def"
+       }
+diff --git a/src/Quad_RL.hh b/src/Quad_RL.hh
+index 00e565c..c375f0e 100644
+--- a/src/Quad_RL.hh
++++ b/src/Quad_RL.hh
+@@ -43,7 +43,7 @@ public:
+ #define Knuth_c 1442695040888963407
+ 
+    /// reset the seed (eg. after )CEAR)
+-   unsigned int reset_seed()
++   int reset_seed()
+       { state = INITIAL_SEED;   return INITIAL_SEED; }
+ 
+ protected:
+diff --git a/src/Quad_SVx.cc b/src/Quad_SVx.cc
+index 6b6c19a..d06bbff 100644
+--- a/src/Quad_SVx.cc
++++ b/src/Quad_SVx.cc
+@@ -39,10 +39,6 @@
+ 
+ extern char **environ;
+ 
+-#ifndef PATH_MAX
+-#define PATH_MAX 4096
+-#endif
+-
+ // shared variable function instances
+ //
+ Quad_SVC Quad_SVC::_fun;
+@@ -120,12 +116,12 @@ const AP_num par_ID = ProcessorID::get_parent_ID();
+ const char * verbose = "";
+    Log(LOG_shared_variables)   verbose = " -v";
+ 
+-char filename[PATH_MAX + 1];
++char filename[APL_PATH_MAX + 1];
+ 
+ bool found_executable = false;
+    for (int d = 0; d < dircount; ++d)
+        {
+-         snprintf(filename, PATH_MAX,
++         snprintf(filename, APL_PATH_MAX,
+                   "%s%s/AP%u --id %u --par %u --gra %u --auto%s",
+                   LibPaths::get_APL_bin_path(), dirs[d], ap, ap,
+                   own_ID, par_ID, verbose);
+@@ -544,10 +540,10 @@ const char * dirs[] = { "", "/APs" };
+ 
+    for (int d = 0; d < dircount; ++d)
+        {
+-         char dirname[PATH_MAX + 1];
+-         snprintf(dirname, PATH_MAX, "%s%s", LibPaths::get_APL_bin_path(),
++         char dirname[APL_PATH_MAX + 1];
++         snprintf(dirname, APL_PATH_MAX, "%s%s", LibPaths::get_APL_bin_path(),
+                   dirs[d]);
+-         dirname[PATH_MAX] = 0;
++         dirname[APL_PATH_MAX] = 0;
+          DIR * dir = opendir(dirname);
+ 
+          // the APs directory only exists below the src directory (i.e when
+@@ -573,16 +569,17 @@ const char * dirs[] = { "", "/APs" };
+                 if (entry->d_type != DT_REG)   continue; // not a regular file
+ #endif
+ 
+-                char filename[PATH_MAX + 1];
+-                snprintf(filename, PATH_MAX, "%s/%s", dirname, entry->d_name);
+-                filename[PATH_MAX] = 0;
++                char filename[APL_PATH_MAX + 1];
++                snprintf(filename, APL_PATH_MAX, "%s/%s", dirname,
++                         entry->d_name);
++                filename[APL_PATH_MAX] = 0;
+ 
+                 if (!is_executable(filename))   continue;
+ 
+                 int apnum;
+                 if (sscanf(entry->d_name, "AP%u", &apnum) != 1)   continue;
+ 
+-                char expected[PATH_MAX + 1];
++                char expected[APL_PATH_MAX + 1];
+                 snprintf(expected, sizeof(expected), "AP%u", apnum);
+                 if (strcmp(entry->d_name, expected))   continue;
+ 
+@@ -604,7 +601,7 @@ vector<int32_t> sorted;
+         // find smallest
+         //
+         int smallest = processors[0];
+-        for (int s = 1; s < processors.size(); ++s)
++        for (size_t s = 1; s < processors.size(); ++s)
+             if (smallest > processors[s])   smallest = processors[s];
+ 
+        // add smallest to sorted
+@@ -613,7 +610,7 @@ vector<int32_t> sorted;
+ 
+        // remove smallest from processors
+        //
+-        for (int s = 0; s < processors.size();)
++        for (size_t s = 0; s < processors.size();)
+             {
+               if (processors[s] != smallest)
+                  {
+diff --git a/src/Simple_string.hh b/src/Simple_string.hh
+index 0bf8836..03f3435 100644
+--- a/src/Simple_string.hh
++++ b/src/Simple_string.hh
+@@ -67,7 +67,7 @@ public:
+         Assert(items_valid >= 0);
+         if (items_allocated < MIN_ALLOC)   items_allocated = MIN_ALLOC;
+         items = new T[items_allocated];
+-        for (unsigned int l = 0; l < len; ++l)   items[l] = data;
++        for (int l = 0; l < len; ++l)   items[l] = data;
+       }
+ 
+    /// constructor: copy other string
+@@ -135,16 +135,16 @@ public:
+       { return items_valid; }
+ 
+    /// return the idx'th character
+-   const T & operator[](unsigned int idx) const
++   const T & operator[](int idx) const
+       {
+         Assert(idx < items_valid);
+         return items[idx];
+       }
+ 
+    /// return the idx'th character
+-   T & operator[](unsigned int idx)
++   T & operator[](int idx)
+       {
+-        if (idx >= items_valid)
++        if ((items_valid - idx) <= 0)
+            {
+              debug(cerr) << "idx = " << idx << endl;
+              Assert(0 && "Bad index");
+@@ -180,7 +180,7 @@ public:
+    /// insert character \b t after position \b pos
+    void insert_after(int pos, const T & t)
+       {
+-        Assert((unsigned int)pos < items_valid);
++        Assert(pos < items_valid);
+         if (items_valid >= items_allocated)   extend();
+         for (int s = items_valid - 1; s > pos; --s)  items[s + 1] = items[s];
+         items[pos + 1] = t;
+@@ -190,7 +190,7 @@ public:
+    /// insert character \b t before position \b pos
+    void insert_before(int pos, const T & t)
+       {
+-        Assert((unsigned int)pos < items_valid);
++        Assert(pos < items_valid);
+         if (items_valid >= items_allocated)   extend();
+         for (int s = items_valid - 1; s >= pos; --s)   items[s + 1] = items[s];
+         items[pos] = t;
+@@ -198,9 +198,9 @@ public:
+       }
+ 
+    /// decrease size to \b new_size
+-   void shrink(unsigned int new_size)
++   void shrink(int new_size)
+       {
+-        Assert(items_valid >= new_size);
++        Assert((items_valid - new_size) >= 0);
+         items_valid = new_size;
+       }
+ 
+@@ -278,7 +278,7 @@ public:
+    void remove_front()   { erase(0, 1); }
+ 
+    /// extend allocated size
+-   void reserve(unsigned int new_alloc_size)
++   void reserve(int new_alloc_size)
+       {
+         extend(new_alloc_size);
+       }
+@@ -286,9 +286,9 @@ public:
+    /// compare strings
+    Comp_result compare(const Simple_string & other) const
+       {
+-        const unsigned int common_len = items_valid < other.items_valid
+-                                      ? items_valid : other.items_valid;
+-        for (unsigned int c = 0; c < common_len; ++c)
++        const int common_len = items_valid < other.items_valid
++                             ? items_valid : other.items_valid;
++        for (int c = 0; c < common_len; ++c)
+             {
+               if (items[c] < other.items[c])   return COMP_LT;
+               if (items[c] > other.items[c])   return COMP_GT;
+@@ -342,9 +342,9 @@ protected:
+       }
+ 
+    /// increase the allocated size to at least new_size
+-   void extend(unsigned int new_size)
++   void extend(int new_size)
+       {
+-        if (new_size <= items_allocated)   return;
++        if ((items_allocated - new_size) >= 0)   return;
+ 
+         items_allocated = new_size + ADD_ALLOC;
+         T * new_items = new T[items_allocated];
+diff --git a/src/Svar_DB.cc b/src/Svar_DB.cc
+index 5700fa1..5a21dc4 100644
+--- a/src/Svar_DB.cc
++++ b/src/Svar_DB.cc
+@@ -62,16 +62,16 @@ Svar_DB::start_APserver(const char * server_sockname,
+    //
+    // set APserver_path to the case that applies.
+    //
+-char APserver_path[PATH_MAX + 1];
+-   snprintf(APserver_path, PATH_MAX, "%s/APserver", bin_dir);
+-   APserver_path[PATH_MAX] = 0;
++char APserver_path[APL_PATH_MAX + 1];
++   snprintf(APserver_path, APL_PATH_MAX, "%s/APserver", bin_dir);
++   APserver_path[APL_PATH_MAX] = 0;
+    if (access(APserver_path, X_OK) != 0)   // no APserver
+       {
+         logit && get_CERR() << "    Executable " << APserver_path
+                  << " not found (this is OK when apl was started\n"
+                     "    from the src directory): " << strerror(errno) << endl;
+ 
+-        snprintf(APserver_path, PATH_MAX, "%s/APs/APserver", bin_dir);
++        snprintf(APserver_path, APL_PATH_MAX, "%s/APs/APserver", bin_dir);
+         if (access(APserver_path, X_OK) != 0)   // no APs/APserver either
+            {
+              get_CERR() << "Executable " << APserver_path << " not found.\n"
+@@ -86,13 +86,13 @@ char APserver_path[PATH_MAX + 1];
+ 
+    logit && get_CERR() << "Found " << APserver_path << endl;
+ 
+-char popen_args[PATH_MAX + 1];
++char popen_args[APL_PATH_MAX + 1];
+    {
+      if (server_sockname)
+-        snprintf(popen_args, PATH_MAX,
++        snprintf(popen_args, APL_PATH_MAX,
+                  "%s --path %s --auto", APserver_path, server_sockname);
+      else
+-        snprintf(popen_args, PATH_MAX,
++        snprintf(popen_args, APL_PATH_MAX,
+                  "%s --port %u --auto", APserver_path, APserver_port);
+    }
+ 
+diff --git a/src/Svar_signals.hh b/src/Svar_signals.hh
+index 2382423..06bb23c 100644
+--- a/src/Svar_signals.hh
++++ b/src/Svar_signals.hh
+@@ -2,7 +2,7 @@
+    This file is part of GNU APL, a free implementation of the
+    ISO/IEC Standard 13751, "Programming Language APL, Extended"
+  
+-   Copyright (C) 2008-2015  Dr. Jürgen Sauermann
++   Copyright (C) 2008-2014  Dr. Jürgen Sauermann
+  
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+@@ -195,14 +195,14 @@ public:
+       {
+         const Sig_item_u16 len (value.size());
+         len.store(buffer);
+-        for (int b = 0; b < value.size(); ++b)   buffer += value[b];
++        for (size_t b = 0; b < value.size(); ++b)   buffer += value[b];
+       }
+ 
+    /// print the item
+    ostream & print(ostream & out) const
+       {
+         bool printable = true;
+-        for (int b = 0; b < value.size(); ++b)
++        for (size_t b = 0; b < value.size(); ++b)
+             {
+               const int v = value[b] & 0xFF;
+               if (v < ' ' || v > '~')   { printable = false;   break; }
+@@ -211,7 +211,7 @@ public:
+         if (printable)   return out << "\"" << value << "\"";
+ 
+         out << hex << setfill('0');
+-        for (int b = 0; b < value.size(); ++b)
++        for (size_t b = 0; b < value.size(); ++b)
+             {
+               if (b > 16)   { out << "...";   break; }
+               out << " " << setw(2) << (value[b] & 0xFF);
+@@ -2842,7 +2842,7 @@ Signal_base::recv_TCP(int tcp_sock, char * buffer, int bufsize,
+ 
+          return 0;
+       }
+-uint32_t siglen = 0;
++ssize_t siglen = 0;
+    for (;;)
+        {
+          errno = 0;
+diff --git a/src/SymbolTable.cc b/src/SymbolTable.cc
+index 6e2e10e..f021421 100644
+--- a/src/SymbolTable.cc
++++ b/src/SymbolTable.cc
+@@ -80,7 +80,12 @@ uint32_t hash = FNV_Offset_32;
+ Symbol *
+ SymbolTable::lookup_symbol(const UCS_string & sym_name)
+ {
+-   Assert(!Avec::is_quad(sym_name[0]));   // should not be called for ⎕xx
++   if (Avec::is_quad(sym_name[0]))   // should not be called for ⎕xx
++      {
++        CERR << "Symbol is: '" << sym_name << endl;
++        FIXME;
++      }
++     
+ 
+    // compute hash for sym_name
+    //
+@@ -293,7 +298,7 @@ vector<int> col_width;
+ 
+    loop(c, count)
+       {
+-        const int col = c % col_width.size();
++        const size_t col = c % col_width.size();
+         out << *sorted_names[c];
+         if (col == (col_width.size() - 1) || c == (count - 1))
+            {
+diff --git a/src/SystemVariable.def b/src/SystemVariable.def
+index 3e3cc4f..bbb3baa 100644
+--- a/src/SystemVariable.def
++++ b/src/SystemVariable.def
+@@ -19,66 +19,66 @@
+ */
+ 
+ // system variables
+-ro_sv_def(Quad_AI,   Account Information)
+-ro_sv_def(Quad_ARG,  command line arguments of the interpreter)
+-ro_sv_def(Quad_AV,   Atomic Vector)
+-rw_sv_def(Quad_CT,   Comparison Tolerance)
+-ro_sv_def(Quad_EM,   Event Message)
+-ro_sv_def(Quad_ET,   Event Type)
+-rw_sv_def(Quad_FC,   Format Control)
+-rw_sv_def(Quad_IO,   Index Origin)
+-rw_sv_def(Quad_L,    Left Argument)
+-ro_sv_def(Quad_LC,   Line Counters)
+-rw_sv_def(Quad_LX,   Latent Expression)
+-rw_sv_def(Quad_PP,   Printing Precision)
+-rw_sv_def(Quad_PR,   Prompt Replacement)
+-rw_sv_def(Quad_PS,   Print Style)
+-rw_sv_def(Quad_PW,   Print Width)
+-rw_sv_def(Quad_R,    Right Argment)
+-rw_sv_def(Quad_RL,   Random Link)
+-ro_sv_def(Quad_SVE,  Shared Variable Event)
+-rw_sv_def(Quad_SYL,  SYstem Limits)
+-ro_sv_def(Quad_TC,   Terminal Control Characters)
+-ro_sv_def(Quad_TS,   Time Stamp)
+-rw_sv_def(Quad_TZ,   Time Zone)
+-ro_sv_def(Quad_UL,   User Load)
+-rw_sv_def(Quad_X,    Axis Argument)
+-ro_sv_def(Quad_WA,   Workspace Available)
++ro_sv_def(Quad_AI,   "Account Information")
++ro_sv_def(Quad_ARG,  "command line arguments of the interpreter")
++ro_sv_def(Quad_AV,   "Atomic Vector")
++rw_sv_def(Quad_CT,   "Comparison Tolerance")
++ro_sv_def(Quad_EM,   "Event Message")
++ro_sv_def(Quad_ET,   "Event Type")
++rw_sv_def(Quad_FC,   "Format Control")
++rw_sv_def(Quad_IO,   "Index Origin")
++rw_sv_def(Quad_L,    "Left Argument")
++ro_sv_def(Quad_LC,   "Line Counters")
++rw_sv_def(Quad_LX,   "Latent Expression")
++rw_sv_def(Quad_PP,   "Printing Precision")
++rw_sv_def(Quad_PR,   "Prompt Replacement")
++rw_sv_def(Quad_PS,   "Print Style")
++rw_sv_def(Quad_PW,   "Print Width")
++rw_sv_def(Quad_R,    "Right Argment")
++rw_sv_def(Quad_RL,   "Random Link")
++ro_sv_def(Quad_SVE,  "Shared Variable Event")
++rw_sv_def(Quad_SYL,  "SYstem Limits")
++ro_sv_def(Quad_TC,   "Terminal Control Characters")
++ro_sv_def(Quad_TS,   "Time Stamp")
++rw_sv_def(Quad_TZ,   "Time Zone")
++ro_sv_def(Quad_UL,   "User Load")
++rw_sv_def(Quad_X,    "Axis Argument")
++ro_sv_def(Quad_WA,   "Workspace Available")
+ 
+-rw_sv_def(LAMBDA,    { ... } result)
+-rw_sv_def(ALPHA,     { ... } left value argument)
+-rw_sv_def(OMEGA,     { ... } right value argument)
+-rw_sv_def(CHI,       { ... } axis argument)
+-rw_sv_def(ALPHA_U,   { ... } left function argument)
+-rw_sv_def(OMEGA_U,   { ... } right function argument)
++rw_sv_def(LAMBDA,    "{ ... } result")
++rw_sv_def(ALPHA,     "{ ... } left value argument")
++rw_sv_def(OMEGA,     "{ ... } right value argument")
++rw_sv_def(CHI,       "{ ... } axis argument")
++rw_sv_def(ALPHA_U,   "{ ... } left function argument")
++rw_sv_def(OMEGA_U,   "{ ... } right function argument")
+ #undef ro_sv_def
+ #undef rw_sv_def
+ 
+ // system functions
+ #ifdef sf_def
+-  sf_def(Quad_AF,    Atomic Function)
+-  sf_def(Quad_AT,    Attributes)
+-  sf_def(Quad_CR,    Character Representation)
+-  sf_def(Quad_DL,    Delay)
+-  sf_def(Quad_EA,    Execute Alternate)
+-  sf_def(Quad_EC,    Execute Controlled)
+-  sf_def(Quad_ENV,   ENvironment Variables)
+-  sf_def(Quad_ES,    Event Simulate)
+-  sf_def(Quad_FX,    Fix)
+-  sf_def(Quad_INP,   Input from script)
+-  sf_def(Quad_NA,    Name Association)
+-  sf_def(Quad_NC,    Name Class)
+-  sf_def(Quad_NL,    Name List)
+-  sf_def(Quad_SI,    State Indicator)
+-  sf_def(Quad_SVC,   Shared Variable Control)
+-  sf_def(Quad_SVO,   Shared Variable Offer)
+-  sf_def(Quad_SVQ,   Shared Variable Query)
+-  sf_def(Quad_SVR,   Shared Variable Retraction)
+-  sf_def(Quad_SVS,   Shared Variable State)
+-  sf_def(Quad_STOP,  Stop vector)
+-  sf_def(Quad_TF,    Transfer Form)
+-  sf_def(Quad_TRACE, Trace vector)
+-  sf_def(Quad_UCS,   Universal Character Set)
++  sf_def(Quad_AF,    "Atomic Function")
++  sf_def(Quad_AT,    "Attributes")
++  sf_def(Quad_CR,    "Character Representation")
++  sf_def(Quad_DL,    "Delay")
++  sf_def(Quad_EA,    "Execute Alternate")
++  sf_def(Quad_EC,    "Execute Controlled")
++  sf_def(Quad_ENV,   "ENvironment Variables")
++  sf_def(Quad_ES,    "Event Simulate")
++  sf_def(Quad_FX,    "Fix")
++  sf_def(Quad_INP,   "Input from script")
++  sf_def(Quad_NA,    "Name Association")
++  sf_def(Quad_NC,    "Name Class")
++  sf_def(Quad_NL,    "Name List")
++  sf_def(Quad_SI,    "State Indicator")
++  sf_def(Quad_SVC,   "Shared Variable Control")
++  sf_def(Quad_SVO,   "Shared Variable Offer")
++  sf_def(Quad_SVQ,   "Shared Variable Query")
++  sf_def(Quad_SVR,   "Shared Variable Retraction")
++  sf_def(Quad_SVS,   "Shared Variable State")
++  sf_def(Quad_STOP,  "Stop vector")
++  sf_def(Quad_TF,    "Transfer Form")
++  sf_def(Quad_TRACE, "Trace vector")
++  sf_def(Quad_UCS,   "Universal Character Set")
+ # undef sf_def
+ #endif
+ 
+diff --git a/src/UCS_string.cc b/src/UCS_string.cc
+index 364eaa3..2741aea 100644
+--- a/src/UCS_string.cc
++++ b/src/UCS_string.cc
+@@ -34,7 +34,7 @@
+ UCS_string::UCS_string(const char * cstring)
+    : Simple_string<Unicode>(0, 0)
+ {
+-const size_t len = strlen(cstring);
++const int len = strlen(cstring);
+    extend(len + 1);
+ 
+    while (items_valid < len)   items[items_valid++] = Unicode(*cstring++);
+@@ -47,7 +47,7 @@ UCS_string::UCS_string(const UTF8_string & utf)
+    Log(LOG_char_conversion)
+       CERR << "UCS_string::UCS_string(): utf = " << utf << endl;
+ 
+-   for (uint32_t i = 0; i < utf.size();)
++   for (int i = 0; i < utf.size();)
+       {
+         const uint32_t b0 = utf[i++];
+         uint32_t bx = b0;
+@@ -909,7 +909,7 @@ UCS_string ret;
+ }
+ //-----------------------------------------------------------------------------
+ UCS_string
+-UCS_string::from_double_expo_prec(double v, unsigned int fract_digits)
++UCS_string::from_double_expo_prec(double v, int fract_digits)
+ {
+ UCS_string ret;
+ 
+@@ -1010,7 +1010,7 @@ int expo = 0;
+ }
+ //-----------------------------------------------------------------------------
+ UCS_string
+-UCS_string::from_double_fixed_prec(double v, unsigned int fract_digits)
++UCS_string::from_double_fixed_prec(double v, int fract_digits)
+ {
+ UCS_string ret;
+ 
+@@ -1088,12 +1088,12 @@ UCS_string::sort_names(vector<UCS_string> names)
+ {
+    if (names.size() < 2)   return;
+ 
+-   for (int h = 0; h < (names.size() - 1); ++h)
++   for (size_t h = 0; h < (names.size() - 1); ++h)
+        {
+          // find smallest above (including) h
+          //
+          int smallest = h;
+-         for (int j = h + 1; j < names.size(); ++j)
++         for (size_t j = h + 1; j < names.size(); ++j)
+              {
+                if (names[smallest].compare(names[j]) == COMP_GT)
+                   {
+diff --git a/src/UCS_string.hh b/src/UCS_string.hh
+index bdde0d5..73ee243 100644
+--- a/src/UCS_string.hh
++++ b/src/UCS_string.hh
+@@ -281,21 +281,19 @@ public:
+ 
+    /// convert double \b value to an UCS_string with \b fract_digits fractional
+    /// digits in scaled (exponential) format
+-   static UCS_string from_double_expo_prec(double value,
+-                                            unsigned int fract_digits);
++   static UCS_string from_double_expo_prec(double value, int fract_digits);
+ 
+    /// convert double \b value to an UCS_string with \b fract_digits fractional
+    /// digits in fixed point format
+-   static UCS_string from_double_fixed_prec(double value,
+-                                            unsigned int fract_digits);
++   static UCS_string from_double_fixed_prec(double value, int fract_digits);
+ 
+    /// convert double \b value to an UCS_string with \b quad_pp significant
+    /// digits in acaled (exponential) format
+-   static UCS_string from_double_expo_pp(double value, unsigned int quad_pp);
++   static UCS_string from_double_expo_pp(double value, int quad_pp);
+ 
+    /// convert double \b value to an UCS_string with \b quad_pp significant
+    /// digits in fixed point format
+-   static UCS_string from_double_fixed_pp(double value, unsigned int quad_pp);
++   static UCS_string from_double_fixed_pp(double value, int quad_pp);
+ 
+    /// sort a (small) number of UCS_strings (filenames, variables, or functions)
+    /// using a simple but quadratic time algorithm
+diff --git a/src/UserFunction.cc b/src/UserFunction.cc
+index 4634877..b4aa699 100644
+--- a/src/UserFunction.cc
++++ b/src/UserFunction.cc
+@@ -975,7 +975,7 @@ DynArray(bool, ts_lines, line_starts.size());
+    loop(ll, line_count)
+       {
+         Function_Line line = lines[ll];
+-        if (line >= 1 && line < line_starts.size())   ts_lines[line] = true;
++        if (line >= 1 && line < (int)line_starts.size())   ts_lines[line] = true;
+       }
+ 
+    if (stop)
+@@ -1142,8 +1142,8 @@ int error_line = -1;
+ Function_PC
+ UserFunction::pc_for_line(Function_Line line) const
+ {
+-   if (line < 1)                     return Function_PC(body.size() - 1);
+-   if (line >= line_starts.size())   return Function_PC(body.size() - 1);
++   if (line < 1)                          return Function_PC(body.size() - 1);
++   if (line >= (int)line_starts.size())   return Function_PC(body.size() - 1);
+    return line_starts[line];
+ }
+ //-----------------------------------------------------------------------------
+diff --git a/src/UserPreferences.cc b/src/UserPreferences.cc
+index 13fdfb0..3b4b5c0 100644
+--- a/src/UserPreferences.cc
++++ b/src/UserPreferences.cc
+@@ -178,7 +178,7 @@ bool
+ UserPreferences::parse_argv_1()
+ {
+ bool log_startup = false;
+-   for (int a = 1; a < expanded_argv.size(); )
++   for (size_t a = 1; a < expanded_argv.size(); )
+        {
+          const char * opt = expanded_argv[a++];
+          const char * val = (a < expanded_argv.size()) ? expanded_argv[a] : 0;
+@@ -221,9 +221,9 @@ UserPreferences::parse_argv_2(bool logit)
+    //
+    // /usr/bin/apl -apl-options... -- -script-options ./scriptname
+    //
+-   for (int a = 1; a < expanded_argv.size(); )
++   for (size_t a = 1; a < expanded_argv.size(); )
+        {
+-         if (a == script_argc)   { ++a;   continue; }   // skip scriptname
++         if ((int)a == script_argc)   { ++a;   continue; }   // skip scriptname
+ 
+          const char * opt = expanded_argv[a++];
+          const char * val = (a < expanded_argv.size()) ? expanded_argv[a] : 0;
+@@ -825,7 +825,7 @@ UserPreferences::open_user_file(const char * fname, char * filename,
+ {
+    if (sys)   // eg. /etc/gnu-apl.d/preferences
+       {
+-        snprintf(filename, PATH_MAX,
++        snprintf(filename, APL_PATH_MAX,
+                  "%s/gnu-apl.d/%s", Makefile__sysconfdir, fname);
+       }
+    else       // try $HOME/.gnu_apl
+@@ -838,20 +838,20 @@ UserPreferences::open_user_file(const char * fname, char * filename,
+              return 0;
+            }
+ 
+-        snprintf(filename, PATH_MAX, "%s/.gnu-apl/%s", HOME, fname);
+-        filename[PATH_MAX] = 0;
++        snprintf(filename, APL_PATH_MAX, "%s/.gnu-apl/%s", HOME, fname);
++        filename[APL_PATH_MAX] = 0;
+ 
+         // check that $HOME/.gnu-apl/preferences exist and fall back to
+         // $HOME/.config gnu-apl/preferences if not
+         //
+         if (access(filename, F_OK) != 0)   // file does not exit
+            {
+-             snprintf(filename, PATH_MAX,
++             snprintf(filename, APL_PATH_MAX,
+                       "%s/.config/gnu-apl/%s", HOME, fname);
+            }
+       }
+ 
+-   filename[PATH_MAX] = 0;
++   filename[APL_PATH_MAX] = 0;
+ 
+ FILE * f = fopen(filename, "r");
+    if (f == 0)
+@@ -871,7 +871,7 @@ FILE * f = fopen(filename, "r");
+ void
+ UserPreferences::read_config_file(bool sys, bool log_startup)
+ {
+-char filename[PATH_MAX + 1];
++char filename[APL_PATH_MAX + 1];
+ 
+ FILE * f = open_user_file("preferences", filename, sys, log_startup);
+    if (f == 0)   return;
+@@ -1162,7 +1162,7 @@ int file_profile = 0;   // the current profile in the preferences file
+ void
+ UserPreferences::read_threshold_file(bool sys, bool log_startup)
+ {
+-char filename[PATH_MAX + 1];
++char filename[APL_PATH_MAX + 1];
+ 
+ FILE * f = open_user_file("parallel_thresholds", filename, sys, log_startup);
+    if (f == 0)   return;
+diff --git a/src/Value.cc b/src/Value.cc
+index eee6bfb..cc3f123 100644
+--- a/src/Value.cc
++++ b/src/Value.cc
+@@ -1054,7 +1054,7 @@ Value::get_single_axis(Rank max_axis) const
+    // if axis becomes (signed) negative then it will be (unsigned) too big.
+    // Therefore we need not test for < 0.
+    //
+-const unsigned int axis = get_ravel(0).get_near_int() - Workspace::get_IO();
++const int axis = get_ravel(0).get_near_int() - Workspace::get_IO();
+    if (axis >= max_axis)   AXIS_ERROR;
+ 
+    return axis;
+diff --git a/src/Workspace.cc b/src/Workspace.cc
+index 80cf3e5..997167d 100644
+--- a/src/Workspace.cc
++++ b/src/Workspace.cc
+@@ -511,8 +511,8 @@ Workspace::unmark_all_values()
+ 
+    // unmark system variables
+    //
+-#define rw_sv_def(x, txt) the_workspace.v_ ## x.unmark_all_values();
+-#define ro_sv_def(x, txt) the_workspace.v_ ## x.unmark_all_values();
++#define rw_sv_def(x, _txt) the_workspace.v_ ## x.unmark_all_values();
++#define ro_sv_def(x, _txt) the_workspace.v_ ## x.unmark_all_values();
+ #include "SystemVariable.def"
+    the_workspace.v_Quad_Quad .unmark_all_values();
+    the_workspace.v_Quad_QUOTE.unmark_all_values();
+@@ -539,8 +539,8 @@ int count = 0;
+ 
+    // system variabes
+    //
+-#define rw_sv_def(x, txt) count += get_v_ ## x().show_owners(out, value);
+-#define ro_sv_def(x, txt) count += get_v_ ## x().show_owners(out, value);
++#define rw_sv_def(x, _txt) count += get_v_ ## x().show_owners(out, value);
++#define ro_sv_def(x, _txt) count += get_v_ ## x().show_owners(out, value);
+ #include "SystemVariable.def"
+    count += the_workspace.v_Quad_Quad .show_owners(out, value);
+    count += the_workspace.v_Quad_QUOTE.show_owners(out, value);
+@@ -602,8 +602,8 @@ Workspace::clear_WS(ostream & out, bool silent)
+ 
+    // clear the value stacks of read/write system variables...
+    //
+-#define rw_sv_def(x, txt) get_v_ ## x().destruct();
+-#define ro_sv_def(x, txt)
++#define rw_sv_def(x, _txt) get_v_ ## x().destruct();
++#define ro_sv_def(x, _txt)
+ #include "SystemVariable.def"
+ 
+    // at this point all values should have been gone.
+@@ -611,8 +611,8 @@ Workspace::clear_WS(ostream & out, bool silent)
+    //
+ // Value::erase_all(out);
+ 
+-#define rw_sv_def(x, txt) new  (&get_v_ ##x()) x;
+-#define ro_sv_def(x, txt)
++#define rw_sv_def(x, _txt) new  (&get_v_ ##x()) x;
++#define ro_sv_def(x, _txt)
+ #include "SystemVariable.def"
+ 
+    get_v_Quad_RL().reset_seed();
+@@ -898,8 +898,8 @@ int variable_count = 0;
+ 
+    // system variables
+    //
+-#define ro_sv_def(x, txt)
+-#define rw_sv_def(x, txt) if (ID:: x != ID::Quad_SYL) { get_v_ ## x().dump(outf);   ++variable_count; }
++#define ro_sv_def(x, _txt)
++#define rw_sv_def(x, _txt) if (ID:: x != ID::Quad_SYL) { get_v_ ## x().dump(outf);   ++variable_count; }
+ #include "SystemVariable.def"
+ 
+    COUT << "DUMPED WORKSPACE '" << wname << "'" << endl
+diff --git a/src/Workspace.hh b/src/Workspace.hh
+index 39621c2..0f9b8cb 100644
+--- a/src/Workspace.hh
++++ b/src/Workspace.hh
+@@ -250,12 +250,12 @@ public:
+ 
+    // access to system variables.
+    //
+-#define ro_sv_def(x, txt) /** return x **/ static x & get_v_ ## x() \
++#define ro_sv_def(x, _txt) /** return x **/ static x & get_v_ ## x() \
+    { return the_workspace.v_ ## x; }
+-#define rw_sv_def(x, txt) /** return ## x **/ static x & get_v_ ## x() \
++#define rw_sv_def(x, _txt) /** return ## x **/ static x & get_v_ ## x() \
+    { return the_workspace.v_ ## x; }
+-   rw_sv_def(Quad_Quad,  ⎕)
+-   rw_sv_def(Quad_QUOTE, ⍞)
++   rw_sv_def(Quad_Quad,  "⎕")
++   rw_sv_def(Quad_QUOTE, "⍞")
+ #include "SystemVariable.def"
+ 
+    /// push a command. This is done when ⍎Command is performed and the command
+@@ -273,10 +273,10 @@ protected:
+ 
+    // system variables.
+    //
+-#define ro_sv_def(x, txt) /** x **/ x v_ ## x;
+-#define rw_sv_def(x, txt) /** x **/ x v_ ## x;
+-   rw_sv_def(Quad_Quad,  ⎕)
+-   rw_sv_def(Quad_QUOTE, ⍞)
++#define ro_sv_def(x, _txt) /** x **/ x v_ ## x;
++#define rw_sv_def(x, _txt) /** x **/ x v_ ## x;
++   rw_sv_def(Quad_Quad,  "⎕")
++   rw_sv_def(Quad_QUOTE, "⍞")
+ #include "SystemVariable.def"
+ 
+    /// the APL prompt (6 blanks by default)
+diff --git a/src/buildtag.hh b/src/buildtag.hh
+index 2dd9f19..bd65279 100644
+--- a/src/buildtag.hh
++++ b/src/buildtag.hh
+@@ -1,3 +1,3 @@
+ #include "Common.hh"
+-#define BUILDTAG PACKAGE_NAME, PACKAGE_VERSION " / 9538", "2015-03-30 13:24:26 UTC", "Linux 3.13.0-37-generic i686", "'--enable-maintainer-mode' 'DEVELOP_WANTED=yes'"
+-#define ARCHIVE_SVN  9479
++#define BUILDTAG PACKAGE_NAME, PACKAGE_VERSION " / 9559", "2015-03-31 14:04:06 UTC", "Linux 3.13.0-37-generic i686", ""
++#define ARCHIVE_SVN  9553
+diff --git a/src/configure_args.cc b/src/configure_args.cc
+new file mode 100644
+index 0000000..187ee63
+--- /dev/null
++++ b/src/configure_args.cc
+@@ -0,0 +1,2 @@
++extern const char * configure_args;
++const char * configure_args = "./configure  '--host=i686-pc-linux-gnu' '--build=i686-pc-linux-gnu' '--program-prefix=' '--disable-dependency-tracking' '--prefix=/usr' '--exec-prefix=/usr' '--bindir=/usr/bin' '--sbindir=/usr/sbin' '--sysconfdir=/etc' '--datadir=/usr/share' '--includedir=/usr/include' '--libdir=/usr/lib' '--libexecdir=/usr/lib/i386-linux-gnu' '--localstatedir=/var' '--sharedstatedir=/usr/com' '--mandir=/usr/share/man' '--infodir=/usr/share/info' 'build_alias=i686-pc-linux-gnu' 'host_alias=i686-pc-linux-gnu' 'CFLAGS=-O2 -g -march=i486' 'CXXFLAGS=-O2 -g -march=i486'";
+diff --git a/src/main.cc b/src/main.cc
+index b011368..7fb8246 100644
+--- a/src/main.cc
++++ b/src/main.cc
+@@ -46,10 +46,6 @@
+ #include "UserPreferences.hh"
+ #include "Value.icc"
+ 
+-#ifndef PATH_MAX
+-#define PATH_MAX 4096
+-#endif
+-
+ static const char * build_tag[] = { BUILDTAG, 0 };
+ 
+ //-----------------------------------------------------------------------------
+diff --git a/src/makefile.h b/src/makefile.h
+new file mode 100644
+index 0000000..97df236
+--- /dev/null
++++ b/src/makefile.h
+@@ -0,0 +1,9 @@
++// some strings exported from Makefile
++//
++#define Makefile__bindir     "/usr/bin"
++#define Makefile__docdir     "/usr/share/doc/apl"
++#define Makefile__sysconfdir "/etc"
++#define Makefile__pkglibdir  "/usr/lib/apl"
++#define Makefile__localedir  "/usr/share/locale"
++#define Makefile__srcdir     "/home/eedjsa/projects/juergen/apl-1.5/src"
++
+diff --git a/src/native/Makefile.am b/src/native/Makefile.am
+index 92f2895..52fa2d3 100644
+--- a/src/native/Makefile.am
++++ b/src/native/Makefile.am
+@@ -2,8 +2,7 @@
+ AM_CXXFLAGS = $(CXX_RDYNAMIC)
+ 
+ if DEVELOP
+-   AM_CXXFLAGS += -Werror -Wall
+-   AM_CXXFLAGS += -Wno-sign-compare -Wno-strict-aliasing
++   AM_CXXFLAGS += -Werror -Wall -Wno-strict-aliasing
+ endif
+ 
+ pkglib_LTLIBRARIES =	lib_file_io.la		\
+diff --git a/src/native/Makefile.in b/src/native/Makefile.in
+index 34162ee..4936043 100644
+--- a/src/native/Makefile.in
++++ b/src/native/Makefile.in
+@@ -78,8 +78,7 @@ PRE_UNINSTALL = :
+ POST_UNINSTALL = :
+ build_triplet = @build@
+ host_triplet = @host@
+-@DEVELOP_TRUE@am__append_1 = -Werror -Wall -Wno-sign-compare \
+-@DEVELOP_TRUE@	-Wno-strict-aliasing
++@DEVELOP_TRUE@am__append_1 = -Werror -Wall -Wno-strict-aliasing
+ subdir = src/native
+ DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
+ 	$(top_srcdir)/depcomp
+diff --git a/src/native/file_io.cc b/src/native/file_io.cc
+index c42eba8..f792f5f 100644
+--- a/src/native/file_io.cc
++++ b/src/native/file_io.cc
+@@ -167,7 +167,7 @@ const Value & format = *A->get_ravel(a++).get_pointer_value();
+          // we want fmt to be "%42.42llf"
+          //
+          char fmt[40];
+-         int fm = 0;        // an index into fmt;
++         unsigned int fm = 0;        // an index into fmt;
+          fmt[fm++] = '%';   // copy the '%'
+          for (;;)
+              {
+@@ -527,11 +527,11 @@ const APL_Integer what = B->get_ravel(0).get_int_value();
+ 
+         case 30:   // getcwd()
+              {
+-               char buffer[PATH_MAX + 1];
+-               char * success = getcwd(buffer, PATH_MAX);
++               char buffer[APL_PATH_MAX + 1];
++               char * success = getcwd(buffer, APL_PATH_MAX);
+                if (!success)   goto out_errno;
+ 
+-               buffer[PATH_MAX] = 0;
++               buffer[APL_PATH_MAX] = 0;
+                UCS_string cwd(buffer);
+ 
+                Value_P Z(cwd, LOC);
+@@ -661,8 +661,8 @@ const int function_number = X->get_ravel(0).get_near_int();
+ 
+                 char buffer[SMALL_BUF];
+ 
+-                const ssize_t len = fread(buffer, 1, SMALL_BUF, file);
+-                if (len < 0)   goto out_errno;
++                const size_t len = fread(buffer, 1, SMALL_BUF, file);
++                if (len == 0)   goto out_errno;
+ 
+                 Value_P Z(len, LOC);
+                 new (&Z->get_ravel(0)) IntCell(0);   // prototype
+@@ -1266,11 +1266,12 @@ const int function_number = X->get_ravel(0).get_near_int();
+                 char small_buffer[SMALL_BUF];
+                 char * buffer = small_buffer;
+                 char * del = 0;
+-                if (bytes > sizeof(small_buffer))
++                if (bytes > (int)sizeof(small_buffer))
+                    buffer = del = new char[bytes];
+ 
+                 const size_t len = fread(buffer, 1, bytes, file);
+-                if (len < 0)   goto out_errno;
++                if (len == 0)   goto out_errno;
++
+                 Value_P Z(len, LOC);
+                 new (&Z->get_ravel(0)) IntCell(0);   // prototype
+                 loop(z, len)   new (Z->next_ravel()) IntCell(buffer[z] & 0xFF);
+@@ -1288,7 +1289,7 @@ const int function_number = X->get_ravel(0).get_near_int();
+                 char small_buffer[SMALL_BUF];
+                 char * buffer = small_buffer;
+                 char * del = 0;
+-                if (bytes > sizeof(small_buffer))
++                if (bytes > (int)sizeof(small_buffer))
+                    buffer = del = new char[bytes];
+ 
+                 loop(z, bytes)   buffer[z] = A->get_ravel(z).get_near_int();
+@@ -1309,7 +1310,7 @@ const int function_number = X->get_ravel(0).get_near_int();
+                 char small_buffer[SMALL_BUF];
+                 char * buffer = small_buffer;
+                 char * del = 0;
+-                if (bytes > sizeof(buffer))
++                if (bytes > (int)sizeof(buffer))
+                    buffer = del = new char[bytes + 1];
+ 
+                 const char * s = fgets(buffer, bytes, file);
+@@ -1486,7 +1487,7 @@ const int function_number = X->get_ravel(0).get_near_int();
+                 char small_buffer[SMALL_BUF];
+                 char * buffer = small_buffer;
+                 char * del = 0;
+-                if (bytes > sizeof(small_buffer))
++                if (bytes > (int)sizeof(small_buffer))
+                    buffer = del = new char[bytes];
+ 
+                 const ssize_t len = recv(fd, buffer, bytes, 0);
+@@ -1509,7 +1510,7 @@ const int function_number = X->get_ravel(0).get_near_int();
+                 char small_buffer[SMALL_BUF];
+                 char * buffer = small_buffer;
+                 char * del = 0;
+-                if (bytes > sizeof(small_buffer))
++                if (bytes > (int)sizeof(small_buffer))
+                    buffer = del = new char[bytes];
+ 
+                 loop(z, bytes)   buffer[z] = A->get_ravel(z).get_near_int();
+@@ -1541,7 +1542,7 @@ const int function_number = X->get_ravel(0).get_near_int();
+                 char small_buffer[SMALL_BUF];
+                 char * buffer = small_buffer;
+                 char * del = 0;
+-                if (bytes > sizeof(small_buffer))
++                if (bytes > (int)sizeof(small_buffer))
+                    buffer = del = new char[bytes];
+ 
+                 errno = 0;
+@@ -1564,7 +1565,7 @@ const int function_number = X->get_ravel(0).get_near_int();
+                 char small_buffer[SMALL_BUF];
+                 char * buffer = small_buffer;
+                 char * del = 0;
+-                if (bytes > sizeof(small_buffer))
++                if (bytes > (int)sizeof(small_buffer))
+                    buffer = del = new char[bytes];
+ 
+                 loop(z, bytes)   buffer[z] = A->get_ravel(z).get_near_int();
+diff --git a/src/tcp_signal.m4 b/src/tcp_signal.m4
+index 20ec83f..83593d7 100644
+--- a/src/tcp_signal.m4
++++ b/src/tcp_signal.m4
+@@ -195,14 +195,14 @@ public:
+       {
+         const Sig_item_u16 len (value.size());
+         len.store(buffer);
+-        for (int b = 0; b < value.size(); ++b)   buffer += value[b];
++        for (size_t b = 0; b < value.size(); ++b)   buffer += value[b];
+       }
+ 
+    /// print the item
+    ostream & print(ostream & out) const
+       {
+         bool printable = true;
+-        for (int b = 0; b < value.size(); ++b)
++        for (size_t b = 0; b < value.size(); ++b)
+             {
+               const int v = value[b] & 0xFF;
+               if (v < ' ' || v > '~')   { printable = false;   break; }
+@@ -211,7 +211,7 @@ public:
+         if (printable)   return out << "\"" << value << "\"";
+ 
+         out << hex << setfill('0');
+-        for (int b = 0; b < value.size(); ++b)
++        for (size_t b = 0; b < value.size(); ++b)
+             {
+               if (b > 16)   { out << "...";   break; }
+               out << " " << setw(2) << (value[b] & 0xFF);
+@@ -408,7 +408,7 @@ Signal_base::recv_TCP(int tcp_sock, char * buffer, int bufsize,
+ 
+          return 0;
+       }
+-uint32_t siglen = 0;
++ssize_t siglen = 0;
+    for (;;)
+        {
+          errno = 0;
+
+From 7fafa990cf5bed607d3b0a2c820a21a02d964339 Mon Sep 17 00:00:00 2001
+From: j_sauermann <j_sauermann@bd74f7bd-1a55-4bac-9fab-68015b139e80>
+Date: Tue, 31 Mar 2015 15:17:20 +0000
+Subject: [PATCH 4/7] fixed more clang issues
+
+---
+ configure           | 11 +++++++----
+ configure.ac        | 12 ++++++++----
+ doc/apl.html        |  2 +-
+ doc/apl.info        | 18 +++++++++---------
+ doc/apl.texi        |  2 +-
+ src/QuadFunction.cc |  4 ++--
+ src/buildtag.hh     |  2 +-
+ 7 files changed, 29 insertions(+), 22 deletions(-)
+
+diff --git a/configure b/configure
+index a21015c..53c7ff1 100755
+--- a/configure
++++ b/configure
+@@ -18310,13 +18310,16 @@ $as_echo "$HAVE_SOLARIS_ATOMIC" >&6; }
+ $as_echo_n "checking if compiler supports dynamic arrays... " >&6; }
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+-extern int foo();
++ extern int foo();
++           class A { public: A() {} };
++
+ int
+ main ()
+ {
+-int len = foo();int array[len];int a,r;
+-    for (a=0; a<len; ++a) array[a]=a;
+-    for (a=0; a<len; ++a) r+=array[a];  return r;
++ int len = foo();
++          A array[len];
++          for (int l = 1; l < len; ++l) array[l] = array[l - 1];
++
+   ;
+   return 0;
+ }
+diff --git a/configure.ac b/configure.ac
+index fdad306..fe40410 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -223,10 +223,14 @@ AC_MSG_RESULT([$HAVE_SOLARIS_ATOMIC])
+ #
+ AC_MSG_CHECKING([if compiler supports dynamic arrays])
+ AC_COMPILE_IFELSE(
+-    [AC_LANG_PROGRAM([[extern int foo();]],
+-   [[int len = foo();][int array[len];][int a,r;]
+-    [for (a=0; a<len; ++a) array[a]=a;]
+-    [for (a=0; a<len; ++a) r+=array[a];] [ return r;]])],
++    [AC_LANG_PROGRAM(
++        [ [extern int foo();]
++          [ class A { public: A() {} }; ]
++        ],
++        [ [int len = foo();]
++          [A array[len];]
++          [for (int l = 1; l < len; ++l) array[l] = array[l - 1];]
++        ]           )],
+     [DynArrays=yes], [DynArrays=no])
+ AC_MSG_RESULT([$DynArrays])
+ if test "x$DynArrays" = "xyes"; then
+diff --git a/doc/apl.html b/doc/apl.html
+index 116963a..af28435 100644
+--- a/doc/apl.html
++++ b/doc/apl.html
+@@ -1457,7 +1457,7 @@ <h4 class="subsection">3.11.1 Named Lambdas</h4>
+ [1] λ← ⍺ + ⍵ 
+ 
+ </pre>
+-<p>The lambda_header is automatically deducted from the presence ior absence
++<p>The lambda_header is automatically deducted from the presence or absence
+ of the variable names (⍺, ⍵, and χ) and function names (⍶ and ⍹) in the
+ body_expression and from whether the body_expression is empty (no λ←) or
+ not (with λ←).
+diff --git a/doc/apl.info b/doc/apl.info
+index 57fd023..26debb8 100644
+--- a/doc/apl.info
++++ b/doc/apl.info
+@@ -1329,7 +1329,7 @@ SUM
+ [1] λ← ⍺ + ⍵
+ 
+ 
+-   The lambda_header is automatically deducted from the presence ior
++   The lambda_header is automatically deducted from the presence or
+ absence of the variable names (⍺, ⍵, and χ) and function names (⍶ and ⍹)
+ in the body_expression and from whether the body_expression is empty (no
+ λ←) or not (with λ←).
+@@ -2833,14 +2833,14 @@ Node: Top383
+ Node: Chapter 11404
+ Node: Chapter 216387
+ Node: Chapter 320656
+-Node: Chapter 453321
+-Node: Chapter 555069
+-Node: Chapter 656198
+-Node: Section 6.156617
+-Node: Section 6.257304
+-Node: Chapter 758135
+-Node: Section 7.158638
+-Node: Section 7.283947
++Node: Chapter 453320
++Node: Chapter 555068
++Node: Chapter 656197
++Node: Section 6.156616
++Node: Section 6.257303
++Node: Chapter 758134
++Node: Section 7.158637
++Node: Section 7.283946
+ 
+ End Tag Table
+ 
+diff --git a/doc/apl.texi b/doc/apl.texi
+index 6a80c55..b4e1c72 100644
+--- a/doc/apl.texi
++++ b/doc/apl.texi
+@@ -1413,7 +1413,7 @@ SUM
+ 
+ @end verbatim
+ 
+-The lambda_header is automatically deducted from the presence ior absence
++The lambda_header is automatically deducted from the presence or absence
+ of the variable names (⍺, ⍵, and χ) and function names (⍶ and ⍹) in the
+ body_expression and from whether the body_expression is empty (no λ←) or
+ not (with λ←).
+diff --git a/src/QuadFunction.cc b/src/QuadFunction.cc
+index 811e516..89e0c27 100644
+--- a/src/QuadFunction.cc
++++ b/src/QuadFunction.cc
+@@ -1971,8 +1971,8 @@ Symbol * symbol = 0;
+       {
+         int len = 0;
+         const Token t = Workspace::get_quad(ucs, len);
+-        if (len < 2)                      ;
+-        if (t.get_Class() == TC_VOID)     ;
++        if (len < 2)                      return 5;    // ⎕ : quad variable
++        if (t.get_Class() == TC_VOID)     return -1;   // invalid
+         if (t.get_Class() == TC_SYMBOL)   symbol = t.get_sym_ptr();
+         else                              return  6;   // quad function
+       }
+diff --git a/src/buildtag.hh b/src/buildtag.hh
+index bd65279..330e5fd 100644
+--- a/src/buildtag.hh
++++ b/src/buildtag.hh
+@@ -1,3 +1,3 @@
+ #include "Common.hh"
+-#define BUILDTAG PACKAGE_NAME, PACKAGE_VERSION " / 9559", "2015-03-31 14:04:06 UTC", "Linux 3.13.0-37-generic i686", ""
++#define BUILDTAG PACKAGE_NAME, PACKAGE_VERSION " / 9563", "2015-03-31 15:12:42 UTC", "Linux 3.13.0-37-generic i686", "'--enable-maintainer-mode' 'DEVELOP_WANTED=yes'"
+ #define ARCHIVE_SVN  9553
+
+From e82978d154f22ebe782bc034109d93c0df58cc55 Mon Sep 17 00:00:00 2001
+From: j_sauermann <j_sauermann@bd74f7bd-1a55-4bac-9fab-68015b139e80>
+Date: Tue, 31 Mar 2015 16:49:51 +0000
+Subject: [PATCH 5/7] replaced mkstemps() by tmpname()
+
+---
+ doc/apl.html                      |  2 +-
+ doc/apl.info                      | 18 +++++++++---------
+ doc/apl.texi                      |  2 +-
+ src/buildtag.hh                   |  2 +-
+ src/emacs_mode/TempFileWrapper.cc | 21 ++++++++++-----------
+ 5 files changed, 22 insertions(+), 23 deletions(-)
+
+diff --git a/doc/apl.html b/doc/apl.html
+index af28435..938e683 100644
+--- a/doc/apl.html
++++ b/doc/apl.html
+@@ -1457,7 +1457,7 @@ <h4 class="subsection">3.11.1 Named Lambdas</h4>
+ [1] λ← ⍺ + ⍵ 
+ 
+ </pre>
+-<p>The lambda_header is automatically deducted from the presence or absence
++<p>The lambda_header is automatically deduced from the presence or absence
+ of the variable names (⍺, ⍵, and χ) and function names (⍶ and ⍹) in the
+ body_expression and from whether the body_expression is empty (no λ←) or
+ not (with λ←).
+diff --git a/doc/apl.info b/doc/apl.info
+index 26debb8..47dec26 100644
+--- a/doc/apl.info
++++ b/doc/apl.info
+@@ -1329,7 +1329,7 @@ SUM
+ [1] λ← ⍺ + ⍵
+ 
+ 
+-   The lambda_header is automatically deducted from the presence or
++   The lambda_header is automatically deduced from the presence or
+ absence of the variable names (⍺, ⍵, and χ) and function names (⍶ and ⍹)
+ in the body_expression and from whether the body_expression is empty (no
+ λ←) or not (with λ←).
+@@ -2833,14 +2833,14 @@ Node: Top383
+ Node: Chapter 11404
+ Node: Chapter 216387
+ Node: Chapter 320656
+-Node: Chapter 453320
+-Node: Chapter 555068
+-Node: Chapter 656197
+-Node: Section 6.156616
+-Node: Section 6.257303
+-Node: Chapter 758134
+-Node: Section 7.158637
+-Node: Section 7.283946
++Node: Chapter 453319
++Node: Chapter 555067
++Node: Chapter 656196
++Node: Section 6.156615
++Node: Section 6.257302
++Node: Chapter 758133
++Node: Section 7.158636
++Node: Section 7.283945
+ 
+ End Tag Table
+ 
+diff --git a/doc/apl.texi b/doc/apl.texi
+index b4e1c72..a7c1654 100644
+--- a/doc/apl.texi
++++ b/doc/apl.texi
+@@ -1413,7 +1413,7 @@ SUM
+ 
+ @end verbatim
+ 
+-The lambda_header is automatically deducted from the presence or absence
++The lambda_header is automatically deduced from the presence or absence
+ of the variable names (⍺, ⍵, and χ) and function names (⍶ and ⍹) in the
+ body_expression and from whether the body_expression is empty (no λ←) or
+ not (with λ←).
+diff --git a/src/buildtag.hh b/src/buildtag.hh
+index 330e5fd..4513c46 100644
+--- a/src/buildtag.hh
++++ b/src/buildtag.hh
+@@ -1,3 +1,3 @@
+ #include "Common.hh"
+-#define BUILDTAG PACKAGE_NAME, PACKAGE_VERSION " / 9563", "2015-03-31 15:12:42 UTC", "Linux 3.13.0-37-generic i686", "'--enable-maintainer-mode' 'DEVELOP_WANTED=yes'"
++#define BUILDTAG PACKAGE_NAME, PACKAGE_VERSION " / 9568", "2015-03-31 16:32:52 UTC", "Linux 3.13.0-37-generic i686", "'--host=i686-pc-linux-gnu' '--build=i686-pc-linux-gnu' '--program-prefix=' '--disable-dependency-tracking' '--prefix=/usr' '--exec-prefix=/usr' '--bindir=/usr/bin' '--sbindir=/usr/sbin' '--sysconfdir=/etc' '--datadir=/usr/share' '--includedir=/usr/include' '--libdir=/usr/lib' '--libexecdir=/usr/lib/i386-linux-gnu' '--localstatedir=/var' '--sharedstatedir=/usr/com' '--mandir=/usr/share/man' '--infodir=/usr/share/info' 'build_alias=i686-pc-linux-gnu' 'host_alias=i686-pc-linux-gnu' 'CFLAGS=-O2 -g -march=i486' 'CXXFLAGS=-O2 -g -march=i486'"
+ #define ARCHIVE_SVN  9553
+diff --git a/src/emacs_mode/TempFileWrapper.cc b/src/emacs_mode/TempFileWrapper.cc
+index ebafc7b..93b867a 100644
+--- a/src/emacs_mode/TempFileWrapper.cc
++++ b/src/emacs_mode/TempFileWrapper.cc
+@@ -21,6 +21,9 @@
+ #include "TempFileWrapper.hh"
+ 
+ #include <stdlib.h>
++#include <fcntl.h>
++#include <string.h>
++
+ #include "emacs.hh"
+ 
+ FileWrapper::FileWrapper( int fd_in )
+@@ -38,18 +41,14 @@ FileWrapper::~FileWrapper()
+ 
+ TempFileWrapper::TempFileWrapper( const std::string &prefix )
+ {
+-    stringstream name_buf;
+-    name_buf << prefix << "XXXXXX";
+-    const char *name_cstr = name_buf.str().c_str();
+-    DynArray( char, tmp_name, strlen( name_cstr ) + 1 );
+-    strcpy( tmp_name, name_cstr );
+-
+-    fd = mkstemp( tmp_name );
+-    if( fd == -1 ) {
+-        abort();
+-    }
++char filename[APL_PATH_MAX + 1];
++   snprintf(filename, APL_PATH_MAX, "%sXXXXXX", prefix.c_str());
++   mktemp(filename);
++   if (!*filename)   abort();   // mktemp() failed
++   fd = open(filename, O_RDWR);
++   if( fd == -1 ) abort();      // open() failed
+ 
+-    name = tmp_name;
++    name = std::string(filename);
+     closed = false;
+ }
+ 
+
+From ae9f34a216a046b29c4b69a87c315509688b6366 Mon Sep 17 00:00:00 2001
+From: j_sauermann <j_sauermann@bd74f7bd-1a55-4bac-9fab-68015b139e80>
+Date: Tue, 31 Mar 2015 16:53:20 +0000
+Subject: [PATCH 6/7] removed auto-generated file
+
+---
+ src/buildtag.hh | 3 ---
+ 1 file changed, 3 deletions(-)
+ delete mode 100644 src/buildtag.hh
+
+diff --git a/src/buildtag.hh b/src/buildtag.hh
+deleted file mode 100644
+index 4513c46..0000000
+--- a/src/buildtag.hh
++++ /dev/null
+@@ -1,3 +0,0 @@
+-#include "Common.hh"
+-#define BUILDTAG PACKAGE_NAME, PACKAGE_VERSION " / 9568", "2015-03-31 16:32:52 UTC", "Linux 3.13.0-37-generic i686", "'--host=i686-pc-linux-gnu' '--build=i686-pc-linux-gnu' '--program-prefix=' '--disable-dependency-tracking' '--prefix=/usr' '--exec-prefix=/usr' '--bindir=/usr/bin' '--sbindir=/usr/sbin' '--sysconfdir=/etc' '--datadir=/usr/share' '--includedir=/usr/include' '--libdir=/usr/lib' '--libexecdir=/usr/lib/i386-linux-gnu' '--localstatedir=/var' '--sharedstatedir=/usr/com' '--mandir=/usr/share/man' '--infodir=/usr/share/info' 'build_alias=i686-pc-linux-gnu' 'host_alias=i686-pc-linux-gnu' 'CFLAGS=-O2 -g -march=i486' 'CXXFLAGS=-O2 -g -march=i486'"
+-#define ARCHIVE_SVN  9553
+
+From 408da4d7ef6f066d10d9eea81cf0cda745f29d90 Mon Sep 17 00:00:00 2001
+From: j_sauermann <j_sauermann@bd74f7bd-1a55-4bac-9fab-68015b139e80>
+Date: Wed, 1 Apr 2015 12:11:41 +0000
+Subject: [PATCH 7/7] fixed some clang and build issues
+
+---
+ Makefile.am                                |    1 +
+ Makefile.in                                |    4 +-
+ aclocal.m4                                 | 8607 +++++++++++++++++++++++++++-
+ config.h                                   |    3 +
+ config.h.in                                |    3 +
+ configure                                  |   62 +-
+ configure.ac                               |   39 +-
+ debian/Makefile.in                         |    3 -
+ debian/source/Makefile.in                  |    3 -
+ doc/Makefile.in                            |    3 -
+ gnu-apl.d/Makefile.in                      |    3 -
+ rpm/Makefile.in                            |    3 -
+ src/APL_types.hh                           |    8 +
+ src/APs/Makefile.in                        |    3 -
+ src/Makefile.in                            |    6 +-
+ src/PrintBuffer.cc                         |   16 +-
+ src/Workspace.cc                           |    7 +-
+ src/buildtag                               |   20 +-
+ src/buildtag.hh                            |    3 +
+ src/emacs_mode/Makefile.in                 |    5 +-
+ src/emacs_mode/TempFileWrapper.cc          |   20 +-
+ src/native/Makefile.in                     |    3 -
+ src/sql/Makefile.in                        |    3 -
+ src/testcases/Makefile.in                  |    3 -
+ src/workspaces/Makefile.in                 |    3 -
+ support-files/Dirk/Makefile.in             |    3 -
+ support-files/Dyalog-Keyboard/Makefile.in  |    3 -
+ support-files/Makefile.in                  |    3 -
+ support-files/OS-X-Keyboard/Makefile.in    |    3 -
+ support-files/Unicomp-Keyboard/Makefile.in |    3 -
+ support-files/WASD-Keyboard/Makefile.in    |    3 -
+ support-files/old-Keyboard/Makefile.in     |    3 -
+ tools/Makefile.in                          |    3 -
+ workspaces/Makefile.in                     |    3 -
+ wslib3/Makefile.in                         |    3 -
+ wslib4/Makefile.in                         |    3 -
+ wslib5/APLComponentFiles/Makefile.in       |    3 -
+ wslib5/Makefile.in                         |    3 -
+ wslib5/iso-apl-cf/Makefile.in              |    3 -
+ 39 files changed, 8750 insertions(+), 126 deletions(-)
+ create mode 100644 src/buildtag.hh
+
+diff --git a/Makefile.am b/Makefile.am
+index 22fcd0c..bfb03f5 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -126,6 +126,7 @@ parallel1:
+ SYNC:	DIST
+ 	tar xvzf apl-$(VERSION).tar.gz
+ 	rm -f apl-$(VERSION)/trunk/src/makefile.h
++	rm -f apl-$(VERSION)/trunk/src/buildtag.hh
+ 	rm -f apl-$(VERSION)/trunk/src/configure_args.cc
+ 	cp -a apl-$(VERSION)/* ../savannah-repo-apl/trunk/
+ 	rm -Rf apl-$(VERSION)
+diff --git a/Makefile.in b/Makefile.in
+index b72f4d2..e7b4525 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -88,9 +88,6 @@ DIST_COMMON = INSTALL NEWS README AUTHORS ChangeLog \
+ 	ltmain.sh
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/m4/depend.m4 \
+-	$(top_srcdir)/m4/libtool.m4 $(top_srcdir)/m4/ltoptions.m4 \
+-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
+-	$(top_srcdir)/m4/lt~obsolete.m4 \
+ 	$(top_srcdir)/m4/ax_lib_sqlite3.m4 \
+ 	$(top_srcdir)/m4/ax_lib_postgresql.m4 \
+ 	$(top_srcdir)/configure.ac
+@@ -1031,6 +1028,7 @@ parallel1:
+ SYNC:	DIST
+ 	tar xvzf apl-$(VERSION).tar.gz
+ 	rm -f apl-$(VERSION)/trunk/src/makefile.h
++	rm -f apl-$(VERSION)/trunk/src/buildtag.hh
+ 	rm -f apl-$(VERSION)/trunk/src/configure_args.cc
+ 	cp -a apl-$(VERSION)/* ../savannah-repo-apl/trunk/
+ 	rm -Rf apl-$(VERSION)
+diff --git a/aclocal.m4 b/aclocal.m4
+index edeae21..94d1393 100644
+--- a/aclocal.m4
++++ b/aclocal.m4
+@@ -20,6 +20,8608 @@ You have another version of autoconf.  It may work, but is not guaranteed to.
+ If you have problems, you may need to regenerate the build system entirely.
+ To do so, use the procedure documented by the package, typically 'autoreconf'.])])
+ 
++# libtool.m4 - Configure libtool for the host system. -*-Autoconf-*-
++#
++#   Copyright (C) 1996, 1997, 1998, 1999, 2000, 2001, 2003, 2004, 2005,
++#                 2006, 2007, 2008, 2009, 2010, 2011 Free Software
++#                 Foundation, Inc.
++#   Written by Gordon Matzigkeit, 1996
++#
++# This file is free software; the Free Software Foundation gives
++# unlimited permission to copy and/or distribute it, with or without
++# modifications, as long as this notice is preserved.
++
++m4_define([_LT_COPYING], [dnl
++#   Copyright (C) 1996, 1997, 1998, 1999, 2000, 2001, 2003, 2004, 2005,
++#                 2006, 2007, 2008, 2009, 2010, 2011 Free Software
++#                 Foundation, Inc.
++#   Written by Gordon Matzigkeit, 1996
++#
++#   This file is part of GNU Libtool.
++#
++# GNU Libtool is free software; you can redistribute it and/or
++# modify it under the terms of the GNU General Public License as
++# published by the Free Software Foundation; either version 2 of
++# the License, or (at your option) any later version.
++#
++# As a special exception to the GNU General Public License,
++# if you distribute this file as part of a program or library that
++# is built using GNU Libtool, you may include this file under the
++# same distribution terms that you use for the rest of that program.
++#
++# GNU Libtool is distributed in the hope that it will be useful,
++# but WITHOUT ANY WARRANTY; without even the implied warranty of
++# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++# GNU General Public License for more details.
++#
++# You should have received a copy of the GNU General Public License
++# along with GNU Libtool; see the file COPYING.  If not, a copy
++# can be downloaded from http://www.gnu.org/licenses/gpl.html, or
++# obtained by writing to the Free Software Foundation, Inc.,
++# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
++])
++
++# serial 57 LT_INIT
++
++
++# LT_PREREQ(VERSION)
++# ------------------
++# Complain and exit if this libtool version is less that VERSION.
++m4_defun([LT_PREREQ],
++[m4_if(m4_version_compare(m4_defn([LT_PACKAGE_VERSION]), [$1]), -1,
++       [m4_default([$3],
++		   [m4_fatal([Libtool version $1 or higher is required],
++		             63)])],
++       [$2])])
++
++
++# _LT_CHECK_BUILDDIR
++# ------------------
++# Complain if the absolute build directory name contains unusual characters
++m4_defun([_LT_CHECK_BUILDDIR],
++[case `pwd` in
++  *\ * | *\	*)
++    AC_MSG_WARN([Libtool does not cope well with whitespace in `pwd`]) ;;
++esac
++])
++
++
++# LT_INIT([OPTIONS])
++# ------------------
++AC_DEFUN([LT_INIT],
++[AC_PREREQ([2.58])dnl We use AC_INCLUDES_DEFAULT
++AC_REQUIRE([AC_CONFIG_AUX_DIR_DEFAULT])dnl
++AC_BEFORE([$0], [LT_LANG])dnl
++AC_BEFORE([$0], [LT_OUTPUT])dnl
++AC_BEFORE([$0], [LTDL_INIT])dnl
++m4_require([_LT_CHECK_BUILDDIR])dnl
++
++dnl Autoconf doesn't catch unexpanded LT_ macros by default:
++m4_pattern_forbid([^_?LT_[A-Z_]+$])dnl
++m4_pattern_allow([^(_LT_EOF|LT_DLGLOBAL|LT_DLLAZY_OR_NOW|LT_MULTI_MODULE)$])dnl
++dnl aclocal doesn't pull ltoptions.m4, ltsugar.m4, or ltversion.m4
++dnl unless we require an AC_DEFUNed macro:
++AC_REQUIRE([LTOPTIONS_VERSION])dnl
++AC_REQUIRE([LTSUGAR_VERSION])dnl
++AC_REQUIRE([LTVERSION_VERSION])dnl
++AC_REQUIRE([LTOBSOLETE_VERSION])dnl
++m4_require([_LT_PROG_LTMAIN])dnl
++
++_LT_SHELL_INIT([SHELL=${CONFIG_SHELL-/bin/sh}])
++
++dnl Parse OPTIONS
++_LT_SET_OPTIONS([$0], [$1])
++
++# This can be used to rebuild libtool when needed
++LIBTOOL_DEPS="$ltmain"
++
++# Always use our own libtool.
++LIBTOOL='$(SHELL) $(top_builddir)/libtool'
++AC_SUBST(LIBTOOL)dnl
++
++_LT_SETUP
++
++# Only expand once:
++m4_define([LT_INIT])
++])# LT_INIT
++
++# Old names:
++AU_ALIAS([AC_PROG_LIBTOOL], [LT_INIT])
++AU_ALIAS([AM_PROG_LIBTOOL], [LT_INIT])
++dnl aclocal-1.4 backwards compatibility:
++dnl AC_DEFUN([AC_PROG_LIBTOOL], [])
++dnl AC_DEFUN([AM_PROG_LIBTOOL], [])
++
++
++# _LT_CC_BASENAME(CC)
++# -------------------
++# Calculate cc_basename.  Skip known compiler wrappers and cross-prefix.
++m4_defun([_LT_CC_BASENAME],
++[for cc_temp in $1""; do
++  case $cc_temp in
++    compile | *[[\\/]]compile | ccache | *[[\\/]]ccache ) ;;
++    distcc | *[[\\/]]distcc | purify | *[[\\/]]purify ) ;;
++    \-*) ;;
++    *) break;;
++  esac
++done
++cc_basename=`$ECHO "$cc_temp" | $SED "s%.*/%%; s%^$host_alias-%%"`
++])
++
++
++# _LT_FILEUTILS_DEFAULTS
++# ----------------------
++# It is okay to use these file commands and assume they have been set
++# sensibly after `m4_require([_LT_FILEUTILS_DEFAULTS])'.
++m4_defun([_LT_FILEUTILS_DEFAULTS],
++[: ${CP="cp -f"}
++: ${MV="mv -f"}
++: ${RM="rm -f"}
++])# _LT_FILEUTILS_DEFAULTS
++
++
++# _LT_SETUP
++# ---------
++m4_defun([_LT_SETUP],
++[AC_REQUIRE([AC_CANONICAL_HOST])dnl
++AC_REQUIRE([AC_CANONICAL_BUILD])dnl
++AC_REQUIRE([_LT_PREPARE_SED_QUOTE_VARS])dnl
++AC_REQUIRE([_LT_PROG_ECHO_BACKSLASH])dnl
++
++_LT_DECL([], [PATH_SEPARATOR], [1], [The PATH separator for the build system])dnl
++dnl
++_LT_DECL([], [host_alias], [0], [The host system])dnl
++_LT_DECL([], [host], [0])dnl
++_LT_DECL([], [host_os], [0])dnl
++dnl
++_LT_DECL([], [build_alias], [0], [The build system])dnl
++_LT_DECL([], [build], [0])dnl
++_LT_DECL([], [build_os], [0])dnl
++dnl
++AC_REQUIRE([AC_PROG_CC])dnl
++AC_REQUIRE([LT_PATH_LD])dnl
++AC_REQUIRE([LT_PATH_NM])dnl
++dnl
++AC_REQUIRE([AC_PROG_LN_S])dnl
++test -z "$LN_S" && LN_S="ln -s"
++_LT_DECL([], [LN_S], [1], [Whether we need soft or hard links])dnl
++dnl
++AC_REQUIRE([LT_CMD_MAX_LEN])dnl
++_LT_DECL([objext], [ac_objext], [0], [Object file suffix (normally "o")])dnl
++_LT_DECL([], [exeext], [0], [Executable file suffix (normally "")])dnl
++dnl
++m4_require([_LT_FILEUTILS_DEFAULTS])dnl
++m4_require([_LT_CHECK_SHELL_FEATURES])dnl
++m4_require([_LT_PATH_CONVERSION_FUNCTIONS])dnl
++m4_require([_LT_CMD_RELOAD])dnl
++m4_require([_LT_CHECK_MAGIC_METHOD])dnl
++m4_require([_LT_CHECK_SHAREDLIB_FROM_LINKLIB])dnl
++m4_require([_LT_CMD_OLD_ARCHIVE])dnl
++m4_require([_LT_CMD_GLOBAL_SYMBOLS])dnl
++m4_require([_LT_WITH_SYSROOT])dnl
++
++_LT_CONFIG_LIBTOOL_INIT([
++# See if we are running on zsh, and set the options which allow our
++# commands through without removal of \ escapes INIT.
++if test -n "\${ZSH_VERSION+set}" ; then
++   setopt NO_GLOB_SUBST
++fi
++])
++if test -n "${ZSH_VERSION+set}" ; then
++   setopt NO_GLOB_SUBST
++fi
++
++_LT_CHECK_OBJDIR
++
++m4_require([_LT_TAG_COMPILER])dnl
++
++case $host_os in
++aix3*)
++  # AIX sometimes has problems with the GCC collect2 program.  For some
++  # reason, if we set the COLLECT_NAMES environment variable, the problems
++  # vanish in a puff of smoke.
++  if test "X${COLLECT_NAMES+set}" != Xset; then
++    COLLECT_NAMES=
++    export COLLECT_NAMES
++  fi
++  ;;
++esac
++
++# Global variables:
++ofile=libtool
++can_build_shared=yes
++
++# All known linkers require a `.a' archive for static linking (except MSVC,
++# which needs '.lib').
++libext=a
++
++with_gnu_ld="$lt_cv_prog_gnu_ld"
++
++old_CC="$CC"
++old_CFLAGS="$CFLAGS"
++
++# Set sane defaults for various variables
++test -z "$CC" && CC=cc
++test -z "$LTCC" && LTCC=$CC
++test -z "$LTCFLAGS" && LTCFLAGS=$CFLAGS
++test -z "$LD" && LD=ld
++test -z "$ac_objext" && ac_objext=o
++
++_LT_CC_BASENAME([$compiler])
++
++# Only perform the check for file, if the check method requires it
++test -z "$MAGIC_CMD" && MAGIC_CMD=file
++case $deplibs_check_method in
++file_magic*)
++  if test "$file_magic_cmd" = '$MAGIC_CMD'; then
++    _LT_PATH_MAGIC
++  fi
++  ;;
++esac
++
++# Use C for the default configuration in the libtool script
++LT_SUPPORTED_TAG([CC])
++_LT_LANG_C_CONFIG
++_LT_LANG_DEFAULT_CONFIG
++_LT_CONFIG_COMMANDS
++])# _LT_SETUP
++
++
++# _LT_PREPARE_SED_QUOTE_VARS
++# --------------------------
++# Define a few sed substitution that help us do robust quoting.
++m4_defun([_LT_PREPARE_SED_QUOTE_VARS],
++[# Backslashify metacharacters that are still active within
++# double-quoted strings.
++sed_quote_subst='s/\([["`$\\]]\)/\\\1/g'
++
++# Same as above, but do not quote variable references.
++double_quote_subst='s/\([["`\\]]\)/\\\1/g'
++
++# Sed substitution to delay expansion of an escaped shell variable in a
++# double_quote_subst'ed string.
++delay_variable_subst='s/\\\\\\\\\\\$/\\\\\\$/g'
++
++# Sed substitution to delay expansion of an escaped single quote.
++delay_single_quote_subst='s/'\''/'\'\\\\\\\'\''/g'
++
++# Sed substitution to avoid accidental globbing in evaled expressions
++no_glob_subst='s/\*/\\\*/g'
++])
++
++# _LT_PROG_LTMAIN
++# ---------------
++# Note that this code is called both from `configure', and `config.status'
++# now that we use AC_CONFIG_COMMANDS to generate libtool.  Notably,
++# `config.status' has no value for ac_aux_dir unless we are using Automake,
++# so we pass a copy along to make sure it has a sensible value anyway.
++m4_defun([_LT_PROG_LTMAIN],
++[m4_ifdef([AC_REQUIRE_AUX_FILE], [AC_REQUIRE_AUX_FILE([ltmain.sh])])dnl
++_LT_CONFIG_LIBTOOL_INIT([ac_aux_dir='$ac_aux_dir'])
++ltmain="$ac_aux_dir/ltmain.sh"
++])# _LT_PROG_LTMAIN
++
++
++
++# So that we can recreate a full libtool script including additional
++# tags, we accumulate the chunks of code to send to AC_CONFIG_COMMANDS
++# in macros and then make a single call at the end using the `libtool'
++# label.
++
++
++# _LT_CONFIG_LIBTOOL_INIT([INIT-COMMANDS])
++# ----------------------------------------
++# Register INIT-COMMANDS to be passed to AC_CONFIG_COMMANDS later.
++m4_define([_LT_CONFIG_LIBTOOL_INIT],
++[m4_ifval([$1],
++          [m4_append([_LT_OUTPUT_LIBTOOL_INIT],
++                     [$1
++])])])
++
++# Initialize.
++m4_define([_LT_OUTPUT_LIBTOOL_INIT])
++
++
++# _LT_CONFIG_LIBTOOL([COMMANDS])
++# ------------------------------
++# Register COMMANDS to be passed to AC_CONFIG_COMMANDS later.
++m4_define([_LT_CONFIG_LIBTOOL],
++[m4_ifval([$1],
++          [m4_append([_LT_OUTPUT_LIBTOOL_COMMANDS],
++                     [$1
++])])])
++
++# Initialize.
++m4_define([_LT_OUTPUT_LIBTOOL_COMMANDS])
++
++
++# _LT_CONFIG_SAVE_COMMANDS([COMMANDS], [INIT_COMMANDS])
++# -----------------------------------------------------
++m4_defun([_LT_CONFIG_SAVE_COMMANDS],
++[_LT_CONFIG_LIBTOOL([$1])
++_LT_CONFIG_LIBTOOL_INIT([$2])
++])
++
++
++# _LT_FORMAT_COMMENT([COMMENT])
++# -----------------------------
++# Add leading comment marks to the start of each line, and a trailing
++# full-stop to the whole comment if one is not present already.
++m4_define([_LT_FORMAT_COMMENT],
++[m4_ifval([$1], [
++m4_bpatsubst([m4_bpatsubst([$1], [^ *], [# ])],
++              [['`$\]], [\\\&])]m4_bmatch([$1], [[!?.]$], [], [.])
++)])
++
++
++
++
++
++# _LT_DECL([CONFIGNAME], VARNAME, VALUE, [DESCRIPTION], [IS-TAGGED?])
++# -------------------------------------------------------------------
++# CONFIGNAME is the name given to the value in the libtool script.
++# VARNAME is the (base) name used in the configure script.
++# VALUE may be 0, 1 or 2 for a computed quote escaped value based on
++# VARNAME.  Any other value will be used directly.
++m4_define([_LT_DECL],
++[lt_if_append_uniq([lt_decl_varnames], [$2], [, ],
++    [lt_dict_add_subkey([lt_decl_dict], [$2], [libtool_name],
++	[m4_ifval([$1], [$1], [$2])])
++    lt_dict_add_subkey([lt_decl_dict], [$2], [value], [$3])
++    m4_ifval([$4],
++	[lt_dict_add_subkey([lt_decl_dict], [$2], [description], [$4])])
++    lt_dict_add_subkey([lt_decl_dict], [$2],
++	[tagged?], [m4_ifval([$5], [yes], [no])])])
++])
++
++
++# _LT_TAGDECL([CONFIGNAME], VARNAME, VALUE, [DESCRIPTION])
++# --------------------------------------------------------
++m4_define([_LT_TAGDECL], [_LT_DECL([$1], [$2], [$3], [$4], [yes])])
++
++
++# lt_decl_tag_varnames([SEPARATOR], [VARNAME1...])
++# ------------------------------------------------
++m4_define([lt_decl_tag_varnames],
++[_lt_decl_filter([tagged?], [yes], $@)])
++
++
++# _lt_decl_filter(SUBKEY, VALUE, [SEPARATOR], [VARNAME1..])
++# ---------------------------------------------------------
++m4_define([_lt_decl_filter],
++[m4_case([$#],
++  [0], [m4_fatal([$0: too few arguments: $#])],
++  [1], [m4_fatal([$0: too few arguments: $#: $1])],
++  [2], [lt_dict_filter([lt_decl_dict], [$1], [$2], [], lt_decl_varnames)],
++  [3], [lt_dict_filter([lt_decl_dict], [$1], [$2], [$3], lt_decl_varnames)],
++  [lt_dict_filter([lt_decl_dict], $@)])[]dnl
++])
++
++
++# lt_decl_quote_varnames([SEPARATOR], [VARNAME1...])
++# --------------------------------------------------
++m4_define([lt_decl_quote_varnames],
++[_lt_decl_filter([value], [1], $@)])
++
++
++# lt_decl_dquote_varnames([SEPARATOR], [VARNAME1...])
++# ---------------------------------------------------
++m4_define([lt_decl_dquote_varnames],
++[_lt_decl_filter([value], [2], $@)])
++
++
++# lt_decl_varnames_tagged([SEPARATOR], [VARNAME1...])
++# ---------------------------------------------------
++m4_define([lt_decl_varnames_tagged],
++[m4_assert([$# <= 2])dnl
++_$0(m4_quote(m4_default([$1], [[, ]])),
++    m4_ifval([$2], [[$2]], [m4_dquote(lt_decl_tag_varnames)]),
++    m4_split(m4_normalize(m4_quote(_LT_TAGS)), [ ]))])
++m4_define([_lt_decl_varnames_tagged],
++[m4_ifval([$3], [lt_combine([$1], [$2], [_], $3)])])
++
++
++# lt_decl_all_varnames([SEPARATOR], [VARNAME1...])
++# ------------------------------------------------
++m4_define([lt_decl_all_varnames],
++[_$0(m4_quote(m4_default([$1], [[, ]])),
++     m4_if([$2], [],
++	   m4_quote(lt_decl_varnames),
++	m4_quote(m4_shift($@))))[]dnl
++])
++m4_define([_lt_decl_all_varnames],
++[lt_join($@, lt_decl_varnames_tagged([$1],
++			lt_decl_tag_varnames([[, ]], m4_shift($@))))dnl
++])
++
++
++# _LT_CONFIG_STATUS_DECLARE([VARNAME])
++# ------------------------------------
++# Quote a variable value, and forward it to `config.status' so that its
++# declaration there will have the same value as in `configure'.  VARNAME
++# must have a single quote delimited value for this to work.
++m4_define([_LT_CONFIG_STATUS_DECLARE],
++[$1='`$ECHO "$][$1" | $SED "$delay_single_quote_subst"`'])
++
++
++# _LT_CONFIG_STATUS_DECLARATIONS
++# ------------------------------
++# We delimit libtool config variables with single quotes, so when
++# we write them to config.status, we have to be sure to quote all
++# embedded single quotes properly.  In configure, this macro expands
++# each variable declared with _LT_DECL (and _LT_TAGDECL) into:
++#
++#    <var>='`$ECHO "$<var>" | $SED "$delay_single_quote_subst"`'
++m4_defun([_LT_CONFIG_STATUS_DECLARATIONS],
++[m4_foreach([_lt_var], m4_quote(lt_decl_all_varnames),
++    [m4_n([_LT_CONFIG_STATUS_DECLARE(_lt_var)])])])
++
++
++# _LT_LIBTOOL_TAGS
++# ----------------
++# Output comment and list of tags supported by the script
++m4_defun([_LT_LIBTOOL_TAGS],
++[_LT_FORMAT_COMMENT([The names of the tagged configurations supported by this script])dnl
++available_tags="_LT_TAGS"dnl
++])
++
++
++# _LT_LIBTOOL_DECLARE(VARNAME, [TAG])
++# -----------------------------------
++# Extract the dictionary values for VARNAME (optionally with TAG) and
++# expand to a commented shell variable setting:
++#
++#    # Some comment about what VAR is for.
++#    visible_name=$lt_internal_name
++m4_define([_LT_LIBTOOL_DECLARE],
++[_LT_FORMAT_COMMENT(m4_quote(lt_dict_fetch([lt_decl_dict], [$1],
++					   [description])))[]dnl
++m4_pushdef([_libtool_name],
++    m4_quote(lt_dict_fetch([lt_decl_dict], [$1], [libtool_name])))[]dnl
++m4_case(m4_quote(lt_dict_fetch([lt_decl_dict], [$1], [value])),
++    [0], [_libtool_name=[$]$1],
++    [1], [_libtool_name=$lt_[]$1],
++    [2], [_libtool_name=$lt_[]$1],
++    [_libtool_name=lt_dict_fetch([lt_decl_dict], [$1], [value])])[]dnl
++m4_ifval([$2], [_$2])[]m4_popdef([_libtool_name])[]dnl
++])
++
++
++# _LT_LIBTOOL_CONFIG_VARS
++# -----------------------
++# Produce commented declarations of non-tagged libtool config variables
++# suitable for insertion in the LIBTOOL CONFIG section of the `libtool'
++# script.  Tagged libtool config variables (even for the LIBTOOL CONFIG
++# section) are produced by _LT_LIBTOOL_TAG_VARS.
++m4_defun([_LT_LIBTOOL_CONFIG_VARS],
++[m4_foreach([_lt_var],
++    m4_quote(_lt_decl_filter([tagged?], [no], [], lt_decl_varnames)),
++    [m4_n([_LT_LIBTOOL_DECLARE(_lt_var)])])])
++
++
++# _LT_LIBTOOL_TAG_VARS(TAG)
++# -------------------------
++m4_define([_LT_LIBTOOL_TAG_VARS],
++[m4_foreach([_lt_var], m4_quote(lt_decl_tag_varnames),
++    [m4_n([_LT_LIBTOOL_DECLARE(_lt_var, [$1])])])])
++
++
++# _LT_TAGVAR(VARNAME, [TAGNAME])
++# ------------------------------
++m4_define([_LT_TAGVAR], [m4_ifval([$2], [$1_$2], [$1])])
++
++
++# _LT_CONFIG_COMMANDS
++# -------------------
++# Send accumulated output to $CONFIG_STATUS.  Thanks to the lists of
++# variables for single and double quote escaping we saved from calls
++# to _LT_DECL, we can put quote escaped variables declarations
++# into `config.status', and then the shell code to quote escape them in
++# for loops in `config.status'.  Finally, any additional code accumulated
++# from calls to _LT_CONFIG_LIBTOOL_INIT is expanded.
++m4_defun([_LT_CONFIG_COMMANDS],
++[AC_PROVIDE_IFELSE([LT_OUTPUT],
++	dnl If the libtool generation code has been placed in $CONFIG_LT,
++	dnl instead of duplicating it all over again into config.status,
++	dnl then we will have config.status run $CONFIG_LT later, so it
++	dnl needs to know what name is stored there:
++        [AC_CONFIG_COMMANDS([libtool],
++            [$SHELL $CONFIG_LT || AS_EXIT(1)], [CONFIG_LT='$CONFIG_LT'])],
++    dnl If the libtool generation code is destined for config.status,
++    dnl expand the accumulated commands and init code now:
++    [AC_CONFIG_COMMANDS([libtool],
++        [_LT_OUTPUT_LIBTOOL_COMMANDS], [_LT_OUTPUT_LIBTOOL_COMMANDS_INIT])])
++])#_LT_CONFIG_COMMANDS
++
++
++# Initialize.
++m4_define([_LT_OUTPUT_LIBTOOL_COMMANDS_INIT],
++[
++
++# The HP-UX ksh and POSIX shell print the target directory to stdout
++# if CDPATH is set.
++(unset CDPATH) >/dev/null 2>&1 && unset CDPATH
++
++sed_quote_subst='$sed_quote_subst'
++double_quote_subst='$double_quote_subst'
++delay_variable_subst='$delay_variable_subst'
++_LT_CONFIG_STATUS_DECLARATIONS
++LTCC='$LTCC'
++LTCFLAGS='$LTCFLAGS'
++compiler='$compiler_DEFAULT'
++
++# A function that is used when there is no print builtin or printf.
++func_fallback_echo ()
++{
++  eval 'cat <<_LTECHO_EOF
++\$[]1
++_LTECHO_EOF'
++}
++
++# Quote evaled strings.
++for var in lt_decl_all_varnames([[ \
++]], lt_decl_quote_varnames); do
++    case \`eval \\\\\$ECHO \\\\""\\\\\$\$var"\\\\"\` in
++    *[[\\\\\\\`\\"\\\$]]*)
++      eval "lt_\$var=\\\\\\"\\\`\\\$ECHO \\"\\\$\$var\\" | \\\$SED \\"\\\$sed_quote_subst\\"\\\`\\\\\\""
++      ;;
++    *)
++      eval "lt_\$var=\\\\\\"\\\$\$var\\\\\\""
++      ;;
++    esac
++done
++
++# Double-quote double-evaled strings.
++for var in lt_decl_all_varnames([[ \
++]], lt_decl_dquote_varnames); do
++    case \`eval \\\\\$ECHO \\\\""\\\\\$\$var"\\\\"\` in
++    *[[\\\\\\\`\\"\\\$]]*)
++      eval "lt_\$var=\\\\\\"\\\`\\\$ECHO \\"\\\$\$var\\" | \\\$SED -e \\"\\\$double_quote_subst\\" -e \\"\\\$sed_quote_subst\\" -e \\"\\\$delay_variable_subst\\"\\\`\\\\\\""
++      ;;
++    *)
++      eval "lt_\$var=\\\\\\"\\\$\$var\\\\\\""
++      ;;
++    esac
++done
++
++_LT_OUTPUT_LIBTOOL_INIT
++])
++
++# _LT_GENERATED_FILE_INIT(FILE, [COMMENT])
++# ------------------------------------
++# Generate a child script FILE with all initialization necessary to
++# reuse the environment learned by the parent script, and make the
++# file executable.  If COMMENT is supplied, it is inserted after the
++# `#!' sequence but before initialization text begins.  After this
++# macro, additional text can be appended to FILE to form the body of
++# the child script.  The macro ends with non-zero status if the
++# file could not be fully written (such as if the disk is full).
++m4_ifdef([AS_INIT_GENERATED],
++[m4_defun([_LT_GENERATED_FILE_INIT],[AS_INIT_GENERATED($@)])],
++[m4_defun([_LT_GENERATED_FILE_INIT],
++[m4_require([AS_PREPARE])]dnl
++[m4_pushdef([AS_MESSAGE_LOG_FD])]dnl
++[lt_write_fail=0
++cat >$1 <<_ASEOF || lt_write_fail=1
++#! $SHELL
++# Generated by $as_me.
++$2
++SHELL=\${CONFIG_SHELL-$SHELL}
++export SHELL
++_ASEOF
++cat >>$1 <<\_ASEOF || lt_write_fail=1
++AS_SHELL_SANITIZE
++_AS_PREPARE
++exec AS_MESSAGE_FD>&1
++_ASEOF
++test $lt_write_fail = 0 && chmod +x $1[]dnl
++m4_popdef([AS_MESSAGE_LOG_FD])])])# _LT_GENERATED_FILE_INIT
++
++# LT_OUTPUT
++# ---------
++# This macro allows early generation of the libtool script (before
++# AC_OUTPUT is called), incase it is used in configure for compilation
++# tests.
++AC_DEFUN([LT_OUTPUT],
++[: ${CONFIG_LT=./config.lt}
++AC_MSG_NOTICE([creating $CONFIG_LT])
++_LT_GENERATED_FILE_INIT(["$CONFIG_LT"],
++[# Run this file to recreate a libtool stub with the current configuration.])
++
++cat >>"$CONFIG_LT" <<\_LTEOF
++lt_cl_silent=false
++exec AS_MESSAGE_LOG_FD>>config.log
++{
++  echo
++  AS_BOX([Running $as_me.])
++} >&AS_MESSAGE_LOG_FD
++
++lt_cl_help="\
++\`$as_me' creates a local libtool stub from the current configuration,
++for use in further configure time tests before the real libtool is
++generated.
++
++Usage: $[0] [[OPTIONS]]
++
++  -h, --help      print this help, then exit
++  -V, --version   print version number, then exit
++  -q, --quiet     do not print progress messages
++  -d, --debug     don't remove temporary files
++
++Report bugs to <bug-libtool@gnu.org>."
++
++lt_cl_version="\
++m4_ifset([AC_PACKAGE_NAME], [AC_PACKAGE_NAME ])config.lt[]dnl
++m4_ifset([AC_PACKAGE_VERSION], [ AC_PACKAGE_VERSION])
++configured by $[0], generated by m4_PACKAGE_STRING.
++
++Copyright (C) 2011 Free Software Foundation, Inc.
++This config.lt script is free software; the Free Software Foundation
++gives unlimited permision to copy, distribute and modify it."
++
++while test $[#] != 0
++do
++  case $[1] in
++    --version | --v* | -V )
++      echo "$lt_cl_version"; exit 0 ;;
++    --help | --h* | -h )
++      echo "$lt_cl_help"; exit 0 ;;
++    --debug | --d* | -d )
++      debug=: ;;
++    --quiet | --q* | --silent | --s* | -q )
++      lt_cl_silent=: ;;
++
++    -*) AC_MSG_ERROR([unrecognized option: $[1]
++Try \`$[0] --help' for more information.]) ;;
++
++    *) AC_MSG_ERROR([unrecognized argument: $[1]
++Try \`$[0] --help' for more information.]) ;;
++  esac
++  shift
++done
++
++if $lt_cl_silent; then
++  exec AS_MESSAGE_FD>/dev/null
++fi
++_LTEOF
++
++cat >>"$CONFIG_LT" <<_LTEOF
++_LT_OUTPUT_LIBTOOL_COMMANDS_INIT
++_LTEOF
++
++cat >>"$CONFIG_LT" <<\_LTEOF
++AC_MSG_NOTICE([creating $ofile])
++_LT_OUTPUT_LIBTOOL_COMMANDS
++AS_EXIT(0)
++_LTEOF
++chmod +x "$CONFIG_LT"
++
++# configure is writing to config.log, but config.lt does its own redirection,
++# appending to config.log, which fails on DOS, as config.log is still kept
++# open by configure.  Here we exec the FD to /dev/null, effectively closing
++# config.log, so it can be properly (re)opened and appended to by config.lt.
++lt_cl_success=:
++test "$silent" = yes &&
++  lt_config_lt_args="$lt_config_lt_args --quiet"
++exec AS_MESSAGE_LOG_FD>/dev/null
++$SHELL "$CONFIG_LT" $lt_config_lt_args || lt_cl_success=false
++exec AS_MESSAGE_LOG_FD>>config.log
++$lt_cl_success || AS_EXIT(1)
++])# LT_OUTPUT
++
++
++# _LT_CONFIG(TAG)
++# ---------------
++# If TAG is the built-in tag, create an initial libtool script with a
++# default configuration from the untagged config vars.  Otherwise add code
++# to config.status for appending the configuration named by TAG from the
++# matching tagged config vars.
++m4_defun([_LT_CONFIG],
++[m4_require([_LT_FILEUTILS_DEFAULTS])dnl
++_LT_CONFIG_SAVE_COMMANDS([
++  m4_define([_LT_TAG], m4_if([$1], [], [C], [$1]))dnl
++  m4_if(_LT_TAG, [C], [
++    # See if we are running on zsh, and set the options which allow our
++    # commands through without removal of \ escapes.
++    if test -n "${ZSH_VERSION+set}" ; then
++      setopt NO_GLOB_SUBST
++    fi
++
++    cfgfile="${ofile}T"
++    trap "$RM \"$cfgfile\"; exit 1" 1 2 15
++    $RM "$cfgfile"
++
++    cat <<_LT_EOF >> "$cfgfile"
++#! $SHELL
++
++# `$ECHO "$ofile" | sed 's%^.*/%%'` - Provide generalized library-building support services.
++# Generated automatically by $as_me ($PACKAGE$TIMESTAMP) $VERSION
++# Libtool was configured on host `(hostname || uname -n) 2>/dev/null | sed 1q`:
++# NOTE: Changes made to this file will be lost: look at ltmain.sh.
++#
++_LT_COPYING
++_LT_LIBTOOL_TAGS
++
++# ### BEGIN LIBTOOL CONFIG
++_LT_LIBTOOL_CONFIG_VARS
++_LT_LIBTOOL_TAG_VARS
++# ### END LIBTOOL CONFIG
++
++_LT_EOF
++
++  case $host_os in
++  aix3*)
++    cat <<\_LT_EOF >> "$cfgfile"
++# AIX sometimes has problems with the GCC collect2 program.  For some
++# reason, if we set the COLLECT_NAMES environment variable, the problems
++# vanish in a puff of smoke.
++if test "X${COLLECT_NAMES+set}" != Xset; then
++  COLLECT_NAMES=
++  export COLLECT_NAMES
++fi
++_LT_EOF
++    ;;
++  esac
++
++  _LT_PROG_LTMAIN
++
++  # We use sed instead of cat because bash on DJGPP gets confused if
++  # if finds mixed CR/LF and LF-only lines.  Since sed operates in
++  # text mode, it properly converts lines to CR/LF.  This bash problem
++  # is reportedly fixed, but why not run on old versions too?
++  sed '$q' "$ltmain" >> "$cfgfile" \
++     || (rm -f "$cfgfile"; exit 1)
++
++  _LT_PROG_REPLACE_SHELLFNS
++
++   mv -f "$cfgfile" "$ofile" ||
++    (rm -f "$ofile" && cp "$cfgfile" "$ofile" && rm -f "$cfgfile")
++  chmod +x "$ofile"
++],
++[cat <<_LT_EOF >> "$ofile"
++
++dnl Unfortunately we have to use $1 here, since _LT_TAG is not expanded
++dnl in a comment (ie after a #).
++# ### BEGIN LIBTOOL TAG CONFIG: $1
++_LT_LIBTOOL_TAG_VARS(_LT_TAG)
++# ### END LIBTOOL TAG CONFIG: $1
++_LT_EOF
++])dnl /m4_if
++],
++[m4_if([$1], [], [
++    PACKAGE='$PACKAGE'
++    VERSION='$VERSION'
++    TIMESTAMP='$TIMESTAMP'
++    RM='$RM'
++    ofile='$ofile'], [])
++])dnl /_LT_CONFIG_SAVE_COMMANDS
++])# _LT_CONFIG
++
++
++# LT_SUPPORTED_TAG(TAG)
++# ---------------------
++# Trace this macro to discover what tags are supported by the libtool
++# --tag option, using:
++#    autoconf --trace 'LT_SUPPORTED_TAG:$1'
++AC_DEFUN([LT_SUPPORTED_TAG], [])
++
++
++# C support is built-in for now
++m4_define([_LT_LANG_C_enabled], [])
++m4_define([_LT_TAGS], [])
++
++
++# LT_LANG(LANG)
++# -------------
++# Enable libtool support for the given language if not already enabled.
++AC_DEFUN([LT_LANG],
++[AC_BEFORE([$0], [LT_OUTPUT])dnl
++m4_case([$1],
++  [C],			[_LT_LANG(C)],
++  [C++],		[_LT_LANG(CXX)],
++  [Go],			[_LT_LANG(GO)],
++  [Java],		[_LT_LANG(GCJ)],
++  [Fortran 77],		[_LT_LANG(F77)],
++  [Fortran],		[_LT_LANG(FC)],
++  [Windows Resource],	[_LT_LANG(RC)],
++  [m4_ifdef([_LT_LANG_]$1[_CONFIG],
++    [_LT_LANG($1)],
++    [m4_fatal([$0: unsupported language: "$1"])])])dnl
++])# LT_LANG
++
++
++# _LT_LANG(LANGNAME)
++# ------------------
++m4_defun([_LT_LANG],
++[m4_ifdef([_LT_LANG_]$1[_enabled], [],
++  [LT_SUPPORTED_TAG([$1])dnl
++  m4_append([_LT_TAGS], [$1 ])dnl
++  m4_define([_LT_LANG_]$1[_enabled], [])dnl
++  _LT_LANG_$1_CONFIG($1)])dnl
++])# _LT_LANG
++
++
++m4_ifndef([AC_PROG_GO], [
++# NOTE: This macro has been submitted for inclusion into   #
++#  GNU Autoconf as AC_PROG_GO.  When it is available in    #
++#  a released version of Autoconf we should remove this    #
++#  macro and use it instead.                               #
++m4_defun([AC_PROG_GO],
++[AC_LANG_PUSH(Go)dnl
++AC_ARG_VAR([GOC],     [Go compiler command])dnl
++AC_ARG_VAR([GOFLAGS], [Go compiler flags])dnl
++_AC_ARG_VAR_LDFLAGS()dnl
++AC_CHECK_TOOL(GOC, gccgo)
++if test -z "$GOC"; then
++  if test -n "$ac_tool_prefix"; then
++    AC_CHECK_PROG(GOC, [${ac_tool_prefix}gccgo], [${ac_tool_prefix}gccgo])
++  fi
++fi
++if test -z "$GOC"; then
++  AC_CHECK_PROG(GOC, gccgo, gccgo, false)
++fi
++])#m4_defun
++])#m4_ifndef
++
++
++# _LT_LANG_DEFAULT_CONFIG
++# -----------------------
++m4_defun([_LT_LANG_DEFAULT_CONFIG],
++[AC_PROVIDE_IFELSE([AC_PROG_CXX],
++  [LT_LANG(CXX)],
++  [m4_define([AC_PROG_CXX], defn([AC_PROG_CXX])[LT_LANG(CXX)])])
++
++AC_PROVIDE_IFELSE([AC_PROG_F77],
++  [LT_LANG(F77)],
++  [m4_define([AC_PROG_F77], defn([AC_PROG_F77])[LT_LANG(F77)])])
++
++AC_PROVIDE_IFELSE([AC_PROG_FC],
++  [LT_LANG(FC)],
++  [m4_define([AC_PROG_FC], defn([AC_PROG_FC])[LT_LANG(FC)])])
++
++dnl The call to [A][M_PROG_GCJ] is quoted like that to stop aclocal
++dnl pulling things in needlessly.
++AC_PROVIDE_IFELSE([AC_PROG_GCJ],
++  [LT_LANG(GCJ)],
++  [AC_PROVIDE_IFELSE([A][M_PROG_GCJ],
++    [LT_LANG(GCJ)],
++    [AC_PROVIDE_IFELSE([LT_PROG_GCJ],
++      [LT_LANG(GCJ)],
++      [m4_ifdef([AC_PROG_GCJ],
++	[m4_define([AC_PROG_GCJ], defn([AC_PROG_GCJ])[LT_LANG(GCJ)])])
++       m4_ifdef([A][M_PROG_GCJ],
++	[m4_define([A][M_PROG_GCJ], defn([A][M_PROG_GCJ])[LT_LANG(GCJ)])])
++       m4_ifdef([LT_PROG_GCJ],
++	[m4_define([LT_PROG_GCJ], defn([LT_PROG_GCJ])[LT_LANG(GCJ)])])])])])
++
++AC_PROVIDE_IFELSE([AC_PROG_GO],
++  [LT_LANG(GO)],
++  [m4_define([AC_PROG_GO], defn([AC_PROG_GO])[LT_LANG(GO)])])
++
++AC_PROVIDE_IFELSE([LT_PROG_RC],
++  [LT_LANG(RC)],
++  [m4_define([LT_PROG_RC], defn([LT_PROG_RC])[LT_LANG(RC)])])
++])# _LT_LANG_DEFAULT_CONFIG
++
++# Obsolete macros:
++AU_DEFUN([AC_LIBTOOL_CXX], [LT_LANG(C++)])
++AU_DEFUN([AC_LIBTOOL_F77], [LT_LANG(Fortran 77)])
++AU_DEFUN([AC_LIBTOOL_FC], [LT_LANG(Fortran)])
++AU_DEFUN([AC_LIBTOOL_GCJ], [LT_LANG(Java)])
++AU_DEFUN([AC_LIBTOOL_RC], [LT_LANG(Windows Resource)])
++dnl aclocal-1.4 backwards compatibility:
++dnl AC_DEFUN([AC_LIBTOOL_CXX], [])
++dnl AC_DEFUN([AC_LIBTOOL_F77], [])
++dnl AC_DEFUN([AC_LIBTOOL_FC], [])
++dnl AC_DEFUN([AC_LIBTOOL_GCJ], [])
++dnl AC_DEFUN([AC_LIBTOOL_RC], [])
++
++
++# _LT_TAG_COMPILER
++# ----------------
++m4_defun([_LT_TAG_COMPILER],
++[AC_REQUIRE([AC_PROG_CC])dnl
++
++_LT_DECL([LTCC], [CC], [1], [A C compiler])dnl
++_LT_DECL([LTCFLAGS], [CFLAGS], [1], [LTCC compiler flags])dnl
++_LT_TAGDECL([CC], [compiler], [1], [A language specific compiler])dnl
++_LT_TAGDECL([with_gcc], [GCC], [0], [Is the compiler the GNU compiler?])dnl
++
++# If no C compiler was specified, use CC.
++LTCC=${LTCC-"$CC"}
++
++# If no C compiler flags were specified, use CFLAGS.
++LTCFLAGS=${LTCFLAGS-"$CFLAGS"}
++
++# Allow CC to be a program name with arguments.
++compiler=$CC
++])# _LT_TAG_COMPILER
++
++
++# _LT_COMPILER_BOILERPLATE
++# ------------------------
++# Check for compiler boilerplate output or warnings with
++# the simple compiler test code.
++m4_defun([_LT_COMPILER_BOILERPLATE],
++[m4_require([_LT_DECL_SED])dnl
++ac_outfile=conftest.$ac_objext
++echo "$lt_simple_compile_test_code" >conftest.$ac_ext
++eval "$ac_compile" 2>&1 >/dev/null | $SED '/^$/d; /^ *+/d' >conftest.err
++_lt_compiler_boilerplate=`cat conftest.err`
++$RM conftest*
++])# _LT_COMPILER_BOILERPLATE
++
++
++# _LT_LINKER_BOILERPLATE
++# ----------------------
++# Check for linker boilerplate output or warnings with
++# the simple link test code.
++m4_defun([_LT_LINKER_BOILERPLATE],
++[m4_require([_LT_DECL_SED])dnl
++ac_outfile=conftest.$ac_objext
++echo "$lt_simple_link_test_code" >conftest.$ac_ext
++eval "$ac_link" 2>&1 >/dev/null | $SED '/^$/d; /^ *+/d' >conftest.err
++_lt_linker_boilerplate=`cat conftest.err`
++$RM -r conftest*
++])# _LT_LINKER_BOILERPLATE
++
++# _LT_REQUIRED_DARWIN_CHECKS
++# -------------------------
++m4_defun_once([_LT_REQUIRED_DARWIN_CHECKS],[
++  case $host_os in
++    rhapsody* | darwin*)
++    AC_CHECK_TOOL([DSYMUTIL], [dsymutil], [:])
++    AC_CHECK_TOOL([NMEDIT], [nmedit], [:])
++    AC_CHECK_TOOL([LIPO], [lipo], [:])
++    AC_CHECK_TOOL([OTOOL], [otool], [:])
++    AC_CHECK_TOOL([OTOOL64], [otool64], [:])
++    _LT_DECL([], [DSYMUTIL], [1],
++      [Tool to manipulate archived DWARF debug symbol files on Mac OS X])
++    _LT_DECL([], [NMEDIT], [1],
++      [Tool to change global to local symbols on Mac OS X])
++    _LT_DECL([], [LIPO], [1],
++      [Tool to manipulate fat objects and archives on Mac OS X])
++    _LT_DECL([], [OTOOL], [1],
++      [ldd/readelf like tool for Mach-O binaries on Mac OS X])
++    _LT_DECL([], [OTOOL64], [1],
++      [ldd/readelf like tool for 64 bit Mach-O binaries on Mac OS X 10.4])
++
++    AC_CACHE_CHECK([for -single_module linker flag],[lt_cv_apple_cc_single_mod],
++      [lt_cv_apple_cc_single_mod=no
++      if test -z "${LT_MULTI_MODULE}"; then
++	# By default we will add the -single_module flag. You can override
++	# by either setting the environment variable LT_MULTI_MODULE
++	# non-empty at configure time, or by adding -multi_module to the
++	# link flags.
++	rm -rf libconftest.dylib*
++	echo "int foo(void){return 1;}" > conftest.c
++	echo "$LTCC $LTCFLAGS $LDFLAGS -o libconftest.dylib \
++-dynamiclib -Wl,-single_module conftest.c" >&AS_MESSAGE_LOG_FD
++	$LTCC $LTCFLAGS $LDFLAGS -o libconftest.dylib \
++	  -dynamiclib -Wl,-single_module conftest.c 2>conftest.err
++        _lt_result=$?
++	# If there is a non-empty error log, and "single_module"
++	# appears in it, assume the flag caused a linker warning
++        if test -s conftest.err && $GREP single_module conftest.err; then
++	  cat conftest.err >&AS_MESSAGE_LOG_FD
++	# Otherwise, if the output was created with a 0 exit code from
++	# the compiler, it worked.
++	elif test -f libconftest.dylib && test $_lt_result -eq 0; then
++	  lt_cv_apple_cc_single_mod=yes
++	else
++	  cat conftest.err >&AS_MESSAGE_LOG_FD
++	fi
++	rm -rf libconftest.dylib*
++	rm -f conftest.*
++      fi])
++
++    AC_CACHE_CHECK([for -exported_symbols_list linker flag],
++      [lt_cv_ld_exported_symbols_list],
++      [lt_cv_ld_exported_symbols_list=no
++      save_LDFLAGS=$LDFLAGS
++      echo "_main" > conftest.sym
++      LDFLAGS="$LDFLAGS -Wl,-exported_symbols_list,conftest.sym"
++      AC_LINK_IFELSE([AC_LANG_PROGRAM([],[])],
++	[lt_cv_ld_exported_symbols_list=yes],
++	[lt_cv_ld_exported_symbols_list=no])
++	LDFLAGS="$save_LDFLAGS"
++    ])
++
++    AC_CACHE_CHECK([for -force_load linker flag],[lt_cv_ld_force_load],
++      [lt_cv_ld_force_load=no
++      cat > conftest.c << _LT_EOF
++int forced_loaded() { return 2;}
++_LT_EOF
++      echo "$LTCC $LTCFLAGS -c -o conftest.o conftest.c" >&AS_MESSAGE_LOG_FD
++      $LTCC $LTCFLAGS -c -o conftest.o conftest.c 2>&AS_MESSAGE_LOG_FD
++      echo "$AR cru libconftest.a conftest.o" >&AS_MESSAGE_LOG_FD
++      $AR cru libconftest.a conftest.o 2>&AS_MESSAGE_LOG_FD
++      echo "$RANLIB libconftest.a" >&AS_MESSAGE_LOG_FD
++      $RANLIB libconftest.a 2>&AS_MESSAGE_LOG_FD
++      cat > conftest.c << _LT_EOF
++int main() { return 0;}
++_LT_EOF
++      echo "$LTCC $LTCFLAGS $LDFLAGS -o conftest conftest.c -Wl,-force_load,./libconftest.a" >&AS_MESSAGE_LOG_FD
++      $LTCC $LTCFLAGS $LDFLAGS -o conftest conftest.c -Wl,-force_load,./libconftest.a 2>conftest.err
++      _lt_result=$?
++      if test -s conftest.err && $GREP force_load conftest.err; then
++	cat conftest.err >&AS_MESSAGE_LOG_FD
++      elif test -f conftest && test $_lt_result -eq 0 && $GREP forced_load conftest >/dev/null 2>&1 ; then
++	lt_cv_ld_force_load=yes
++      else
++	cat conftest.err >&AS_MESSAGE_LOG_FD
++      fi
++        rm -f conftest.err libconftest.a conftest conftest.c
++        rm -rf conftest.dSYM
++    ])
++    case $host_os in
++    rhapsody* | darwin1.[[012]])
++      _lt_dar_allow_undefined='${wl}-undefined ${wl}suppress' ;;
++    darwin1.*)
++      _lt_dar_allow_undefined='${wl}-flat_namespace ${wl}-undefined ${wl}suppress' ;;
++    darwin*) # darwin 5.x on
++      # if running on 10.5 or later, the deployment target defaults
++      # to the OS version, if on x86, and 10.4, the deployment
++      # target defaults to 10.4. Don't you love it?
++      case ${MACOSX_DEPLOYMENT_TARGET-10.0},$host in
++	10.0,*86*-darwin8*|10.0,*-darwin[[91]]*)
++	  _lt_dar_allow_undefined='${wl}-undefined ${wl}dynamic_lookup' ;;
++	10.[[012]]*)
++	  _lt_dar_allow_undefined='${wl}-flat_namespace ${wl}-undefined ${wl}suppress' ;;
++	10.*)
++	  _lt_dar_allow_undefined='${wl}-undefined ${wl}dynamic_lookup' ;;
++      esac
++    ;;
++  esac
++    if test "$lt_cv_apple_cc_single_mod" = "yes"; then
++      _lt_dar_single_mod='$single_module'
++    fi
++    if test "$lt_cv_ld_exported_symbols_list" = "yes"; then
++      _lt_dar_export_syms=' ${wl}-exported_symbols_list,$output_objdir/${libname}-symbols.expsym'
++    else
++      _lt_dar_export_syms='~$NMEDIT -s $output_objdir/${libname}-symbols.expsym ${lib}'
++    fi
++    if test "$DSYMUTIL" != ":" && test "$lt_cv_ld_force_load" = "no"; then
++      _lt_dsymutil='~$DSYMUTIL $lib || :'
++    else
++      _lt_dsymutil=
++    fi
++    ;;
++  esac
++])
++
++
++# _LT_DARWIN_LINKER_FEATURES([TAG])
++# ---------------------------------
++# Checks for linker and compiler features on darwin
++m4_defun([_LT_DARWIN_LINKER_FEATURES],
++[
++  m4_require([_LT_REQUIRED_DARWIN_CHECKS])
++  _LT_TAGVAR(archive_cmds_need_lc, $1)=no
++  _LT_TAGVAR(hardcode_direct, $1)=no
++  _LT_TAGVAR(hardcode_automatic, $1)=yes
++  _LT_TAGVAR(hardcode_shlibpath_var, $1)=unsupported
++  if test "$lt_cv_ld_force_load" = "yes"; then
++    _LT_TAGVAR(whole_archive_flag_spec, $1)='`for conv in $convenience\"\"; do test  -n \"$conv\" && new_convenience=\"$new_convenience ${wl}-force_load,$conv\"; done; func_echo_all \"$new_convenience\"`'
++    m4_case([$1], [F77], [_LT_TAGVAR(compiler_needs_object, $1)=yes],
++                  [FC],  [_LT_TAGVAR(compiler_needs_object, $1)=yes])
++  else
++    _LT_TAGVAR(whole_archive_flag_spec, $1)=''
++  fi
++  _LT_TAGVAR(link_all_deplibs, $1)=yes
++  _LT_TAGVAR(allow_undefined_flag, $1)="$_lt_dar_allow_undefined"
++  case $cc_basename in
++     ifort*) _lt_dar_can_shared=yes ;;
++     *) _lt_dar_can_shared=$GCC ;;
++  esac
++  if test "$_lt_dar_can_shared" = "yes"; then
++    output_verbose_link_cmd=func_echo_all
++    _LT_TAGVAR(archive_cmds, $1)="\$CC -dynamiclib \$allow_undefined_flag -o \$lib \$libobjs \$deplibs \$compiler_flags -install_name \$rpath/\$soname \$verstring $_lt_dar_single_mod${_lt_dsymutil}"
++    _LT_TAGVAR(module_cmds, $1)="\$CC \$allow_undefined_flag -o \$lib -bundle \$libobjs \$deplibs \$compiler_flags${_lt_dsymutil}"
++    _LT_TAGVAR(archive_expsym_cmds, $1)="sed 's,^,_,' < \$export_symbols > \$output_objdir/\${libname}-symbols.expsym~\$CC -dynamiclib \$allow_undefined_flag -o \$lib \$libobjs \$deplibs \$compiler_flags -install_name \$rpath/\$soname \$verstring ${_lt_dar_single_mod}${_lt_dar_export_syms}${_lt_dsymutil}"
++    _LT_TAGVAR(module_expsym_cmds, $1)="sed -e 's,^,_,' < \$export_symbols > \$output_objdir/\${libname}-symbols.expsym~\$CC \$allow_undefined_flag -o \$lib -bundle \$libobjs \$deplibs \$compiler_flags${_lt_dar_export_syms}${_lt_dsymutil}"
++    m4_if([$1], [CXX],
++[   if test "$lt_cv_apple_cc_single_mod" != "yes"; then
++      _LT_TAGVAR(archive_cmds, $1)="\$CC -r -keep_private_externs -nostdlib -o \${lib}-master.o \$libobjs~\$CC -dynamiclib \$allow_undefined_flag -o \$lib \${lib}-master.o \$deplibs \$compiler_flags -install_name \$rpath/\$soname \$verstring${_lt_dsymutil}"
++      _LT_TAGVAR(archive_expsym_cmds, $1)="sed 's,^,_,' < \$export_symbols > \$output_objdir/\${libname}-symbols.expsym~\$CC -r -keep_private_externs -nostdlib -o \${lib}-master.o \$libobjs~\$CC -dynamiclib \$allow_undefined_flag -o \$lib \${lib}-master.o \$deplibs \$compiler_flags -install_name \$rpath/\$soname \$verstring${_lt_dar_export_syms}${_lt_dsymutil}"
++    fi
++],[])
++  else
++  _LT_TAGVAR(ld_shlibs, $1)=no
++  fi
++])
++
++# _LT_SYS_MODULE_PATH_AIX([TAGNAME])
++# ----------------------------------
++# Links a minimal program and checks the executable
++# for the system default hardcoded library path. In most cases,
++# this is /usr/lib:/lib, but when the MPI compilers are used
++# the location of the communication and MPI libs are included too.
++# If we don't find anything, use the default library path according
++# to the aix ld manual.
++# Store the results from the different compilers for each TAGNAME.
++# Allow to override them for all tags through lt_cv_aix_libpath.
++m4_defun([_LT_SYS_MODULE_PATH_AIX],
++[m4_require([_LT_DECL_SED])dnl
++if test "${lt_cv_aix_libpath+set}" = set; then
++  aix_libpath=$lt_cv_aix_libpath
++else
++  AC_CACHE_VAL([_LT_TAGVAR([lt_cv_aix_libpath_], [$1])],
++  [AC_LINK_IFELSE([AC_LANG_PROGRAM],[
++  lt_aix_libpath_sed='[
++      /Import File Strings/,/^$/ {
++	  /^0/ {
++	      s/^0  *\([^ ]*\) *$/\1/
++	      p
++	  }
++      }]'
++  _LT_TAGVAR([lt_cv_aix_libpath_], [$1])=`dump -H conftest$ac_exeext 2>/dev/null | $SED -n -e "$lt_aix_libpath_sed"`
++  # Check for a 64-bit object if we didn't find anything.
++  if test -z "$_LT_TAGVAR([lt_cv_aix_libpath_], [$1])"; then
++    _LT_TAGVAR([lt_cv_aix_libpath_], [$1])=`dump -HX64 conftest$ac_exeext 2>/dev/null | $SED -n -e "$lt_aix_libpath_sed"`
++  fi],[])
++  if test -z "$_LT_TAGVAR([lt_cv_aix_libpath_], [$1])"; then
++    _LT_TAGVAR([lt_cv_aix_libpath_], [$1])="/usr/lib:/lib"
++  fi
++  ])
++  aix_libpath=$_LT_TAGVAR([lt_cv_aix_libpath_], [$1])
++fi
++])# _LT_SYS_MODULE_PATH_AIX
++
++
++# _LT_SHELL_INIT(ARG)
++# -------------------
++m4_define([_LT_SHELL_INIT],
++[m4_divert_text([M4SH-INIT], [$1
++])])# _LT_SHELL_INIT
++
++
++
++# _LT_PROG_ECHO_BACKSLASH
++# -----------------------
++# Find how we can fake an echo command that does not interpret backslash.
++# In particular, with Autoconf 2.60 or later we add some code to the start
++# of the generated configure script which will find a shell with a builtin
++# printf (which we can use as an echo command).
++m4_defun([_LT_PROG_ECHO_BACKSLASH],
++[ECHO='\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\'
++ECHO=$ECHO$ECHO$ECHO$ECHO$ECHO
++ECHO=$ECHO$ECHO$ECHO$ECHO$ECHO$ECHO
++
++AC_MSG_CHECKING([how to print strings])
++# Test print first, because it will be a builtin if present.
++if test "X`( print -r -- -n ) 2>/dev/null`" = X-n && \
++   test "X`print -r -- $ECHO 2>/dev/null`" = "X$ECHO"; then
++  ECHO='print -r --'
++elif test "X`printf %s $ECHO 2>/dev/null`" = "X$ECHO"; then
++  ECHO='printf %s\n'
++else
++  # Use this function as a fallback that always works.
++  func_fallback_echo ()
++  {
++    eval 'cat <<_LTECHO_EOF
++$[]1
++_LTECHO_EOF'
++  }
++  ECHO='func_fallback_echo'
++fi
++
++# func_echo_all arg...
++# Invoke $ECHO with all args, space-separated.
++func_echo_all ()
++{
++    $ECHO "$*" 
++}
++
++case "$ECHO" in
++  printf*) AC_MSG_RESULT([printf]) ;;
++  print*) AC_MSG_RESULT([print -r]) ;;
++  *) AC_MSG_RESULT([cat]) ;;
++esac
++
++m4_ifdef([_AS_DETECT_SUGGESTED],
++[_AS_DETECT_SUGGESTED([
++  test -n "${ZSH_VERSION+set}${BASH_VERSION+set}" || (
++    ECHO='\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\'
++    ECHO=$ECHO$ECHO$ECHO$ECHO$ECHO
++    ECHO=$ECHO$ECHO$ECHO$ECHO$ECHO$ECHO
++    PATH=/empty FPATH=/empty; export PATH FPATH
++    test "X`printf %s $ECHO`" = "X$ECHO" \
++      || test "X`print -r -- $ECHO`" = "X$ECHO" )])])
++
++_LT_DECL([], [SHELL], [1], [Shell to use when invoking shell scripts])
++_LT_DECL([], [ECHO], [1], [An echo program that protects backslashes])
++])# _LT_PROG_ECHO_BACKSLASH
++
++
++# _LT_WITH_SYSROOT
++# ----------------
++AC_DEFUN([_LT_WITH_SYSROOT],
++[AC_MSG_CHECKING([for sysroot])
++AC_ARG_WITH([sysroot],
++[  --with-sysroot[=DIR] Search for dependent libraries within DIR
++                        (or the compiler's sysroot if not specified).],
++[], [with_sysroot=no])
++
++dnl lt_sysroot will always be passed unquoted.  We quote it here
++dnl in case the user passed a directory name.
++lt_sysroot=
++case ${with_sysroot} in #(
++ yes)
++   if test "$GCC" = yes; then
++     lt_sysroot=`$CC --print-sysroot 2>/dev/null`
++   fi
++   ;; #(
++ /*)
++   lt_sysroot=`echo "$with_sysroot" | sed -e "$sed_quote_subst"`
++   ;; #(
++ no|'')
++   ;; #(
++ *)
++   AC_MSG_RESULT([${with_sysroot}])
++   AC_MSG_ERROR([The sysroot must be an absolute path.])
++   ;;
++esac
++
++ AC_MSG_RESULT([${lt_sysroot:-no}])
++_LT_DECL([], [lt_sysroot], [0], [The root where to search for ]dnl
++[dependent libraries, and in which our libraries should be installed.])])
++
++# _LT_ENABLE_LOCK
++# ---------------
++m4_defun([_LT_ENABLE_LOCK],
++[AC_ARG_ENABLE([libtool-lock],
++  [AS_HELP_STRING([--disable-libtool-lock],
++    [avoid locking (might break parallel builds)])])
++test "x$enable_libtool_lock" != xno && enable_libtool_lock=yes
++
++# Some flags need to be propagated to the compiler or linker for good
++# libtool support.
++case $host in
++ia64-*-hpux*)
++  # Find out which ABI we are using.
++  echo 'int i;' > conftest.$ac_ext
++  if AC_TRY_EVAL(ac_compile); then
++    case `/usr/bin/file conftest.$ac_objext` in
++      *ELF-32*)
++	HPUX_IA64_MODE="32"
++	;;
++      *ELF-64*)
++	HPUX_IA64_MODE="64"
++	;;
++    esac
++  fi
++  rm -rf conftest*
++  ;;
++*-*-irix6*)
++  # Find out which ABI we are using.
++  echo '[#]line '$LINENO' "configure"' > conftest.$ac_ext
++  if AC_TRY_EVAL(ac_compile); then
++    if test "$lt_cv_prog_gnu_ld" = yes; then
++      case `/usr/bin/file conftest.$ac_objext` in
++	*32-bit*)
++	  LD="${LD-ld} -melf32bsmip"
++	  ;;
++	*N32*)
++	  LD="${LD-ld} -melf32bmipn32"
++	  ;;
++	*64-bit*)
++	  LD="${LD-ld} -melf64bmip"
++	;;
++      esac
++    else
++      case `/usr/bin/file conftest.$ac_objext` in
++	*32-bit*)
++	  LD="${LD-ld} -32"
++	  ;;
++	*N32*)
++	  LD="${LD-ld} -n32"
++	  ;;
++	*64-bit*)
++	  LD="${LD-ld} -64"
++	  ;;
++      esac
++    fi
++  fi
++  rm -rf conftest*
++  ;;
++
++x86_64-*kfreebsd*-gnu|x86_64-*linux*|powerpc*-*linux*| \
++s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
++  # Find out which ABI we are using.
++  echo 'int i;' > conftest.$ac_ext
++  if AC_TRY_EVAL(ac_compile); then
++    case `/usr/bin/file conftest.o` in
++      *32-bit*)
++	case $host in
++	  x86_64-*kfreebsd*-gnu)
++	    LD="${LD-ld} -m elf_i386_fbsd"
++	    ;;
++	  x86_64-*linux*)
++	    case `/usr/bin/file conftest.o` in
++	      *x86-64*)
++		LD="${LD-ld} -m elf32_x86_64"
++		;;
++	      *)
++		LD="${LD-ld} -m elf_i386"
++		;;
++	    esac
++	    ;;
++	  powerpc64le-*)
++	    LD="${LD-ld} -m elf32lppclinux"
++	    ;;
++	  powerpc64-*)
++	    LD="${LD-ld} -m elf32ppclinux"
++	    ;;
++	  s390x-*linux*)
++	    LD="${LD-ld} -m elf_s390"
++	    ;;
++	  sparc64-*linux*)
++	    LD="${LD-ld} -m elf32_sparc"
++	    ;;
++	esac
++	;;
++      *64-bit*)
++	case $host in
++	  x86_64-*kfreebsd*-gnu)
++	    LD="${LD-ld} -m elf_x86_64_fbsd"
++	    ;;
++	  x86_64-*linux*)
++	    LD="${LD-ld} -m elf_x86_64"
++	    ;;
++	  powerpcle-*)
++	    LD="${LD-ld} -m elf64lppc"
++	    ;;
++	  powerpc-*)
++	    LD="${LD-ld} -m elf64ppc"
++	    ;;
++	  s390*-*linux*|s390*-*tpf*)
++	    LD="${LD-ld} -m elf64_s390"
++	    ;;
++	  sparc*-*linux*)
++	    LD="${LD-ld} -m elf64_sparc"
++	    ;;
++	esac
++	;;
++    esac
++  fi
++  rm -rf conftest*
++  ;;
++
++*-*-sco3.2v5*)
++  # On SCO OpenServer 5, we need -belf to get full-featured binaries.
++  SAVE_CFLAGS="$CFLAGS"
++  CFLAGS="$CFLAGS -belf"
++  AC_CACHE_CHECK([whether the C compiler needs -belf], lt_cv_cc_needs_belf,
++    [AC_LANG_PUSH(C)
++     AC_LINK_IFELSE([AC_LANG_PROGRAM([[]],[[]])],[lt_cv_cc_needs_belf=yes],[lt_cv_cc_needs_belf=no])
++     AC_LANG_POP])
++  if test x"$lt_cv_cc_needs_belf" != x"yes"; then
++    # this is probably gcc 2.8.0, egcs 1.0 or newer; no need for -belf
++    CFLAGS="$SAVE_CFLAGS"
++  fi
++  ;;
++*-*solaris*)
++  # Find out which ABI we are using.
++  echo 'int i;' > conftest.$ac_ext
++  if AC_TRY_EVAL(ac_compile); then
++    case `/usr/bin/file conftest.o` in
++    *64-bit*)
++      case $lt_cv_prog_gnu_ld in
++      yes*)
++        case $host in
++        i?86-*-solaris*)
++          LD="${LD-ld} -m elf_x86_64"
++          ;;
++        sparc*-*-solaris*)
++          LD="${LD-ld} -m elf64_sparc"
++          ;;
++        esac
++        # GNU ld 2.21 introduced _sol2 emulations.  Use them if available.
++        if ${LD-ld} -V | grep _sol2 >/dev/null 2>&1; then
++          LD="${LD-ld}_sol2"
++        fi
++        ;;
++      *)
++	if ${LD-ld} -64 -r -o conftest2.o conftest.o >/dev/null 2>&1; then
++	  LD="${LD-ld} -64"
++	fi
++	;;
++      esac
++      ;;
++    esac
++  fi
++  rm -rf conftest*
++  ;;
++esac
++
++need_locks="$enable_libtool_lock"
++])# _LT_ENABLE_LOCK
++
++
++# _LT_PROG_AR
++# -----------
++m4_defun([_LT_PROG_AR],
++[AC_CHECK_TOOLS(AR, [ar], false)
++: ${AR=ar}
++: ${AR_FLAGS=cru}
++_LT_DECL([], [AR], [1], [The archiver])
++_LT_DECL([], [AR_FLAGS], [1], [Flags to create an archive])
++
++AC_CACHE_CHECK([for archiver @FILE support], [lt_cv_ar_at_file],
++  [lt_cv_ar_at_file=no
++   AC_COMPILE_IFELSE([AC_LANG_PROGRAM],
++     [echo conftest.$ac_objext > conftest.lst
++      lt_ar_try='$AR $AR_FLAGS libconftest.a @conftest.lst >&AS_MESSAGE_LOG_FD'
++      AC_TRY_EVAL([lt_ar_try])
++      if test "$ac_status" -eq 0; then
++	# Ensure the archiver fails upon bogus file names.
++	rm -f conftest.$ac_objext libconftest.a
++	AC_TRY_EVAL([lt_ar_try])
++	if test "$ac_status" -ne 0; then
++          lt_cv_ar_at_file=@
++        fi
++      fi
++      rm -f conftest.* libconftest.a
++     ])
++  ])
++
++if test "x$lt_cv_ar_at_file" = xno; then
++  archiver_list_spec=
++else
++  archiver_list_spec=$lt_cv_ar_at_file
++fi
++_LT_DECL([], [archiver_list_spec], [1],
++  [How to feed a file listing to the archiver])
++])# _LT_PROG_AR
++
++
++# _LT_CMD_OLD_ARCHIVE
++# -------------------
++m4_defun([_LT_CMD_OLD_ARCHIVE],
++[_LT_PROG_AR
++
++AC_CHECK_TOOL(STRIP, strip, :)
++test -z "$STRIP" && STRIP=:
++_LT_DECL([], [STRIP], [1], [A symbol stripping program])
++
++AC_CHECK_TOOL(RANLIB, ranlib, :)
++test -z "$RANLIB" && RANLIB=:
++_LT_DECL([], [RANLIB], [1],
++    [Commands used to install an old-style archive])
++
++# Determine commands to create old-style static archives.
++old_archive_cmds='$AR $AR_FLAGS $oldlib$oldobjs'
++old_postinstall_cmds='chmod 644 $oldlib'
++old_postuninstall_cmds=
++
++if test -n "$RANLIB"; then
++  case $host_os in
++  openbsd*)
++    old_postinstall_cmds="$old_postinstall_cmds~\$RANLIB -t \$tool_oldlib"
++    ;;
++  *)
++    old_postinstall_cmds="$old_postinstall_cmds~\$RANLIB \$tool_oldlib"
++    ;;
++  esac
++  old_archive_cmds="$old_archive_cmds~\$RANLIB \$tool_oldlib"
++fi
++
++case $host_os in
++  darwin*)
++    lock_old_archive_extraction=yes ;;
++  *)
++    lock_old_archive_extraction=no ;;
++esac
++_LT_DECL([], [old_postinstall_cmds], [2])
++_LT_DECL([], [old_postuninstall_cmds], [2])
++_LT_TAGDECL([], [old_archive_cmds], [2],
++    [Commands used to build an old-style archive])
++_LT_DECL([], [lock_old_archive_extraction], [0],
++    [Whether to use a lock for old archive extraction])
++])# _LT_CMD_OLD_ARCHIVE
++
++
++# _LT_COMPILER_OPTION(MESSAGE, VARIABLE-NAME, FLAGS,
++#		[OUTPUT-FILE], [ACTION-SUCCESS], [ACTION-FAILURE])
++# ----------------------------------------------------------------
++# Check whether the given compiler option works
++AC_DEFUN([_LT_COMPILER_OPTION],
++[m4_require([_LT_FILEUTILS_DEFAULTS])dnl
++m4_require([_LT_DECL_SED])dnl
++AC_CACHE_CHECK([$1], [$2],
++  [$2=no
++   m4_if([$4], , [ac_outfile=conftest.$ac_objext], [ac_outfile=$4])
++   echo "$lt_simple_compile_test_code" > conftest.$ac_ext
++   lt_compiler_flag="$3"
++   # Insert the option either (1) after the last *FLAGS variable, or
++   # (2) before a word containing "conftest.", or (3) at the end.
++   # Note that $ac_compile itself does not contain backslashes and begins
++   # with a dollar sign (not a hyphen), so the echo should work correctly.
++   # The option is referenced via a variable to avoid confusing sed.
++   lt_compile=`echo "$ac_compile" | $SED \
++   -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
++   -e 's: [[^ ]]*conftest\.: $lt_compiler_flag&:; t' \
++   -e 's:$: $lt_compiler_flag:'`
++   (eval echo "\"\$as_me:$LINENO: $lt_compile\"" >&AS_MESSAGE_LOG_FD)
++   (eval "$lt_compile" 2>conftest.err)
++   ac_status=$?
++   cat conftest.err >&AS_MESSAGE_LOG_FD
++   echo "$as_me:$LINENO: \$? = $ac_status" >&AS_MESSAGE_LOG_FD
++   if (exit $ac_status) && test -s "$ac_outfile"; then
++     # The compiler can only warn and ignore the option if not recognized
++     # So say no if there are warnings other than the usual output.
++     $ECHO "$_lt_compiler_boilerplate" | $SED '/^$/d' >conftest.exp
++     $SED '/^$/d; /^ *+/d' conftest.err >conftest.er2
++     if test ! -s conftest.er2 || diff conftest.exp conftest.er2 >/dev/null; then
++       $2=yes
++     fi
++   fi
++   $RM conftest*
++])
++
++if test x"[$]$2" = xyes; then
++    m4_if([$5], , :, [$5])
++else
++    m4_if([$6], , :, [$6])
++fi
++])# _LT_COMPILER_OPTION
++
++# Old name:
++AU_ALIAS([AC_LIBTOOL_COMPILER_OPTION], [_LT_COMPILER_OPTION])
++dnl aclocal-1.4 backwards compatibility:
++dnl AC_DEFUN([AC_LIBTOOL_COMPILER_OPTION], [])
++
++
++# _LT_LINKER_OPTION(MESSAGE, VARIABLE-NAME, FLAGS,
++#                  [ACTION-SUCCESS], [ACTION-FAILURE])
++# ----------------------------------------------------
++# Check whether the given linker option works
++AC_DEFUN([_LT_LINKER_OPTION],
++[m4_require([_LT_FILEUTILS_DEFAULTS])dnl
++m4_require([_LT_DECL_SED])dnl
++AC_CACHE_CHECK([$1], [$2],
++  [$2=no
++   save_LDFLAGS="$LDFLAGS"
++   LDFLAGS="$LDFLAGS $3"
++   echo "$lt_simple_link_test_code" > conftest.$ac_ext
++   if (eval $ac_link 2>conftest.err) && test -s conftest$ac_exeext; then
++     # The linker can only warn and ignore the option if not recognized
++     # So say no if there are warnings
++     if test -s conftest.err; then
++       # Append any errors to the config.log.
++       cat conftest.err 1>&AS_MESSAGE_LOG_FD
++       $ECHO "$_lt_linker_boilerplate" | $SED '/^$/d' > conftest.exp
++       $SED '/^$/d; /^ *+/d' conftest.err >conftest.er2
++       if diff conftest.exp conftest.er2 >/dev/null; then
++         $2=yes
++       fi
++     else
++       $2=yes
++     fi
++   fi
++   $RM -r conftest*
++   LDFLAGS="$save_LDFLAGS"
++])
++
++if test x"[$]$2" = xyes; then
++    m4_if([$4], , :, [$4])
++else
++    m4_if([$5], , :, [$5])
++fi
++])# _LT_LINKER_OPTION
++
++# Old name:
++AU_ALIAS([AC_LIBTOOL_LINKER_OPTION], [_LT_LINKER_OPTION])
++dnl aclocal-1.4 backwards compatibility:
++dnl AC_DEFUN([AC_LIBTOOL_LINKER_OPTION], [])
++
++
++# LT_CMD_MAX_LEN
++#---------------
++AC_DEFUN([LT_CMD_MAX_LEN],
++[AC_REQUIRE([AC_CANONICAL_HOST])dnl
++# find the maximum length of command line arguments
++AC_MSG_CHECKING([the maximum length of command line arguments])
++AC_CACHE_VAL([lt_cv_sys_max_cmd_len], [dnl
++  i=0
++  teststring="ABCD"
++
++  case $build_os in
++  msdosdjgpp*)
++    # On DJGPP, this test can blow up pretty badly due to problems in libc
++    # (any single argument exceeding 2000 bytes causes a buffer overrun
++    # during glob expansion).  Even if it were fixed, the result of this
++    # check would be larger than it should be.
++    lt_cv_sys_max_cmd_len=12288;    # 12K is about right
++    ;;
++
++  gnu*)
++    # Under GNU Hurd, this test is not required because there is
++    # no limit to the length of command line arguments.
++    # Libtool will interpret -1 as no limit whatsoever
++    lt_cv_sys_max_cmd_len=-1;
++    ;;
++
++  cygwin* | mingw* | cegcc*)
++    # On Win9x/ME, this test blows up -- it succeeds, but takes
++    # about 5 minutes as the teststring grows exponentially.
++    # Worse, since 9x/ME are not pre-emptively multitasking,
++    # you end up with a "frozen" computer, even though with patience
++    # the test eventually succeeds (with a max line length of 256k).
++    # Instead, let's just punt: use the minimum linelength reported by
++    # all of the supported platforms: 8192 (on NT/2K/XP).
++    lt_cv_sys_max_cmd_len=8192;
++    ;;
++
++  mint*)
++    # On MiNT this can take a long time and run out of memory.
++    lt_cv_sys_max_cmd_len=8192;
++    ;;
++
++  amigaos*)
++    # On AmigaOS with pdksh, this test takes hours, literally.
++    # So we just punt and use a minimum line length of 8192.
++    lt_cv_sys_max_cmd_len=8192;
++    ;;
++
++  netbsd* | freebsd* | openbsd* | darwin* | dragonfly*)
++    # This has been around since 386BSD, at least.  Likely further.
++    if test -x /sbin/sysctl; then
++      lt_cv_sys_max_cmd_len=`/sbin/sysctl -n kern.argmax`
++    elif test -x /usr/sbin/sysctl; then
++      lt_cv_sys_max_cmd_len=`/usr/sbin/sysctl -n kern.argmax`
++    else
++      lt_cv_sys_max_cmd_len=65536	# usable default for all BSDs
++    fi
++    # And add a safety zone
++    lt_cv_sys_max_cmd_len=`expr $lt_cv_sys_max_cmd_len \/ 4`
++    lt_cv_sys_max_cmd_len=`expr $lt_cv_sys_max_cmd_len \* 3`
++    ;;
++
++  interix*)
++    # We know the value 262144 and hardcode it with a safety zone (like BSD)
++    lt_cv_sys_max_cmd_len=196608
++    ;;
++
++  os2*)
++    # The test takes a long time on OS/2.
++    lt_cv_sys_max_cmd_len=8192
++    ;;
++
++  osf*)
++    # Dr. Hans Ekkehard Plesser reports seeing a kernel panic running configure
++    # due to this test when exec_disable_arg_limit is 1 on Tru64. It is not
++    # nice to cause kernel panics so lets avoid the loop below.
++    # First set a reasonable default.
++    lt_cv_sys_max_cmd_len=16384
++    #
++    if test -x /sbin/sysconfig; then
++      case `/sbin/sysconfig -q proc exec_disable_arg_limit` in
++        *1*) lt_cv_sys_max_cmd_len=-1 ;;
++      esac
++    fi
++    ;;
++  sco3.2v5*)
++    lt_cv_sys_max_cmd_len=102400
++    ;;
++  sysv5* | sco5v6* | sysv4.2uw2*)
++    kargmax=`grep ARG_MAX /etc/conf/cf.d/stune 2>/dev/null`
++    if test -n "$kargmax"; then
++      lt_cv_sys_max_cmd_len=`echo $kargmax | sed 's/.*[[	 ]]//'`
++    else
++      lt_cv_sys_max_cmd_len=32768
++    fi
++    ;;
++  *)
++    lt_cv_sys_max_cmd_len=`(getconf ARG_MAX) 2> /dev/null`
++    if test -n "$lt_cv_sys_max_cmd_len" && \
++	test undefined != "$lt_cv_sys_max_cmd_len"; then
++      lt_cv_sys_max_cmd_len=`expr $lt_cv_sys_max_cmd_len \/ 4`
++      lt_cv_sys_max_cmd_len=`expr $lt_cv_sys_max_cmd_len \* 3`
++    else
++      # Make teststring a little bigger before we do anything with it.
++      # a 1K string should be a reasonable start.
++      for i in 1 2 3 4 5 6 7 8 ; do
++        teststring=$teststring$teststring
++      done
++      SHELL=${SHELL-${CONFIG_SHELL-/bin/sh}}
++      # If test is not a shell built-in, we'll probably end up computing a
++      # maximum length that is only half of the actual maximum length, but
++      # we can't tell.
++      while { test "X"`env echo "$teststring$teststring" 2>/dev/null` \
++	         = "X$teststring$teststring"; } >/dev/null 2>&1 &&
++	      test $i != 17 # 1/2 MB should be enough
++      do
++        i=`expr $i + 1`
++        teststring=$teststring$teststring
++      done
++      # Only check the string length outside the loop.
++      lt_cv_sys_max_cmd_len=`expr "X$teststring" : ".*" 2>&1`
++      teststring=
++      # Add a significant safety factor because C++ compilers can tack on
++      # massive amounts of additional arguments before passing them to the
++      # linker.  It appears as though 1/2 is a usable value.
++      lt_cv_sys_max_cmd_len=`expr $lt_cv_sys_max_cmd_len \/ 2`
++    fi
++    ;;
++  esac
++])
++if test -n $lt_cv_sys_max_cmd_len ; then
++  AC_MSG_RESULT($lt_cv_sys_max_cmd_len)
++else
++  AC_MSG_RESULT(none)
++fi
++max_cmd_len=$lt_cv_sys_max_cmd_len
++_LT_DECL([], [max_cmd_len], [0],
++    [What is the maximum length of a command?])
++])# LT_CMD_MAX_LEN
++
++# Old name:
++AU_ALIAS([AC_LIBTOOL_SYS_MAX_CMD_LEN], [LT_CMD_MAX_LEN])
++dnl aclocal-1.4 backwards compatibility:
++dnl AC_DEFUN([AC_LIBTOOL_SYS_MAX_CMD_LEN], [])
++
++
++# _LT_HEADER_DLFCN
++# ----------------
++m4_defun([_LT_HEADER_DLFCN],
++[AC_CHECK_HEADERS([dlfcn.h], [], [], [AC_INCLUDES_DEFAULT])dnl
++])# _LT_HEADER_DLFCN
++
++
++# _LT_TRY_DLOPEN_SELF (ACTION-IF-TRUE, ACTION-IF-TRUE-W-USCORE,
++#                      ACTION-IF-FALSE, ACTION-IF-CROSS-COMPILING)
++# ----------------------------------------------------------------
++m4_defun([_LT_TRY_DLOPEN_SELF],
++[m4_require([_LT_HEADER_DLFCN])dnl
++if test "$cross_compiling" = yes; then :
++  [$4]
++else
++  lt_dlunknown=0; lt_dlno_uscore=1; lt_dlneed_uscore=2
++  lt_status=$lt_dlunknown
++  cat > conftest.$ac_ext <<_LT_EOF
++[#line $LINENO "configure"
++#include "confdefs.h"
++
++#if HAVE_DLFCN_H
++#include <dlfcn.h>
++#endif
++
++#include <stdio.h>
++
++#ifdef RTLD_GLOBAL
++#  define LT_DLGLOBAL		RTLD_GLOBAL
++#else
++#  ifdef DL_GLOBAL
++#    define LT_DLGLOBAL		DL_GLOBAL
++#  else
++#    define LT_DLGLOBAL		0
++#  endif
++#endif
++
++/* We may have to define LT_DLLAZY_OR_NOW in the command line if we
++   find out it does not work in some platform. */
++#ifndef LT_DLLAZY_OR_NOW
++#  ifdef RTLD_LAZY
++#    define LT_DLLAZY_OR_NOW		RTLD_LAZY
++#  else
++#    ifdef DL_LAZY
++#      define LT_DLLAZY_OR_NOW		DL_LAZY
++#    else
++#      ifdef RTLD_NOW
++#        define LT_DLLAZY_OR_NOW	RTLD_NOW
++#      else
++#        ifdef DL_NOW
++#          define LT_DLLAZY_OR_NOW	DL_NOW
++#        else
++#          define LT_DLLAZY_OR_NOW	0
++#        endif
++#      endif
++#    endif
++#  endif
++#endif
++
++/* When -fvisbility=hidden is used, assume the code has been annotated
++   correspondingly for the symbols needed.  */
++#if defined(__GNUC__) && (((__GNUC__ == 3) && (__GNUC_MINOR__ >= 3)) || (__GNUC__ > 3))
++int fnord () __attribute__((visibility("default")));
++#endif
++
++int fnord () { return 42; }
++int main ()
++{
++  void *self = dlopen (0, LT_DLGLOBAL|LT_DLLAZY_OR_NOW);
++  int status = $lt_dlunknown;
++
++  if (self)
++    {
++      if (dlsym (self,"fnord"))       status = $lt_dlno_uscore;
++      else
++        {
++	  if (dlsym( self,"_fnord"))  status = $lt_dlneed_uscore;
++          else puts (dlerror ());
++	}
++      /* dlclose (self); */
++    }
++  else
++    puts (dlerror ());
++
++  return status;
++}]
++_LT_EOF
++  if AC_TRY_EVAL(ac_link) && test -s conftest${ac_exeext} 2>/dev/null; then
++    (./conftest; exit; ) >&AS_MESSAGE_LOG_FD 2>/dev/null
++    lt_status=$?
++    case x$lt_status in
++      x$lt_dlno_uscore) $1 ;;
++      x$lt_dlneed_uscore) $2 ;;
++      x$lt_dlunknown|x*) $3 ;;
++    esac
++  else :
++    # compilation failed
++    $3
++  fi
++fi
++rm -fr conftest*
++])# _LT_TRY_DLOPEN_SELF
++
++
++# LT_SYS_DLOPEN_SELF
++# ------------------
++AC_DEFUN([LT_SYS_DLOPEN_SELF],
++[m4_require([_LT_HEADER_DLFCN])dnl
++if test "x$enable_dlopen" != xyes; then
++  enable_dlopen=unknown
++  enable_dlopen_self=unknown
++  enable_dlopen_self_static=unknown
++else
++  lt_cv_dlopen=no
++  lt_cv_dlopen_libs=
++
++  case $host_os in
++  beos*)
++    lt_cv_dlopen="load_add_on"
++    lt_cv_dlopen_libs=
++    lt_cv_dlopen_self=yes
++    ;;
++
++  mingw* | pw32* | cegcc*)
++    lt_cv_dlopen="LoadLibrary"
++    lt_cv_dlopen_libs=
++    ;;
++
++  cygwin*)
++    lt_cv_dlopen="dlopen"
++    lt_cv_dlopen_libs=
++    ;;
++
++  darwin*)
++  # if libdl is installed we need to link against it
++    AC_CHECK_LIB([dl], [dlopen],
++		[lt_cv_dlopen="dlopen" lt_cv_dlopen_libs="-ldl"],[
++    lt_cv_dlopen="dyld"
++    lt_cv_dlopen_libs=
++    lt_cv_dlopen_self=yes
++    ])
++    ;;
++
++  *)
++    AC_CHECK_FUNC([shl_load],
++	  [lt_cv_dlopen="shl_load"],
++      [AC_CHECK_LIB([dld], [shl_load],
++	    [lt_cv_dlopen="shl_load" lt_cv_dlopen_libs="-ldld"],
++	[AC_CHECK_FUNC([dlopen],
++	      [lt_cv_dlopen="dlopen"],
++	  [AC_CHECK_LIB([dl], [dlopen],
++		[lt_cv_dlopen="dlopen" lt_cv_dlopen_libs="-ldl"],
++	    [AC_CHECK_LIB([svld], [dlopen],
++		  [lt_cv_dlopen="dlopen" lt_cv_dlopen_libs="-lsvld"],
++	      [AC_CHECK_LIB([dld], [dld_link],
++		    [lt_cv_dlopen="dld_link" lt_cv_dlopen_libs="-ldld"])
++	      ])
++	    ])
++	  ])
++	])
++      ])
++    ;;
++  esac
++
++  if test "x$lt_cv_dlopen" != xno; then
++    enable_dlopen=yes
++  else
++    enable_dlopen=no
++  fi
++
++  case $lt_cv_dlopen in
++  dlopen)
++    save_CPPFLAGS="$CPPFLAGS"
++    test "x$ac_cv_header_dlfcn_h" = xyes && CPPFLAGS="$CPPFLAGS -DHAVE_DLFCN_H"
++
++    save_LDFLAGS="$LDFLAGS"
++    wl=$lt_prog_compiler_wl eval LDFLAGS=\"\$LDFLAGS $export_dynamic_flag_spec\"
++
++    save_LIBS="$LIBS"
++    LIBS="$lt_cv_dlopen_libs $LIBS"
++
++    AC_CACHE_CHECK([whether a program can dlopen itself],
++	  lt_cv_dlopen_self, [dnl
++	  _LT_TRY_DLOPEN_SELF(
++	    lt_cv_dlopen_self=yes, lt_cv_dlopen_self=yes,
++	    lt_cv_dlopen_self=no, lt_cv_dlopen_self=cross)
++    ])
++
++    if test "x$lt_cv_dlopen_self" = xyes; then
++      wl=$lt_prog_compiler_wl eval LDFLAGS=\"\$LDFLAGS $lt_prog_compiler_static\"
++      AC_CACHE_CHECK([whether a statically linked program can dlopen itself],
++	  lt_cv_dlopen_self_static, [dnl
++	  _LT_TRY_DLOPEN_SELF(
++	    lt_cv_dlopen_self_static=yes, lt_cv_dlopen_self_static=yes,
++	    lt_cv_dlopen_self_static=no,  lt_cv_dlopen_self_static=cross)
++      ])
++    fi
++
++    CPPFLAGS="$save_CPPFLAGS"
++    LDFLAGS="$save_LDFLAGS"
++    LIBS="$save_LIBS"
++    ;;
++  esac
++
++  case $lt_cv_dlopen_self in
++  yes|no) enable_dlopen_self=$lt_cv_dlopen_self ;;
++  *) enable_dlopen_self=unknown ;;
++  esac
++
++  case $lt_cv_dlopen_self_static in
++  yes|no) enable_dlopen_self_static=$lt_cv_dlopen_self_static ;;
++  *) enable_dlopen_self_static=unknown ;;
++  esac
++fi
++_LT_DECL([dlopen_support], [enable_dlopen], [0],
++	 [Whether dlopen is supported])
++_LT_DECL([dlopen_self], [enable_dlopen_self], [0],
++	 [Whether dlopen of programs is supported])
++_LT_DECL([dlopen_self_static], [enable_dlopen_self_static], [0],
++	 [Whether dlopen of statically linked programs is supported])
++])# LT_SYS_DLOPEN_SELF
++
++# Old name:
++AU_ALIAS([AC_LIBTOOL_DLOPEN_SELF], [LT_SYS_DLOPEN_SELF])
++dnl aclocal-1.4 backwards compatibility:
++dnl AC_DEFUN([AC_LIBTOOL_DLOPEN_SELF], [])
++
++
++# _LT_COMPILER_C_O([TAGNAME])
++# ---------------------------
++# Check to see if options -c and -o are simultaneously supported by compiler.
++# This macro does not hard code the compiler like AC_PROG_CC_C_O.
++m4_defun([_LT_COMPILER_C_O],
++[m4_require([_LT_DECL_SED])dnl
++m4_require([_LT_FILEUTILS_DEFAULTS])dnl
++m4_require([_LT_TAG_COMPILER])dnl
++AC_CACHE_CHECK([if $compiler supports -c -o file.$ac_objext],
++  [_LT_TAGVAR(lt_cv_prog_compiler_c_o, $1)],
++  [_LT_TAGVAR(lt_cv_prog_compiler_c_o, $1)=no
++   $RM -r conftest 2>/dev/null
++   mkdir conftest
++   cd conftest
++   mkdir out
++   echo "$lt_simple_compile_test_code" > conftest.$ac_ext
++
++   lt_compiler_flag="-o out/conftest2.$ac_objext"
++   # Insert the option either (1) after the last *FLAGS variable, or
++   # (2) before a word containing "conftest.", or (3) at the end.
++   # Note that $ac_compile itself does not contain backslashes and begins
++   # with a dollar sign (not a hyphen), so the echo should work correctly.
++   lt_compile=`echo "$ac_compile" | $SED \
++   -e 's:.*FLAGS}\{0,1\} :&$lt_compiler_flag :; t' \
++   -e 's: [[^ ]]*conftest\.: $lt_compiler_flag&:; t' \
++   -e 's:$: $lt_compiler_flag:'`
++   (eval echo "\"\$as_me:$LINENO: $lt_compile\"" >&AS_MESSAGE_LOG_FD)
++   (eval "$lt_compile" 2>out/conftest.err)
++   ac_status=$?
++   cat out/conftest.err >&AS_MESSAGE_LOG_FD
++   echo "$as_me:$LINENO: \$? = $ac_status" >&AS_MESSAGE_LOG_FD
++   if (exit $ac_status) && test -s out/conftest2.$ac_objext
++   then
++     # The compiler can only warn and ignore the option if not recognized
++     # So say no if there are warnings
++     $ECHO "$_lt_compiler_boilerplate" | $SED '/^$/d' > out/conftest.exp
++     $SED '/^$/d; /^ *+/d' out/conftest.err >out/conftest.er2
++     if test ! -s out/conftest.er2 || diff out/conftest.exp out/conftest.er2 >/dev/null; then
++       _LT_TAGVAR(lt_cv_prog_compiler_c_o, $1)=yes
++     fi
++   fi
++   chmod u+w . 2>&AS_MESSAGE_LOG_FD
++   $RM conftest*
++   # SGI C++ compiler will create directory out/ii_files/ for
++   # template instantiation
++   test -d out/ii_files && $RM out/ii_files/* && rmdir out/ii_files
++   $RM out/* && rmdir out
++   cd ..
++   $RM -r conftest
++   $RM conftest*
++])
++_LT_TAGDECL([compiler_c_o], [lt_cv_prog_compiler_c_o], [1],
++	[Does compiler simultaneously support -c and -o options?])
++])# _LT_COMPILER_C_O
++
++
++# _LT_COMPILER_FILE_LOCKS([TAGNAME])
++# ----------------------------------
++# Check to see if we can do hard links to lock some files if needed
++m4_defun([_LT_COMPILER_FILE_LOCKS],
++[m4_require([_LT_ENABLE_LOCK])dnl
++m4_require([_LT_FILEUTILS_DEFAULTS])dnl
++_LT_COMPILER_C_O([$1])
++
++hard_links="nottested"
++if test "$_LT_TAGVAR(lt_cv_prog_compiler_c_o, $1)" = no && test "$need_locks" != no; then
++  # do not overwrite the value of need_locks provided by the user
++  AC_MSG_CHECKING([if we can lock with hard links])
++  hard_links=yes
++  $RM conftest*
++  ln conftest.a conftest.b 2>/dev/null && hard_links=no
++  touch conftest.a
++  ln conftest.a conftest.b 2>&5 || hard_links=no
++  ln conftest.a conftest.b 2>/dev/null && hard_links=no
++  AC_MSG_RESULT([$hard_links])
++  if test "$hard_links" = no; then
++    AC_MSG_WARN([`$CC' does not support `-c -o', so `make -j' may be unsafe])
++    need_locks=warn
++  fi
++else
++  need_locks=no
++fi
++_LT_DECL([], [need_locks], [1], [Must we lock files when doing compilation?])
++])# _LT_COMPILER_FILE_LOCKS
++
++
++# _LT_CHECK_OBJDIR
++# ----------------
++m4_defun([_LT_CHECK_OBJDIR],
++[AC_CACHE_CHECK([for objdir], [lt_cv_objdir],
++[rm -f .libs 2>/dev/null
++mkdir .libs 2>/dev/null
++if test -d .libs; then
++  lt_cv_objdir=.libs
++else
++  # MS-DOS does not allow filenames that begin with a dot.
++  lt_cv_objdir=_libs
++fi
++rmdir .libs 2>/dev/null])
++objdir=$lt_cv_objdir
++_LT_DECL([], [objdir], [0],
++         [The name of the directory that contains temporary libtool files])dnl
++m4_pattern_allow([LT_OBJDIR])dnl
++AC_DEFINE_UNQUOTED(LT_OBJDIR, "$lt_cv_objdir/",
++  [Define to the sub-directory in which libtool stores uninstalled libraries.])
++])# _LT_CHECK_OBJDIR
++
++
++# _LT_LINKER_HARDCODE_LIBPATH([TAGNAME])
++# --------------------------------------
++# Check hardcoding attributes.
++m4_defun([_LT_LINKER_HARDCODE_LIBPATH],
++[AC_MSG_CHECKING([how to hardcode library paths into programs])
++_LT_TAGVAR(hardcode_action, $1)=
++if test -n "$_LT_TAGVAR(hardcode_libdir_flag_spec, $1)" ||
++   test -n "$_LT_TAGVAR(runpath_var, $1)" ||
++   test "X$_LT_TAGVAR(hardcode_automatic, $1)" = "Xyes" ; then
++
++  # We can hardcode non-existent directories.
++  if test "$_LT_TAGVAR(hardcode_direct, $1)" != no &&
++     # If the only mechanism to avoid hardcoding is shlibpath_var, we
++     # have to relink, otherwise we might link with an installed library
++     # when we should be linking with a yet-to-be-installed one
++     ## test "$_LT_TAGVAR(hardcode_shlibpath_var, $1)" != no &&
++     test "$_LT_TAGVAR(hardcode_minus_L, $1)" != no; then
++    # Linking always hardcodes the temporary library directory.
++    _LT_TAGVAR(hardcode_action, $1)=relink
++  else
++    # We can link without hardcoding, and we can hardcode nonexisting dirs.
++    _LT_TAGVAR(hardcode_action, $1)=immediate
++  fi
++else
++  # We cannot hardcode anything, or else we can only hardcode existing
++  # directories.
++  _LT_TAGVAR(hardcode_action, $1)=unsupported
++fi
++AC_MSG_RESULT([$_LT_TAGVAR(hardcode_action, $1)])
++
++if test "$_LT_TAGVAR(hardcode_action, $1)" = relink ||
++   test "$_LT_TAGVAR(inherit_rpath, $1)" = yes; then
++  # Fast installation is not supported
++  enable_fast_install=no
++elif test "$shlibpath_overrides_runpath" = yes ||
++     test "$enable_shared" = no; then
++  # Fast installation is not necessary
++  enable_fast_install=needless
++fi
++_LT_TAGDECL([], [hardcode_action], [0],
++    [How to hardcode a shared library path into an executable])
++])# _LT_LINKER_HARDCODE_LIBPATH
++
++
++# _LT_CMD_STRIPLIB
++# ----------------
++m4_defun([_LT_CMD_STRIPLIB],
++[m4_require([_LT_DECL_EGREP])
++striplib=
++old_striplib=
++AC_MSG_CHECKING([whether stripping libraries is possible])
++if test -n "$STRIP" && $STRIP -V 2>&1 | $GREP "GNU strip" >/dev/null; then
++  test -z "$old_striplib" && old_striplib="$STRIP --strip-debug"
++  test -z "$striplib" && striplib="$STRIP --strip-unneeded"
++  AC_MSG_RESULT([yes])
++else
++# FIXME - insert some real tests, host_os isn't really good enough
++  case $host_os in
++  darwin*)
++    if test -n "$STRIP" ; then
++      striplib="$STRIP -x"
++      old_striplib="$STRIP -S"
++      AC_MSG_RESULT([yes])
++    else
++      AC_MSG_RESULT([no])
++    fi
++    ;;
++  *)
++    AC_MSG_RESULT([no])
++    ;;
++  esac
++fi
++_LT_DECL([], [old_striplib], [1], [Commands to strip libraries])
++_LT_DECL([], [striplib], [1])
++])# _LT_CMD_STRIPLIB
++
++
++# _LT_SYS_DYNAMIC_LINKER([TAG])
++# -----------------------------
++# PORTME Fill in your ld.so characteristics
++m4_defun([_LT_SYS_DYNAMIC_LINKER],
++[AC_REQUIRE([AC_CANONICAL_HOST])dnl
++m4_require([_LT_DECL_EGREP])dnl
++m4_require([_LT_FILEUTILS_DEFAULTS])dnl
++m4_require([_LT_DECL_OBJDUMP])dnl
++m4_require([_LT_DECL_SED])dnl
++m4_require([_LT_CHECK_SHELL_FEATURES])dnl
++AC_MSG_CHECKING([dynamic linker characteristics])
++m4_if([$1],
++	[], [
++if test "$GCC" = yes; then
++  case $host_os in
++    darwin*) lt_awk_arg="/^libraries:/,/LR/" ;;
++    *) lt_awk_arg="/^libraries:/" ;;
++  esac
++  case $host_os in
++    mingw* | cegcc*) lt_sed_strip_eq="s,=\([[A-Za-z]]:\),\1,g" ;;
++    *) lt_sed_strip_eq="s,=/,/,g" ;;
++  esac
++  lt_search_path_spec=`$CC -print-search-dirs | awk $lt_awk_arg | $SED -e "s/^libraries://" -e $lt_sed_strip_eq`
++  case $lt_search_path_spec in
++  *\;*)
++    # if the path contains ";" then we assume it to be the separator
++    # otherwise default to the standard path separator (i.e. ":") - it is
++    # assumed that no part of a normal pathname contains ";" but that should
++    # okay in the real world where ";" in dirpaths is itself problematic.
++    lt_search_path_spec=`$ECHO "$lt_search_path_spec" | $SED 's/;/ /g'`
++    ;;
++  *)
++    lt_search_path_spec=`$ECHO "$lt_search_path_spec" | $SED "s/$PATH_SEPARATOR/ /g"`
++    ;;
++  esac
++  # Ok, now we have the path, separated by spaces, we can step through it
++  # and add multilib dir if necessary.
++  lt_tmp_lt_search_path_spec=
++  lt_multi_os_dir=`$CC $CPPFLAGS $CFLAGS $LDFLAGS -print-multi-os-directory 2>/dev/null`
++  for lt_sys_path in $lt_search_path_spec; do
++    if test -d "$lt_sys_path/$lt_multi_os_dir"; then
++      lt_tmp_lt_search_path_spec="$lt_tmp_lt_search_path_spec $lt_sys_path/$lt_multi_os_dir"
++    else
++      test -d "$lt_sys_path" && \
++	lt_tmp_lt_search_path_spec="$lt_tmp_lt_search_path_spec $lt_sys_path"
++    fi
++  done
++  lt_search_path_spec=`$ECHO "$lt_tmp_lt_search_path_spec" | awk '
++BEGIN {RS=" "; FS="/|\n";} {
++  lt_foo="";
++  lt_count=0;
++  for (lt_i = NF; lt_i > 0; lt_i--) {
++    if ($lt_i != "" && $lt_i != ".") {
++      if ($lt_i == "..") {
++        lt_count++;
++      } else {
++        if (lt_count == 0) {
++          lt_foo="/" $lt_i lt_foo;
++        } else {
++          lt_count--;
++        }
++      }
++    }
++  }
++  if (lt_foo != "") { lt_freq[[lt_foo]]++; }
++  if (lt_freq[[lt_foo]] == 1) { print lt_foo; }
++}'`
++  # AWK program above erroneously prepends '/' to C:/dos/paths
++  # for these hosts.
++  case $host_os in
++    mingw* | cegcc*) lt_search_path_spec=`$ECHO "$lt_search_path_spec" |\
++      $SED 's,/\([[A-Za-z]]:\),\1,g'` ;;
++  esac
++  sys_lib_search_path_spec=`$ECHO "$lt_search_path_spec" | $lt_NL2SP`
++else
++  sys_lib_search_path_spec="/lib /usr/lib /usr/local/lib"
++fi])
++library_names_spec=
++libname_spec='lib$name'
++soname_spec=
++shrext_cmds=".so"
++postinstall_cmds=
++postuninstall_cmds=
++finish_cmds=
++finish_eval=
++shlibpath_var=
++shlibpath_overrides_runpath=unknown
++version_type=none
++dynamic_linker="$host_os ld.so"
++sys_lib_dlsearch_path_spec="/lib /usr/lib"
++need_lib_prefix=unknown
++hardcode_into_libs=no
++
++# when you set need_version to no, make sure it does not cause -set_version
++# flags to be left without arguments
++need_version=unknown
++
++case $host_os in
++aix3*)
++  version_type=linux # correct to gnu/linux during the next big refactor
++  library_names_spec='${libname}${release}${shared_ext}$versuffix $libname.a'
++  shlibpath_var=LIBPATH
++
++  # AIX 3 has no versioning support, so we append a major version to the name.
++  soname_spec='${libname}${release}${shared_ext}$major'
++  ;;
++
++aix[[4-9]]*)
++  version_type=linux # correct to gnu/linux during the next big refactor
++  need_lib_prefix=no
++  need_version=no
++  hardcode_into_libs=yes
++  if test "$host_cpu" = ia64; then
++    # AIX 5 supports IA64
++    library_names_spec='${libname}${release}${shared_ext}$major ${libname}${release}${shared_ext}$versuffix $libname${shared_ext}'
++    shlibpath_var=LD_LIBRARY_PATH
++  else
++    # With GCC up to 2.95.x, collect2 would create an import file
++    # for dependence libraries.  The import file would start with
++    # the line `#! .'.  This would cause the generated library to
++    # depend on `.', always an invalid library.  This was fixed in
++    # development snapshots of GCC prior to 3.0.
++    case $host_os in
++      aix4 | aix4.[[01]] | aix4.[[01]].*)
++      if { echo '#if __GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ >= 97)'
++	   echo ' yes '
++	   echo '#endif'; } | ${CC} -E - | $GREP yes > /dev/null; then
++	:
++      else
++	can_build_shared=no
++      fi
++      ;;
++    esac
++    # AIX (on Power*) has no versioning support, so currently we can not hardcode correct
++    # soname into executable. Probably we can add versioning support to
++    # collect2, so additional links can be useful in future.
++    if test "$aix_use_runtimelinking" = yes; then
++      # If using run time linking (on AIX 4.2 or later) use lib<name>.so
++      # instead of lib<name>.a to let people know that these are not
++      # typical AIX shared libraries.
++      library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
++    else
++      # We preserve .a as extension for shared libraries through AIX4.2
++      # and later when we are not doing run time linking.
++      library_names_spec='${libname}${release}.a $libname.a'
++      soname_spec='${libname}${release}${shared_ext}$major'
++    fi
++    shlibpath_var=LIBPATH
++  fi
++  ;;
++
++amigaos*)
++  case $host_cpu in
++  powerpc)
++    # Since July 2007 AmigaOS4 officially supports .so libraries.
++    # When compiling the executable, add -use-dynld -Lsobjs: to the compileline.
++    library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
++    ;;
++  m68k)
++    library_names_spec='$libname.ixlibrary $libname.a'
++    # Create ${libname}_ixlibrary.a entries in /sys/libs.
++    finish_eval='for lib in `ls $libdir/*.ixlibrary 2>/dev/null`; do libname=`func_echo_all "$lib" | $SED '\''s%^.*/\([[^/]]*\)\.ixlibrary$%\1%'\''`; test $RM /sys/libs/${libname}_ixlibrary.a; $show "cd /sys/libs && $LN_S $lib ${libname}_ixlibrary.a"; cd /sys/libs && $LN_S $lib ${libname}_ixlibrary.a || exit 1; done'
++    ;;
++  esac
++  ;;
++
++beos*)
++  library_names_spec='${libname}${shared_ext}'
++  dynamic_linker="$host_os ld.so"
++  shlibpath_var=LIBRARY_PATH
++  ;;
++
++bsdi[[45]]*)
++  version_type=linux # correct to gnu/linux during the next big refactor
++  need_version=no
++  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}$major'
++  finish_cmds='PATH="\$PATH:/sbin" ldconfig $libdir'
++  shlibpath_var=LD_LIBRARY_PATH
++  sys_lib_search_path_spec="/shlib /usr/lib /usr/X11/lib /usr/contrib/lib /lib /usr/local/lib"
++  sys_lib_dlsearch_path_spec="/shlib /usr/lib /usr/local/lib"
++  # the default ld.so.conf also contains /usr/contrib/lib and
++  # /usr/X11R6/lib (/usr/X11 is a link to /usr/X11R6), but let us allow
++  # libtool to hard-code these into programs
++  ;;
++
++cygwin* | mingw* | pw32* | cegcc*)
++  version_type=windows
++  shrext_cmds=".dll"
++  need_version=no
++  need_lib_prefix=no
++
++  case $GCC,$cc_basename in
++  yes,*)
++    # gcc
++    library_names_spec='$libname.dll.a'
++    # DLL is installed to $(libdir)/../bin by postinstall_cmds
++    postinstall_cmds='base_file=`basename \${file}`~
++      dlpath=`$SHELL 2>&1 -c '\''. $dir/'\''\${base_file}'\''i; echo \$dlname'\''`~
++      dldir=$destdir/`dirname \$dlpath`~
++      test -d \$dldir || mkdir -p \$dldir~
++      $install_prog $dir/$dlname \$dldir/$dlname~
++      chmod a+x \$dldir/$dlname~
++      if test -n '\''$stripme'\'' && test -n '\''$striplib'\''; then
++        eval '\''$striplib \$dldir/$dlname'\'' || exit \$?;
++      fi'
++    postuninstall_cmds='dldll=`$SHELL 2>&1 -c '\''. $file; echo \$dlname'\''`~
++      dlpath=$dir/\$dldll~
++       $RM \$dlpath'
++    shlibpath_overrides_runpath=yes
++
++    case $host_os in
++    cygwin*)
++      # Cygwin DLLs use 'cyg' prefix rather than 'lib'
++      soname_spec='`echo ${libname} | sed -e 's/^lib/cyg/'``echo ${release} | $SED -e 's/[[.]]/-/g'`${versuffix}${shared_ext}'
++m4_if([$1], [],[
++      sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/lib/w32api"])
++      ;;
++    mingw* | cegcc*)
++      # MinGW DLLs use traditional 'lib' prefix
++      soname_spec='${libname}`echo ${release} | $SED -e 's/[[.]]/-/g'`${versuffix}${shared_ext}'
++      ;;
++    pw32*)
++      # pw32 DLLs use 'pw' prefix rather than 'lib'
++      library_names_spec='`echo ${libname} | sed -e 's/^lib/pw/'``echo ${release} | $SED -e 's/[[.]]/-/g'`${versuffix}${shared_ext}'
++      ;;
++    esac
++    dynamic_linker='Win32 ld.exe'
++    ;;
++
++  *,cl*)
++    # Native MSVC
++    libname_spec='$name'
++    soname_spec='${libname}`echo ${release} | $SED -e 's/[[.]]/-/g'`${versuffix}${shared_ext}'
++    library_names_spec='${libname}.dll.lib'
++
++    case $build_os in
++    mingw*)
++      sys_lib_search_path_spec=
++      lt_save_ifs=$IFS
++      IFS=';'
++      for lt_path in $LIB
++      do
++        IFS=$lt_save_ifs
++        # Let DOS variable expansion print the short 8.3 style file name.
++        lt_path=`cd "$lt_path" 2>/dev/null && cmd //C "for %i in (".") do @echo %~si"`
++        sys_lib_search_path_spec="$sys_lib_search_path_spec $lt_path"
++      done
++      IFS=$lt_save_ifs
++      # Convert to MSYS style.
++      sys_lib_search_path_spec=`$ECHO "$sys_lib_search_path_spec" | sed -e 's|\\\\|/|g' -e 's| \\([[a-zA-Z]]\\):| /\\1|g' -e 's|^ ||'`
++      ;;
++    cygwin*)
++      # Convert to unix form, then to dos form, then back to unix form
++      # but this time dos style (no spaces!) so that the unix form looks
++      # like /cygdrive/c/PROGRA~1:/cygdr...
++      sys_lib_search_path_spec=`cygpath --path --unix "$LIB"`
++      sys_lib_search_path_spec=`cygpath --path --dos "$sys_lib_search_path_spec" 2>/dev/null`
++      sys_lib_search_path_spec=`cygpath --path --unix "$sys_lib_search_path_spec" | $SED -e "s/$PATH_SEPARATOR/ /g"`
++      ;;
++    *)
++      sys_lib_search_path_spec="$LIB"
++      if $ECHO "$sys_lib_search_path_spec" | [$GREP ';[c-zC-Z]:/' >/dev/null]; then
++        # It is most probably a Windows format PATH.
++        sys_lib_search_path_spec=`$ECHO "$sys_lib_search_path_spec" | $SED -e 's/;/ /g'`
++      else
++        sys_lib_search_path_spec=`$ECHO "$sys_lib_search_path_spec" | $SED -e "s/$PATH_SEPARATOR/ /g"`
++      fi
++      # FIXME: find the short name or the path components, as spaces are
++      # common. (e.g. "Program Files" -> "PROGRA~1")
++      ;;
++    esac
++
++    # DLL is installed to $(libdir)/../bin by postinstall_cmds
++    postinstall_cmds='base_file=`basename \${file}`~
++      dlpath=`$SHELL 2>&1 -c '\''. $dir/'\''\${base_file}'\''i; echo \$dlname'\''`~
++      dldir=$destdir/`dirname \$dlpath`~
++      test -d \$dldir || mkdir -p \$dldir~
++      $install_prog $dir/$dlname \$dldir/$dlname'
++    postuninstall_cmds='dldll=`$SHELL 2>&1 -c '\''. $file; echo \$dlname'\''`~
++      dlpath=$dir/\$dldll~
++       $RM \$dlpath'
++    shlibpath_overrides_runpath=yes
++    dynamic_linker='Win32 link.exe'
++    ;;
++
++  *)
++    # Assume MSVC wrapper
++    library_names_spec='${libname}`echo ${release} | $SED -e 's/[[.]]/-/g'`${versuffix}${shared_ext} $libname.lib'
++    dynamic_linker='Win32 ld.exe'
++    ;;
++  esac
++  # FIXME: first we should search . and the directory the executable is in
++  shlibpath_var=PATH
++  ;;
++
++darwin* | rhapsody*)
++  dynamic_linker="$host_os dyld"
++  version_type=darwin
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='${libname}${release}${major}$shared_ext ${libname}$shared_ext'
++  soname_spec='${libname}${release}${major}$shared_ext'
++  shlibpath_overrides_runpath=yes
++  shlibpath_var=DYLD_LIBRARY_PATH
++  shrext_cmds='`test .$module = .yes && echo .so || echo .dylib`'
++m4_if([$1], [],[
++  sys_lib_search_path_spec="$sys_lib_search_path_spec /usr/local/lib"])
++  sys_lib_dlsearch_path_spec='/usr/local/lib /lib /usr/lib'
++  ;;
++
++dgux*)
++  version_type=linux # correct to gnu/linux during the next big refactor
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname$shared_ext'
++  soname_spec='${libname}${release}${shared_ext}$major'
++  shlibpath_var=LD_LIBRARY_PATH
++  ;;
++
++freebsd* | dragonfly*)
++  # DragonFly does not have aout.  When/if they implement a new
++  # versioning mechanism, adjust this.
++  if test -x /usr/bin/objformat; then
++    objformat=`/usr/bin/objformat`
++  else
++    case $host_os in
++    freebsd[[23]].*) objformat=aout ;;
++    *) objformat=elf ;;
++    esac
++  fi
++  version_type=freebsd-$objformat
++  case $version_type in
++    freebsd-elf*)
++      library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext} $libname${shared_ext}'
++      need_version=no
++      need_lib_prefix=no
++      ;;
++    freebsd-*)
++      library_names_spec='${libname}${release}${shared_ext}$versuffix $libname${shared_ext}$versuffix'
++      need_version=yes
++      ;;
++  esac
++  shlibpath_var=LD_LIBRARY_PATH
++  case $host_os in
++  freebsd2.*)
++    shlibpath_overrides_runpath=yes
++    ;;
++  freebsd3.[[01]]* | freebsdelf3.[[01]]*)
++    shlibpath_overrides_runpath=yes
++    hardcode_into_libs=yes
++    ;;
++  freebsd3.[[2-9]]* | freebsdelf3.[[2-9]]* | \
++  freebsd4.[[0-5]] | freebsdelf4.[[0-5]] | freebsd4.1.1 | freebsdelf4.1.1)
++    shlibpath_overrides_runpath=no
++    hardcode_into_libs=yes
++    ;;
++  *) # from 4.6 on, and DragonFly
++    shlibpath_overrides_runpath=yes
++    hardcode_into_libs=yes
++    ;;
++  esac
++  ;;
++
++haiku*)
++  version_type=linux # correct to gnu/linux during the next big refactor
++  need_lib_prefix=no
++  need_version=no
++  dynamic_linker="$host_os runtime_loader"
++  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}$major'
++  shlibpath_var=LIBRARY_PATH
++  shlibpath_overrides_runpath=yes
++  sys_lib_dlsearch_path_spec='/boot/home/config/lib /boot/common/lib /boot/system/lib'
++  hardcode_into_libs=yes
++  ;;
++
++hpux9* | hpux10* | hpux11*)
++  # Give a soname corresponding to the major version so that dld.sl refuses to
++  # link against other versions.
++  version_type=sunos
++  need_lib_prefix=no
++  need_version=no
++  case $host_cpu in
++  ia64*)
++    shrext_cmds='.so'
++    hardcode_into_libs=yes
++    dynamic_linker="$host_os dld.so"
++    shlibpath_var=LD_LIBRARY_PATH
++    shlibpath_overrides_runpath=yes # Unless +noenvvar is specified.
++    library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
++    soname_spec='${libname}${release}${shared_ext}$major'
++    if test "X$HPUX_IA64_MODE" = X32; then
++      sys_lib_search_path_spec="/usr/lib/hpux32 /usr/local/lib/hpux32 /usr/local/lib"
++    else
++      sys_lib_search_path_spec="/usr/lib/hpux64 /usr/local/lib/hpux64"
++    fi
++    sys_lib_dlsearch_path_spec=$sys_lib_search_path_spec
++    ;;
++  hppa*64*)
++    shrext_cmds='.sl'
++    hardcode_into_libs=yes
++    dynamic_linker="$host_os dld.sl"
++    shlibpath_var=LD_LIBRARY_PATH # How should we handle SHLIB_PATH
++    shlibpath_overrides_runpath=yes # Unless +noenvvar is specified.
++    library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
++    soname_spec='${libname}${release}${shared_ext}$major'
++    sys_lib_search_path_spec="/usr/lib/pa20_64 /usr/ccs/lib/pa20_64"
++    sys_lib_dlsearch_path_spec=$sys_lib_search_path_spec
++    ;;
++  *)
++    shrext_cmds='.sl'
++    dynamic_linker="$host_os dld.sl"
++    shlibpath_var=SHLIB_PATH
++    shlibpath_overrides_runpath=no # +s is required to enable SHLIB_PATH
++    library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
++    soname_spec='${libname}${release}${shared_ext}$major'
++    ;;
++  esac
++  # HP-UX runs *really* slowly unless shared libraries are mode 555, ...
++  postinstall_cmds='chmod 555 $lib'
++  # or fails outright, so override atomically:
++  install_override_mode=555
++  ;;
++
++interix[[3-9]]*)
++  version_type=linux # correct to gnu/linux during the next big refactor
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major ${libname}${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}$major'
++  dynamic_linker='Interix 3.x ld.so.1 (PE, like ELF)'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=no
++  hardcode_into_libs=yes
++  ;;
++
++irix5* | irix6* | nonstopux*)
++  case $host_os in
++    nonstopux*) version_type=nonstopux ;;
++    *)
++	if test "$lt_cv_prog_gnu_ld" = yes; then
++		version_type=linux # correct to gnu/linux during the next big refactor
++	else
++		version_type=irix
++	fi ;;
++  esac
++  need_lib_prefix=no
++  need_version=no
++  soname_spec='${libname}${release}${shared_ext}$major'
++  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major ${libname}${release}${shared_ext} $libname${shared_ext}'
++  case $host_os in
++  irix5* | nonstopux*)
++    libsuff= shlibsuff=
++    ;;
++  *)
++    case $LD in # libtool.m4 will add one of these switches to LD
++    *-32|*"-32 "|*-melf32bsmip|*"-melf32bsmip ")
++      libsuff= shlibsuff= libmagic=32-bit;;
++    *-n32|*"-n32 "|*-melf32bmipn32|*"-melf32bmipn32 ")
++      libsuff=32 shlibsuff=N32 libmagic=N32;;
++    *-64|*"-64 "|*-melf64bmip|*"-melf64bmip ")
++      libsuff=64 shlibsuff=64 libmagic=64-bit;;
++    *) libsuff= shlibsuff= libmagic=never-match;;
++    esac
++    ;;
++  esac
++  shlibpath_var=LD_LIBRARY${shlibsuff}_PATH
++  shlibpath_overrides_runpath=no
++  sys_lib_search_path_spec="/usr/lib${libsuff} /lib${libsuff} /usr/local/lib${libsuff}"
++  sys_lib_dlsearch_path_spec="/usr/lib${libsuff} /lib${libsuff}"
++  hardcode_into_libs=yes
++  ;;
++
++# No shared lib support for Linux oldld, aout, or coff.
++linux*oldld* | linux*aout* | linux*coff*)
++  dynamic_linker=no
++  ;;
++
++# This must be glibc/ELF.
++linux* | k*bsd*-gnu | kopensolaris*-gnu | gnu*)
++  version_type=linux # correct to gnu/linux during the next big refactor
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}$major'
++  finish_cmds='PATH="\$PATH:/sbin" ldconfig -n $libdir'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=no
++
++  # Some binutils ld are patched to set DT_RUNPATH
++  AC_CACHE_VAL([lt_cv_shlibpath_overrides_runpath],
++    [lt_cv_shlibpath_overrides_runpath=no
++    save_LDFLAGS=$LDFLAGS
++    save_libdir=$libdir
++    eval "libdir=/foo; wl=\"$_LT_TAGVAR(lt_prog_compiler_wl, $1)\"; \
++	 LDFLAGS=\"\$LDFLAGS $_LT_TAGVAR(hardcode_libdir_flag_spec, $1)\""
++    AC_LINK_IFELSE([AC_LANG_PROGRAM([],[])],
++      [AS_IF([ ($OBJDUMP -p conftest$ac_exeext) 2>/dev/null | grep "RUNPATH.*$libdir" >/dev/null],
++	 [lt_cv_shlibpath_overrides_runpath=yes])])
++    LDFLAGS=$save_LDFLAGS
++    libdir=$save_libdir
++    ])
++  shlibpath_overrides_runpath=$lt_cv_shlibpath_overrides_runpath
++
++  # This implies no fast_install, which is unacceptable.
++  # Some rework will be needed to allow for fast_install
++  # before this can be enabled.
++  hardcode_into_libs=yes
++
++  # Append ld.so.conf contents to the search path
++  if test -f /etc/ld.so.conf; then
++    lt_ld_extra=`awk '/^include / { system(sprintf("cd /etc; cat %s 2>/dev/null", \[$]2)); skip = 1; } { if (!skip) print \[$]0; skip = 0; }' < /etc/ld.so.conf | $SED -e 's/#.*//;/^[	 ]*hwcap[	 ]/d;s/[:,	]/ /g;s/=[^=]*$//;s/=[^= ]* / /g;s/"//g;/^$/d' | tr '\n' ' '`
++    sys_lib_dlsearch_path_spec="/lib /usr/lib $lt_ld_extra"
++  fi
++
++  # We used to test for /lib/ld.so.1 and disable shared libraries on
++  # powerpc, because MkLinux only supported shared libraries with the
++  # GNU dynamic linker.  Since this was broken with cross compilers,
++  # most powerpc-linux boxes support dynamic linking these days and
++  # people can always --disable-shared, the test was removed, and we
++  # assume the GNU/Linux dynamic linker is in use.
++  dynamic_linker='GNU/Linux ld.so'
++  ;;
++
++netbsdelf*-gnu)
++  version_type=linux
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major ${libname}${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}$major'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=no
++  hardcode_into_libs=yes
++  dynamic_linker='NetBSD ld.elf_so'
++  ;;
++
++netbsd*)
++  version_type=sunos
++  need_lib_prefix=no
++  need_version=no
++  if echo __ELF__ | $CC -E - | $GREP __ELF__ >/dev/null; then
++    library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${shared_ext}$versuffix'
++    finish_cmds='PATH="\$PATH:/sbin" ldconfig -m $libdir'
++    dynamic_linker='NetBSD (a.out) ld.so'
++  else
++    library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major ${libname}${shared_ext}'
++    soname_spec='${libname}${release}${shared_ext}$major'
++    dynamic_linker='NetBSD ld.elf_so'
++  fi
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=yes
++  hardcode_into_libs=yes
++  ;;
++
++newsos6)
++  version_type=linux # correct to gnu/linux during the next big refactor
++  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=yes
++  ;;
++
++*nto* | *qnx*)
++  version_type=qnx
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}$major'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=no
++  hardcode_into_libs=yes
++  dynamic_linker='ldqnx.so'
++  ;;
++
++openbsd*)
++  version_type=sunos
++  sys_lib_dlsearch_path_spec="/usr/lib"
++  need_lib_prefix=no
++  # Some older versions of OpenBSD (3.3 at least) *do* need versioned libs.
++  case $host_os in
++    openbsd3.3 | openbsd3.3.*)	need_version=yes ;;
++    *)				need_version=no  ;;
++  esac
++  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${shared_ext}$versuffix'
++  finish_cmds='PATH="\$PATH:/sbin" ldconfig -m $libdir'
++  shlibpath_var=LD_LIBRARY_PATH
++  if test -z "`echo __ELF__ | $CC -E - | $GREP __ELF__`" || test "$host_os-$host_cpu" = "openbsd2.8-powerpc"; then
++    case $host_os in
++      openbsd2.[[89]] | openbsd2.[[89]].*)
++	shlibpath_overrides_runpath=no
++	;;
++      *)
++	shlibpath_overrides_runpath=yes
++	;;
++      esac
++  else
++    shlibpath_overrides_runpath=yes
++  fi
++  ;;
++
++os2*)
++  libname_spec='$name'
++  shrext_cmds=".dll"
++  need_lib_prefix=no
++  library_names_spec='$libname${shared_ext} $libname.a'
++  dynamic_linker='OS/2 ld.exe'
++  shlibpath_var=LIBPATH
++  ;;
++
++osf3* | osf4* | osf5*)
++  version_type=osf
++  need_lib_prefix=no
++  need_version=no
++  soname_spec='${libname}${release}${shared_ext}$major'
++  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
++  shlibpath_var=LD_LIBRARY_PATH
++  sys_lib_search_path_spec="/usr/shlib /usr/ccs/lib /usr/lib/cmplrs/cc /usr/lib /usr/local/lib /var/shlib"
++  sys_lib_dlsearch_path_spec="$sys_lib_search_path_spec"
++  ;;
++
++rdos*)
++  dynamic_linker=no
++  ;;
++
++solaris*)
++  version_type=linux # correct to gnu/linux during the next big refactor
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}$major'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=yes
++  hardcode_into_libs=yes
++  # ldd complains unless libraries are executable
++  postinstall_cmds='chmod +x $lib'
++  ;;
++
++sunos4*)
++  version_type=sunos
++  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${shared_ext}$versuffix'
++  finish_cmds='PATH="\$PATH:/usr/etc" ldconfig $libdir'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=yes
++  if test "$with_gnu_ld" = yes; then
++    need_lib_prefix=no
++  fi
++  need_version=yes
++  ;;
++
++sysv4 | sysv4.3*)
++  version_type=linux # correct to gnu/linux during the next big refactor
++  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}$major'
++  shlibpath_var=LD_LIBRARY_PATH
++  case $host_vendor in
++    sni)
++      shlibpath_overrides_runpath=no
++      need_lib_prefix=no
++      runpath_var=LD_RUN_PATH
++      ;;
++    siemens)
++      need_lib_prefix=no
++      ;;
++    motorola)
++      need_lib_prefix=no
++      need_version=no
++      shlibpath_overrides_runpath=no
++      sys_lib_search_path_spec='/lib /usr/lib /usr/ccs/lib'
++      ;;
++  esac
++  ;;
++
++sysv4*MP*)
++  if test -d /usr/nec ;then
++    version_type=linux # correct to gnu/linux during the next big refactor
++    library_names_spec='$libname${shared_ext}.$versuffix $libname${shared_ext}.$major $libname${shared_ext}'
++    soname_spec='$libname${shared_ext}.$major'
++    shlibpath_var=LD_LIBRARY_PATH
++  fi
++  ;;
++
++sysv5* | sco3.2v5* | sco5v6* | unixware* | OpenUNIX* | sysv4*uw2*)
++  version_type=freebsd-elf
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext} $libname${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}$major'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=yes
++  hardcode_into_libs=yes
++  if test "$with_gnu_ld" = yes; then
++    sys_lib_search_path_spec='/usr/local/lib /usr/gnu/lib /usr/ccs/lib /usr/lib /lib'
++  else
++    sys_lib_search_path_spec='/usr/ccs/lib /usr/lib'
++    case $host_os in
++      sco3.2v5*)
++        sys_lib_search_path_spec="$sys_lib_search_path_spec /lib"
++	;;
++    esac
++  fi
++  sys_lib_dlsearch_path_spec='/usr/lib'
++  ;;
++
++tpf*)
++  # TPF is a cross-target only.  Preferred cross-host = GNU/Linux.
++  version_type=linux # correct to gnu/linux during the next big refactor
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=no
++  hardcode_into_libs=yes
++  ;;
++
++uts4*)
++  version_type=linux # correct to gnu/linux during the next big refactor
++  library_names_spec='${libname}${release}${shared_ext}$versuffix ${libname}${release}${shared_ext}$major $libname${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}$major'
++  shlibpath_var=LD_LIBRARY_PATH
++  ;;
++
++*)
++  dynamic_linker=no
++  ;;
++esac
++AC_MSG_RESULT([$dynamic_linker])
++test "$dynamic_linker" = no && can_build_shared=no
++
++variables_saved_for_relink="PATH $shlibpath_var $runpath_var"
++if test "$GCC" = yes; then
++  variables_saved_for_relink="$variables_saved_for_relink GCC_EXEC_PREFIX COMPILER_PATH LIBRARY_PATH"
++fi
++
++if test "${lt_cv_sys_lib_search_path_spec+set}" = set; then
++  sys_lib_search_path_spec="$lt_cv_sys_lib_search_path_spec"
++fi
++if test "${lt_cv_sys_lib_dlsearch_path_spec+set}" = set; then
++  sys_lib_dlsearch_path_spec="$lt_cv_sys_lib_dlsearch_path_spec"
++fi
++
++_LT_DECL([], [variables_saved_for_relink], [1],
++    [Variables whose values should be saved in libtool wrapper scripts and
++    restored at link time])
++_LT_DECL([], [need_lib_prefix], [0],
++    [Do we need the "lib" prefix for modules?])
++_LT_DECL([], [need_version], [0], [Do we need a version for libraries?])
++_LT_DECL([], [version_type], [0], [Library versioning type])
++_LT_DECL([], [runpath_var], [0],  [Shared library runtime path variable])
++_LT_DECL([], [shlibpath_var], [0],[Shared library path variable])
++_LT_DECL([], [shlibpath_overrides_runpath], [0],
++    [Is shlibpath searched before the hard-coded library search path?])
++_LT_DECL([], [libname_spec], [1], [Format of library name prefix])
++_LT_DECL([], [library_names_spec], [1],
++    [[List of archive names.  First name is the real one, the rest are links.
++    The last name is the one that the linker finds with -lNAME]])
++_LT_DECL([], [soname_spec], [1],
++    [[The coded name of the library, if different from the real name]])
++_LT_DECL([], [install_override_mode], [1],
++    [Permission mode override for installation of shared libraries])
++_LT_DECL([], [postinstall_cmds], [2],
++    [Command to use after installation of a shared archive])
++_LT_DECL([], [postuninstall_cmds], [2],
++    [Command to use after uninstallation of a shared archive])
++_LT_DECL([], [finish_cmds], [2],
++    [Commands used to finish a libtool library installation in a directory])
++_LT_DECL([], [finish_eval], [1],
++    [[As "finish_cmds", except a single script fragment to be evaled but
++    not shown]])
++_LT_DECL([], [hardcode_into_libs], [0],
++    [Whether we should hardcode library paths into libraries])
++_LT_DECL([], [sys_lib_search_path_spec], [2],
++    [Compile-time system search path for libraries])
++_LT_DECL([], [sys_lib_dlsearch_path_spec], [2],
++    [Run-time system search path for libraries])
++])# _LT_SYS_DYNAMIC_LINKER
++
++
++# _LT_PATH_TOOL_PREFIX(TOOL)
++# --------------------------
++# find a file program which can recognize shared library
++AC_DEFUN([_LT_PATH_TOOL_PREFIX],
++[m4_require([_LT_DECL_EGREP])dnl
++AC_MSG_CHECKING([for $1])
++AC_CACHE_VAL(lt_cv_path_MAGIC_CMD,
++[case $MAGIC_CMD in
++[[\\/*] |  ?:[\\/]*])
++  lt_cv_path_MAGIC_CMD="$MAGIC_CMD" # Let the user override the test with a path.
++  ;;
++*)
++  lt_save_MAGIC_CMD="$MAGIC_CMD"
++  lt_save_ifs="$IFS"; IFS=$PATH_SEPARATOR
++dnl $ac_dummy forces splitting on constant user-supplied paths.
++dnl POSIX.2 word splitting is done only on the output of word expansions,
++dnl not every word.  This closes a longstanding sh security hole.
++  ac_dummy="m4_if([$2], , $PATH, [$2])"
++  for ac_dir in $ac_dummy; do
++    IFS="$lt_save_ifs"
++    test -z "$ac_dir" && ac_dir=.
++    if test -f $ac_dir/$1; then
++      lt_cv_path_MAGIC_CMD="$ac_dir/$1"
++      if test -n "$file_magic_test_file"; then
++	case $deplibs_check_method in
++	"file_magic "*)
++	  file_magic_regex=`expr "$deplibs_check_method" : "file_magic \(.*\)"`
++	  MAGIC_CMD="$lt_cv_path_MAGIC_CMD"
++	  if eval $file_magic_cmd \$file_magic_test_file 2> /dev/null |
++	    $EGREP "$file_magic_regex" > /dev/null; then
++	    :
++	  else
++	    cat <<_LT_EOF 1>&2
++
++*** Warning: the command libtool uses to detect shared libraries,
++*** $file_magic_cmd, produces output that libtool cannot recognize.
++*** The result is that libtool may fail to recognize shared libraries
++*** as such.  This will affect the creation of libtool libraries that
++*** depend on shared libraries, but programs linked with such libtool
++*** libraries will work regardless of this problem.  Nevertheless, you
++*** may want to report the problem to your system manager and/or to
++*** bug-libtool@gnu.org
++
++_LT_EOF
++	  fi ;;
++	esac
++      fi
++      break
++    fi
++  done
++  IFS="$lt_save_ifs"
++  MAGIC_CMD="$lt_save_MAGIC_CMD"
++  ;;
++esac])
++MAGIC_CMD="$lt_cv_path_MAGIC_CMD"
++if test -n "$MAGIC_CMD"; then
++  AC_MSG_RESULT($MAGIC_CMD)
++else
++  AC_MSG_RESULT(no)
++fi
++_LT_DECL([], [MAGIC_CMD], [0],
++	 [Used to examine libraries when file_magic_cmd begins with "file"])dnl
++])# _LT_PATH_TOOL_PREFIX
++
++# Old name:
++AU_ALIAS([AC_PATH_TOOL_PREFIX], [_LT_PATH_TOOL_PREFIX])
++dnl aclocal-1.4 backwards compatibility:
++dnl AC_DEFUN([AC_PATH_TOOL_PREFIX], [])
++
++
++# _LT_PATH_MAGIC
++# --------------
++# find a file program which can recognize a shared library
++m4_defun([_LT_PATH_MAGIC],
++[_LT_PATH_TOOL_PREFIX(${ac_tool_prefix}file, /usr/bin$PATH_SEPARATOR$PATH)
++if test -z "$lt_cv_path_MAGIC_CMD"; then
++  if test -n "$ac_tool_prefix"; then
++    _LT_PATH_TOOL_PREFIX(file, /usr/bin$PATH_SEPARATOR$PATH)
++  else
++    MAGIC_CMD=:
++  fi
++fi
++])# _LT_PATH_MAGIC
++
++
++# LT_PATH_LD
++# ----------
++# find the pathname to the GNU or non-GNU linker
++AC_DEFUN([LT_PATH_LD],
++[AC_REQUIRE([AC_PROG_CC])dnl
++AC_REQUIRE([AC_CANONICAL_HOST])dnl
++AC_REQUIRE([AC_CANONICAL_BUILD])dnl
++m4_require([_LT_DECL_SED])dnl
++m4_require([_LT_DECL_EGREP])dnl
++m4_require([_LT_PROG_ECHO_BACKSLASH])dnl
++
++AC_ARG_WITH([gnu-ld],
++    [AS_HELP_STRING([--with-gnu-ld],
++	[assume the C compiler uses GNU ld @<:@default=no@:>@])],
++    [test "$withval" = no || with_gnu_ld=yes],
++    [with_gnu_ld=no])dnl
++
++ac_prog=ld
++if test "$GCC" = yes; then
++  # Check if gcc -print-prog-name=ld gives a path.
++  AC_MSG_CHECKING([for ld used by $CC])
++  case $host in
++  *-*-mingw*)
++    # gcc leaves a trailing carriage return which upsets mingw
++    ac_prog=`($CC -print-prog-name=ld) 2>&5 | tr -d '\015'` ;;
++  *)
++    ac_prog=`($CC -print-prog-name=ld) 2>&5` ;;
++  esac
++  case $ac_prog in
++    # Accept absolute paths.
++    [[\\/]]* | ?:[[\\/]]*)
++      re_direlt='/[[^/]][[^/]]*/\.\./'
++      # Canonicalize the pathname of ld
++      ac_prog=`$ECHO "$ac_prog"| $SED 's%\\\\%/%g'`
++      while $ECHO "$ac_prog" | $GREP "$re_direlt" > /dev/null 2>&1; do
++	ac_prog=`$ECHO $ac_prog| $SED "s%$re_direlt%/%"`
++      done
++      test -z "$LD" && LD="$ac_prog"
++      ;;
++  "")
++    # If it fails, then pretend we aren't using GCC.
++    ac_prog=ld
++    ;;
++  *)
++    # If it is relative, then search for the first ld in PATH.
++    with_gnu_ld=unknown
++    ;;
++  esac
++elif test "$with_gnu_ld" = yes; then
++  AC_MSG_CHECKING([for GNU ld])
++else
++  AC_MSG_CHECKING([for non-GNU ld])
++fi
++AC_CACHE_VAL(lt_cv_path_LD,
++[if test -z "$LD"; then
++  lt_save_ifs="$IFS"; IFS=$PATH_SEPARATOR
++  for ac_dir in $PATH; do
++    IFS="$lt_save_ifs"
++    test -z "$ac_dir" && ac_dir=.
++    if test -f "$ac_dir/$ac_prog" || test -f "$ac_dir/$ac_prog$ac_exeext"; then
++      lt_cv_path_LD="$ac_dir/$ac_prog"
++      # Check to see if the program is GNU ld.  I'd rather use --version,
++      # but apparently some variants of GNU ld only accept -v.
++      # Break only if it was the GNU/non-GNU ld that we prefer.
++      case `"$lt_cv_path_LD" -v 2>&1 </dev/null` in
++      *GNU* | *'with BFD'*)
++	test "$with_gnu_ld" != no && break
++	;;
++      *)
++	test "$with_gnu_ld" != yes && break
++	;;
++      esac
++    fi
++  done
++  IFS="$lt_save_ifs"
++else
++  lt_cv_path_LD="$LD" # Let the user override the test with a path.
++fi])
++LD="$lt_cv_path_LD"
++if test -n "$LD"; then
++  AC_MSG_RESULT($LD)
++else
++  AC_MSG_RESULT(no)
++fi
++test -z "$LD" && AC_MSG_ERROR([no acceptable ld found in \$PATH])
++_LT_PATH_LD_GNU
++AC_SUBST([LD])
++
++_LT_TAGDECL([], [LD], [1], [The linker used to build libraries])
++])# LT_PATH_LD
++
++# Old names:
++AU_ALIAS([AM_PROG_LD], [LT_PATH_LD])
++AU_ALIAS([AC_PROG_LD], [LT_PATH_LD])
++dnl aclocal-1.4 backwards compatibility:
++dnl AC_DEFUN([AM_PROG_LD], [])
++dnl AC_DEFUN([AC_PROG_LD], [])
++
++
++# _LT_PATH_LD_GNU
++#- --------------
++m4_defun([_LT_PATH_LD_GNU],
++[AC_CACHE_CHECK([if the linker ($LD) is GNU ld], lt_cv_prog_gnu_ld,
++[# I'd rather use --version here, but apparently some GNU lds only accept -v.
++case `$LD -v 2>&1 </dev/null` in
++*GNU* | *'with BFD'*)
++  lt_cv_prog_gnu_ld=yes
++  ;;
++*)
++  lt_cv_prog_gnu_ld=no
++  ;;
++esac])
++with_gnu_ld=$lt_cv_prog_gnu_ld
++])# _LT_PATH_LD_GNU
++
++
++# _LT_CMD_RELOAD
++# --------------
++# find reload flag for linker
++#   -- PORTME Some linkers may need a different reload flag.
++m4_defun([_LT_CMD_RELOAD],
++[AC_CACHE_CHECK([for $LD option to reload object files],
++  lt_cv_ld_reload_flag,
++  [lt_cv_ld_reload_flag='-r'])
++reload_flag=$lt_cv_ld_reload_flag
++case $reload_flag in
++"" | " "*) ;;
++*) reload_flag=" $reload_flag" ;;
++esac
++reload_cmds='$LD$reload_flag -o $output$reload_objs'
++case $host_os in
++  cygwin* | mingw* | pw32* | cegcc*)
++    if test "$GCC" != yes; then
++      reload_cmds=false
++    fi
++    ;;
++  darwin*)
++    if test "$GCC" = yes; then
++      reload_cmds='$LTCC $LTCFLAGS -nostdlib ${wl}-r -o $output$reload_objs'
++    else
++      reload_cmds='$LD$reload_flag -o $output$reload_objs'
++    fi
++    ;;
++esac
++_LT_TAGDECL([], [reload_flag], [1], [How to create reloadable object files])dnl
++_LT_TAGDECL([], [reload_cmds], [2])dnl
++])# _LT_CMD_RELOAD
++
++
++# _LT_CHECK_MAGIC_METHOD
++# ----------------------
++# how to check for library dependencies
++#  -- PORTME fill in with the dynamic library characteristics
++m4_defun([_LT_CHECK_MAGIC_METHOD],
++[m4_require([_LT_DECL_EGREP])
++m4_require([_LT_DECL_OBJDUMP])
++AC_CACHE_CHECK([how to recognize dependent libraries],
++lt_cv_deplibs_check_method,
++[lt_cv_file_magic_cmd='$MAGIC_CMD'
++lt_cv_file_magic_test_file=
++lt_cv_deplibs_check_method='unknown'
++# Need to set the preceding variable on all platforms that support
++# interlibrary dependencies.
++# 'none' -- dependencies not supported.
++# `unknown' -- same as none, but documents that we really don't know.
++# 'pass_all' -- all dependencies passed with no checks.
++# 'test_compile' -- check by making test program.
++# 'file_magic [[regex]]' -- check by looking for files in library path
++# which responds to the $file_magic_cmd with a given extended regex.
++# If you have `file' or equivalent on your system and you're not sure
++# whether `pass_all' will *always* work, you probably want this one.
++
++case $host_os in
++aix[[4-9]]*)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
++
++beos*)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
++
++bsdi[[45]]*)
++  lt_cv_deplibs_check_method='file_magic ELF [[0-9]][[0-9]]*-bit [[ML]]SB (shared object|dynamic lib)'
++  lt_cv_file_magic_cmd='/usr/bin/file -L'
++  lt_cv_file_magic_test_file=/shlib/libc.so
++  ;;
++
++cygwin*)
++  # func_win32_libid is a shell function defined in ltmain.sh
++  lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
++  lt_cv_file_magic_cmd='func_win32_libid'
++  ;;
++
++mingw* | pw32*)
++  # Base MSYS/MinGW do not provide the 'file' command needed by
++  # func_win32_libid shell function, so use a weaker test based on 'objdump',
++  # unless we find 'file', for example because we are cross-compiling.
++  # func_win32_libid assumes BSD nm, so disallow it if using MS dumpbin.
++  if ( test "$lt_cv_nm_interface" = "BSD nm" && file / ) >/dev/null 2>&1; then
++    lt_cv_deplibs_check_method='file_magic ^x86 archive import|^x86 DLL'
++    lt_cv_file_magic_cmd='func_win32_libid'
++  else
++    # Keep this pattern in sync with the one in func_win32_libid.
++    lt_cv_deplibs_check_method='file_magic file format (pei*-i386(.*architecture: i386)?|pe-arm-wince|pe-x86-64)'
++    lt_cv_file_magic_cmd='$OBJDUMP -f'
++  fi
++  ;;
++
++cegcc*)
++  # use the weaker test based on 'objdump'. See mingw*.
++  lt_cv_deplibs_check_method='file_magic file format pe-arm-.*little(.*architecture: arm)?'
++  lt_cv_file_magic_cmd='$OBJDUMP -f'
++  ;;
++
++darwin* | rhapsody*)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
++
++freebsd* | dragonfly*)
++  if echo __ELF__ | $CC -E - | $GREP __ELF__ > /dev/null; then
++    case $host_cpu in
++    i*86 )
++      # Not sure whether the presence of OpenBSD here was a mistake.
++      # Let's accept both of them until this is cleared up.
++      lt_cv_deplibs_check_method='file_magic (FreeBSD|OpenBSD|DragonFly)/i[[3-9]]86 (compact )?demand paged shared library'
++      lt_cv_file_magic_cmd=/usr/bin/file
++      lt_cv_file_magic_test_file=`echo /usr/lib/libc.so.*`
++      ;;
++    esac
++  else
++    lt_cv_deplibs_check_method=pass_all
++  fi
++  ;;
++
++haiku*)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
++
++hpux10.20* | hpux11*)
++  lt_cv_file_magic_cmd=/usr/bin/file
++  case $host_cpu in
++  ia64*)
++    lt_cv_deplibs_check_method='file_magic (s[[0-9]][[0-9]][[0-9]]|ELF-[[0-9]][[0-9]]) shared object file - IA64'
++    lt_cv_file_magic_test_file=/usr/lib/hpux32/libc.so
++    ;;
++  hppa*64*)
++    [lt_cv_deplibs_check_method='file_magic (s[0-9][0-9][0-9]|ELF[ -][0-9][0-9])(-bit)?( [LM]SB)? shared object( file)?[, -]* PA-RISC [0-9]\.[0-9]']
++    lt_cv_file_magic_test_file=/usr/lib/pa20_64/libc.sl
++    ;;
++  *)
++    lt_cv_deplibs_check_method='file_magic (s[[0-9]][[0-9]][[0-9]]|PA-RISC[[0-9]]\.[[0-9]]) shared library'
++    lt_cv_file_magic_test_file=/usr/lib/libc.sl
++    ;;
++  esac
++  ;;
++
++interix[[3-9]]*)
++  # PIC code is broken on Interix 3.x, that's why |\.a not |_pic\.a here
++  lt_cv_deplibs_check_method='match_pattern /lib[[^/]]+(\.so|\.a)$'
++  ;;
++
++irix5* | irix6* | nonstopux*)
++  case $LD in
++  *-32|*"-32 ") libmagic=32-bit;;
++  *-n32|*"-n32 ") libmagic=N32;;
++  *-64|*"-64 ") libmagic=64-bit;;
++  *) libmagic=never-match;;
++  esac
++  lt_cv_deplibs_check_method=pass_all
++  ;;
++
++# This must be glibc/ELF.
++linux* | k*bsd*-gnu | kopensolaris*-gnu | gnu*)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
++
++netbsd* | netbsdelf*-gnu)
++  if echo __ELF__ | $CC -E - | $GREP __ELF__ > /dev/null; then
++    lt_cv_deplibs_check_method='match_pattern /lib[[^/]]+(\.so\.[[0-9]]+\.[[0-9]]+|_pic\.a)$'
++  else
++    lt_cv_deplibs_check_method='match_pattern /lib[[^/]]+(\.so|_pic\.a)$'
++  fi
++  ;;
++
++newos6*)
++  lt_cv_deplibs_check_method='file_magic ELF [[0-9]][[0-9]]*-bit [[ML]]SB (executable|dynamic lib)'
++  lt_cv_file_magic_cmd=/usr/bin/file
++  lt_cv_file_magic_test_file=/usr/lib/libnls.so
++  ;;
++
++*nto* | *qnx*)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
++
++openbsd*)
++  if test -z "`echo __ELF__ | $CC -E - | $GREP __ELF__`" || test "$host_os-$host_cpu" = "openbsd2.8-powerpc"; then
++    lt_cv_deplibs_check_method='match_pattern /lib[[^/]]+(\.so\.[[0-9]]+\.[[0-9]]+|\.so|_pic\.a)$'
++  else
++    lt_cv_deplibs_check_method='match_pattern /lib[[^/]]+(\.so\.[[0-9]]+\.[[0-9]]+|_pic\.a)$'
++  fi
++  ;;
++
++osf3* | osf4* | osf5*)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
++
++rdos*)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
++
++solaris*)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
++
++sysv5* | sco3.2v5* | sco5v6* | unixware* | OpenUNIX* | sysv4*uw2*)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
++
++sysv4 | sysv4.3*)
++  case $host_vendor in
++  motorola)
++    lt_cv_deplibs_check_method='file_magic ELF [[0-9]][[0-9]]*-bit [[ML]]SB (shared object|dynamic lib) M[[0-9]][[0-9]]* Version [[0-9]]'
++    lt_cv_file_magic_test_file=`echo /usr/lib/libc.so*`
++    ;;
++  ncr)
++    lt_cv_deplibs_check_method=pass_all
++    ;;
++  sequent)
++    lt_cv_file_magic_cmd='/bin/file'
++    lt_cv_deplibs_check_method='file_magic ELF [[0-9]][[0-9]]*-bit [[LM]]SB (shared object|dynamic lib )'
++    ;;
++  sni)
++    lt_cv_file_magic_cmd='/bin/file'
++    lt_cv_deplibs_check_method="file_magic ELF [[0-9]][[0-9]]*-bit [[LM]]SB dynamic lib"
++    lt_cv_file_magic_test_file=/lib/libc.so
++    ;;
++  siemens)
++    lt_cv_deplibs_check_method=pass_all
++    ;;
++  pc)
++    lt_cv_deplibs_check_method=pass_all
++    ;;
++  esac
++  ;;
++
++tpf*)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
++esac
++])
++
++file_magic_glob=
++want_nocaseglob=no
++if test "$build" = "$host"; then
++  case $host_os in
++  mingw* | pw32*)
++    if ( shopt | grep nocaseglob ) >/dev/null 2>&1; then
++      want_nocaseglob=yes
++    else
++      file_magic_glob=`echo aAbBcCdDeEfFgGhHiIjJkKlLmMnNoOpPqQrRsStTuUvVwWxXyYzZ | $SED -e "s/\(..\)/s\/[[\1]]\/[[\1]]\/g;/g"`
++    fi
++    ;;
++  esac
++fi
++
++file_magic_cmd=$lt_cv_file_magic_cmd
++deplibs_check_method=$lt_cv_deplibs_check_method
++test -z "$deplibs_check_method" && deplibs_check_method=unknown
++
++_LT_DECL([], [deplibs_check_method], [1],
++    [Method to check whether dependent libraries are shared objects])
++_LT_DECL([], [file_magic_cmd], [1],
++    [Command to use when deplibs_check_method = "file_magic"])
++_LT_DECL([], [file_magic_glob], [1],
++    [How to find potential files when deplibs_check_method = "file_magic"])
++_LT_DECL([], [want_nocaseglob], [1],
++    [Find potential files using nocaseglob when deplibs_check_method = "file_magic"])
++])# _LT_CHECK_MAGIC_METHOD
++
++
++# LT_PATH_NM
++# ----------
++# find the pathname to a BSD- or MS-compatible name lister
++AC_DEFUN([LT_PATH_NM],
++[AC_REQUIRE([AC_PROG_CC])dnl
++AC_CACHE_CHECK([for BSD- or MS-compatible name lister (nm)], lt_cv_path_NM,
++[if test -n "$NM"; then
++  # Let the user override the test.
++  lt_cv_path_NM="$NM"
++else
++  lt_nm_to_check="${ac_tool_prefix}nm"
++  if test -n "$ac_tool_prefix" && test "$build" = "$host"; then
++    lt_nm_to_check="$lt_nm_to_check nm"
++  fi
++  for lt_tmp_nm in $lt_nm_to_check; do
++    lt_save_ifs="$IFS"; IFS=$PATH_SEPARATOR
++    for ac_dir in $PATH /usr/ccs/bin/elf /usr/ccs/bin /usr/ucb /bin; do
++      IFS="$lt_save_ifs"
++      test -z "$ac_dir" && ac_dir=.
++      tmp_nm="$ac_dir/$lt_tmp_nm"
++      if test -f "$tmp_nm" || test -f "$tmp_nm$ac_exeext" ; then
++	# Check to see if the nm accepts a BSD-compat flag.
++	# Adding the `sed 1q' prevents false positives on HP-UX, which says:
++	#   nm: unknown option "B" ignored
++	# Tru64's nm complains that /dev/null is an invalid object file
++	case `"$tmp_nm" -B /dev/null 2>&1 | sed '1q'` in
++	*/dev/null* | *'Invalid file or object type'*)
++	  lt_cv_path_NM="$tmp_nm -B"
++	  break
++	  ;;
++	*)
++	  case `"$tmp_nm" -p /dev/null 2>&1 | sed '1q'` in
++	  */dev/null*)
++	    lt_cv_path_NM="$tmp_nm -p"
++	    break
++	    ;;
++	  *)
++	    lt_cv_path_NM=${lt_cv_path_NM="$tmp_nm"} # keep the first match, but
++	    continue # so that we can try to find one that supports BSD flags
++	    ;;
++	  esac
++	  ;;
++	esac
++      fi
++    done
++    IFS="$lt_save_ifs"
++  done
++  : ${lt_cv_path_NM=no}
++fi])
++if test "$lt_cv_path_NM" != "no"; then
++  NM="$lt_cv_path_NM"
++else
++  # Didn't find any BSD compatible name lister, look for dumpbin.
++  if test -n "$DUMPBIN"; then :
++    # Let the user override the test.
++  else
++    AC_CHECK_TOOLS(DUMPBIN, [dumpbin "link -dump"], :)
++    case `$DUMPBIN -symbols /dev/null 2>&1 | sed '1q'` in
++    *COFF*)
++      DUMPBIN="$DUMPBIN -symbols"
++      ;;
++    *)
++      DUMPBIN=:
++      ;;
++    esac
++  fi
++  AC_SUBST([DUMPBIN])
++  if test "$DUMPBIN" != ":"; then
++    NM="$DUMPBIN"
++  fi
++fi
++test -z "$NM" && NM=nm
++AC_SUBST([NM])
++_LT_DECL([], [NM], [1], [A BSD- or MS-compatible name lister])dnl
++
++AC_CACHE_CHECK([the name lister ($NM) interface], [lt_cv_nm_interface],
++  [lt_cv_nm_interface="BSD nm"
++  echo "int some_variable = 0;" > conftest.$ac_ext
++  (eval echo "\"\$as_me:$LINENO: $ac_compile\"" >&AS_MESSAGE_LOG_FD)
++  (eval "$ac_compile" 2>conftest.err)
++  cat conftest.err >&AS_MESSAGE_LOG_FD
++  (eval echo "\"\$as_me:$LINENO: $NM \\\"conftest.$ac_objext\\\"\"" >&AS_MESSAGE_LOG_FD)
++  (eval "$NM \"conftest.$ac_objext\"" 2>conftest.err > conftest.out)
++  cat conftest.err >&AS_MESSAGE_LOG_FD
++  (eval echo "\"\$as_me:$LINENO: output\"" >&AS_MESSAGE_LOG_FD)
++  cat conftest.out >&AS_MESSAGE_LOG_FD
++  if $GREP 'External.*some_variable' conftest.out > /dev/null; then
++    lt_cv_nm_interface="MS dumpbin"
++  fi
++  rm -f conftest*])
++])# LT_PATH_NM
++
++# Old names:
++AU_ALIAS([AM_PROG_NM], [LT_PATH_NM])
++AU_ALIAS([AC_PROG_NM], [LT_PATH_NM])
++dnl aclocal-1.4 backwards compatibility:
++dnl AC_DEFUN([AM_PROG_NM], [])
++dnl AC_DEFUN([AC_PROG_NM], [])
++
++# _LT_CHECK_SHAREDLIB_FROM_LINKLIB
++# --------------------------------
++# how to determine the name of the shared library
++# associated with a specific link library.
++#  -- PORTME fill in with the dynamic library characteristics
++m4_defun([_LT_CHECK_SHAREDLIB_FROM_LINKLIB],
++[m4_require([_LT_DECL_EGREP])
++m4_require([_LT_DECL_OBJDUMP])
++m4_require([_LT_DECL_DLLTOOL])
++AC_CACHE_CHECK([how to associate runtime and link libraries],
++lt_cv_sharedlib_from_linklib_cmd,
++[lt_cv_sharedlib_from_linklib_cmd='unknown'
++
++case $host_os in
++cygwin* | mingw* | pw32* | cegcc*)
++  # two different shell functions defined in ltmain.sh
++  # decide which to use based on capabilities of $DLLTOOL
++  case `$DLLTOOL --help 2>&1` in
++  *--identify-strict*)
++    lt_cv_sharedlib_from_linklib_cmd=func_cygming_dll_for_implib
++    ;;
++  *)
++    lt_cv_sharedlib_from_linklib_cmd=func_cygming_dll_for_implib_fallback
++    ;;
++  esac
++  ;;
++*)
++  # fallback: assume linklib IS sharedlib
++  lt_cv_sharedlib_from_linklib_cmd="$ECHO"
++  ;;
++esac
++])
++sharedlib_from_linklib_cmd=$lt_cv_sharedlib_from_linklib_cmd
++test -z "$sharedlib_from_linklib_cmd" && sharedlib_from_linklib_cmd=$ECHO
++
++_LT_DECL([], [sharedlib_from_linklib_cmd], [1],
++    [Command to associate shared and link libraries])
++])# _LT_CHECK_SHAREDLIB_FROM_LINKLIB
++
++
++# _LT_PATH_MANIFEST_TOOL
++# ----------------------
++# locate the manifest tool
++m4_defun([_LT_PATH_MANIFEST_TOOL],
++[AC_CHECK_TOOL(MANIFEST_TOOL, mt, :)
++test -z "$MANIFEST_TOOL" && MANIFEST_TOOL=mt
++AC_CACHE_CHECK([if $MANIFEST_TOOL is a manifest tool], [lt_cv_path_mainfest_tool],
++  [lt_cv_path_mainfest_tool=no
++  echo "$as_me:$LINENO: $MANIFEST_TOOL '-?'" >&AS_MESSAGE_LOG_FD
++  $MANIFEST_TOOL '-?' 2>conftest.err > conftest.out
++  cat conftest.err >&AS_MESSAGE_LOG_FD
++  if $GREP 'Manifest Tool' conftest.out > /dev/null; then
++    lt_cv_path_mainfest_tool=yes
++  fi
++  rm -f conftest*])
++if test "x$lt_cv_path_mainfest_tool" != xyes; then
++  MANIFEST_TOOL=:
++fi
++_LT_DECL([], [MANIFEST_TOOL], [1], [Manifest tool])dnl
++])# _LT_PATH_MANIFEST_TOOL
++
++
++# LT_LIB_M
++# --------
++# check for math library
++AC_DEFUN([LT_LIB_M],
++[AC_REQUIRE([AC_CANONICAL_HOST])dnl
++LIBM=
++case $host in
++*-*-beos* | *-*-cegcc* | *-*-cygwin* | *-*-haiku* | *-*-pw32* | *-*-darwin*)
++  # These system don't have libm, or don't need it
++  ;;
++*-ncr-sysv4.3*)
++  AC_CHECK_LIB(mw, _mwvalidcheckl, LIBM="-lmw")
++  AC_CHECK_LIB(m, cos, LIBM="$LIBM -lm")
++  ;;
++*)
++  AC_CHECK_LIB(m, cos, LIBM="-lm")
++  ;;
++esac
++AC_SUBST([LIBM])
++])# LT_LIB_M
++
++# Old name:
++AU_ALIAS([AC_CHECK_LIBM], [LT_LIB_M])
++dnl aclocal-1.4 backwards compatibility:
++dnl AC_DEFUN([AC_CHECK_LIBM], [])
++
++
++# _LT_COMPILER_NO_RTTI([TAGNAME])
++# -------------------------------
++m4_defun([_LT_COMPILER_NO_RTTI],
++[m4_require([_LT_TAG_COMPILER])dnl
++
++_LT_TAGVAR(lt_prog_compiler_no_builtin_flag, $1)=
++
++if test "$GCC" = yes; then
++  case $cc_basename in
++  nvcc*)
++    _LT_TAGVAR(lt_prog_compiler_no_builtin_flag, $1)=' -Xcompiler -fno-builtin' ;;
++  *)
++    _LT_TAGVAR(lt_prog_compiler_no_builtin_flag, $1)=' -fno-builtin' ;;
++  esac
++
++  _LT_COMPILER_OPTION([if $compiler supports -fno-rtti -fno-exceptions],
++    lt_cv_prog_compiler_rtti_exceptions,
++    [-fno-rtti -fno-exceptions], [],
++    [_LT_TAGVAR(lt_prog_compiler_no_builtin_flag, $1)="$_LT_TAGVAR(lt_prog_compiler_no_builtin_flag, $1) -fno-rtti -fno-exceptions"])
++fi
++_LT_TAGDECL([no_builtin_flag], [lt_prog_compiler_no_builtin_flag], [1],
++	[Compiler flag to turn off builtin functions])
++])# _LT_COMPILER_NO_RTTI
++
++
++# _LT_CMD_GLOBAL_SYMBOLS
++# ----------------------
++m4_defun([_LT_CMD_GLOBAL_SYMBOLS],
++[AC_REQUIRE([AC_CANONICAL_HOST])dnl
++AC_REQUIRE([AC_PROG_CC])dnl
++AC_REQUIRE([AC_PROG_AWK])dnl
++AC_REQUIRE([LT_PATH_NM])dnl
++AC_REQUIRE([LT_PATH_LD])dnl
++m4_require([_LT_DECL_SED])dnl
++m4_require([_LT_DECL_EGREP])dnl
++m4_require([_LT_TAG_COMPILER])dnl
++
++# Check for command to grab the raw symbol name followed by C symbol from nm.
++AC_MSG_CHECKING([command to parse $NM output from $compiler object])
++AC_CACHE_VAL([lt_cv_sys_global_symbol_pipe],
++[
++# These are sane defaults that work on at least a few old systems.
++# [They come from Ultrix.  What could be older than Ultrix?!! ;)]
++
++# Character class describing NM global symbol codes.
++symcode='[[BCDEGRST]]'
++
++# Regexp to match symbols that can be accessed directly from C.
++sympat='\([[_A-Za-z]][[_A-Za-z0-9]]*\)'
++
++# Define system-specific variables.
++case $host_os in
++aix*)
++  symcode='[[BCDT]]'
++  ;;
++cygwin* | mingw* | pw32* | cegcc*)
++  symcode='[[ABCDGISTW]]'
++  ;;
++hpux*)
++  if test "$host_cpu" = ia64; then
++    symcode='[[ABCDEGRST]]'
++  fi
++  ;;
++irix* | nonstopux*)
++  symcode='[[BCDEGRST]]'
++  ;;
++osf*)
++  symcode='[[BCDEGQRST]]'
++  ;;
++solaris*)
++  symcode='[[BDRT]]'
++  ;;
++sco3.2v5*)
++  symcode='[[DT]]'
++  ;;
++sysv4.2uw2*)
++  symcode='[[DT]]'
++  ;;
++sysv5* | sco5v6* | unixware* | OpenUNIX*)
++  symcode='[[ABDT]]'
++  ;;
++sysv4)
++  symcode='[[DFNSTU]]'
++  ;;
++esac
++
++# If we're using GNU nm, then use its standard symbol codes.
++case `$NM -V 2>&1` in
++*GNU* | *'with BFD'*)
++  symcode='[[ABCDGIRSTW]]' ;;
++esac
++
++# Transform an extracted symbol line into a proper C declaration.
++# Some systems (esp. on ia64) link data and code symbols differently,
++# so use this general approach.
++lt_cv_sys_global_symbol_to_cdecl="sed -n -e 's/^T .* \(.*\)$/extern int \1();/p' -e 's/^$symcode* .* \(.*\)$/extern char \1;/p'"
++
++# Transform an extracted symbol line into symbol name and symbol address
++lt_cv_sys_global_symbol_to_c_name_address="sed -n -e 's/^: \([[^ ]]*\)[[ ]]*$/  {\\\"\1\\\", (void *) 0},/p' -e 's/^$symcode* \([[^ ]]*\) \([[^ ]]*\)$/  {\"\2\", (void *) \&\2},/p'"
++lt_cv_sys_global_symbol_to_c_name_address_lib_prefix="sed -n -e 's/^: \([[^ ]]*\)[[ ]]*$/  {\\\"\1\\\", (void *) 0},/p' -e 's/^$symcode* \([[^ ]]*\) \(lib[[^ ]]*\)$/  {\"\2\", (void *) \&\2},/p' -e 's/^$symcode* \([[^ ]]*\) \([[^ ]]*\)$/  {\"lib\2\", (void *) \&\2},/p'"
++
++# Handle CRLF in mingw tool chain
++opt_cr=
++case $build_os in
++mingw*)
++  opt_cr=`$ECHO 'x\{0,1\}' | tr x '\015'` # option cr in regexp
++  ;;
++esac
++
++# Try without a prefix underscore, then with it.
++for ac_symprfx in "" "_"; do
++
++  # Transform symcode, sympat, and symprfx into a raw symbol and a C symbol.
++  symxfrm="\\1 $ac_symprfx\\2 \\2"
++
++  # Write the raw and C identifiers.
++  if test "$lt_cv_nm_interface" = "MS dumpbin"; then
++    # Fake it for dumpbin and say T for any non-static function
++    # and D for any global variable.
++    # Also find C++ and __fastcall symbols from MSVC++,
++    # which start with @ or ?.
++    lt_cv_sys_global_symbol_pipe="$AWK ['"\
++"     {last_section=section; section=\$ 3};"\
++"     /^COFF SYMBOL TABLE/{for(i in hide) delete hide[i]};"\
++"     /Section length .*#relocs.*(pick any)/{hide[last_section]=1};"\
++"     \$ 0!~/External *\|/{next};"\
++"     / 0+ UNDEF /{next}; / UNDEF \([^|]\)*()/{next};"\
++"     {if(hide[section]) next};"\
++"     {f=0}; \$ 0~/\(\).*\|/{f=1}; {printf f ? \"T \" : \"D \"};"\
++"     {split(\$ 0, a, /\||\r/); split(a[2], s)};"\
++"     s[1]~/^[@?]/{print s[1], s[1]; next};"\
++"     s[1]~prfx {split(s[1],t,\"@\"); print t[1], substr(t[1],length(prfx))}"\
++"     ' prfx=^$ac_symprfx]"
++  else
++    lt_cv_sys_global_symbol_pipe="sed -n -e 's/^.*[[	 ]]\($symcode$symcode*\)[[	 ]][[	 ]]*$ac_symprfx$sympat$opt_cr$/$symxfrm/p'"
++  fi
++  lt_cv_sys_global_symbol_pipe="$lt_cv_sys_global_symbol_pipe | sed '/ __gnu_lto/d'"
++
++  # Check to see that the pipe works correctly.
++  pipe_works=no
++
++  rm -f conftest*
++  cat > conftest.$ac_ext <<_LT_EOF
++#ifdef __cplusplus
++extern "C" {
++#endif
++char nm_test_var;
++void nm_test_func(void);
++void nm_test_func(void){}
++#ifdef __cplusplus
++}
++#endif
++int main(){nm_test_var='a';nm_test_func();return(0);}
++_LT_EOF
++
++  if AC_TRY_EVAL(ac_compile); then
++    # Now try to grab the symbols.
++    nlist=conftest.nm
++    if AC_TRY_EVAL(NM conftest.$ac_objext \| "$lt_cv_sys_global_symbol_pipe" \> $nlist) && test -s "$nlist"; then
++      # Try sorting and uniquifying the output.
++      if sort "$nlist" | uniq > "$nlist"T; then
++	mv -f "$nlist"T "$nlist"
++      else
++	rm -f "$nlist"T
++      fi
++
++      # Make sure that we snagged all the symbols we need.
++      if $GREP ' nm_test_var$' "$nlist" >/dev/null; then
++	if $GREP ' nm_test_func$' "$nlist" >/dev/null; then
++	  cat <<_LT_EOF > conftest.$ac_ext
++/* Keep this code in sync between libtool.m4, ltmain, lt_system.h, and tests.  */
++#if defined(_WIN32) || defined(__CYGWIN__) || defined(_WIN32_WCE)
++/* DATA imports from DLLs on WIN32 con't be const, because runtime
++   relocations are performed -- see ld's documentation on pseudo-relocs.  */
++# define LT@&t@_DLSYM_CONST
++#elif defined(__osf__)
++/* This system does not cope well with relocations in const data.  */
++# define LT@&t@_DLSYM_CONST
++#else
++# define LT@&t@_DLSYM_CONST const
++#endif
++
++#ifdef __cplusplus
++extern "C" {
++#endif
++
++_LT_EOF
++	  # Now generate the symbol file.
++	  eval "$lt_cv_sys_global_symbol_to_cdecl"' < "$nlist" | $GREP -v main >> conftest.$ac_ext'
++
++	  cat <<_LT_EOF >> conftest.$ac_ext
++
++/* The mapping between symbol names and symbols.  */
++LT@&t@_DLSYM_CONST struct {
++  const char *name;
++  void       *address;
++}
++lt__PROGRAM__LTX_preloaded_symbols[[]] =
++{
++  { "@PROGRAM@", (void *) 0 },
++_LT_EOF
++	  $SED "s/^$symcode$symcode* \(.*\) \(.*\)$/  {\"\2\", (void *) \&\2},/" < "$nlist" | $GREP -v main >> conftest.$ac_ext
++	  cat <<\_LT_EOF >> conftest.$ac_ext
++  {0, (void *) 0}
++};
++
++/* This works around a problem in FreeBSD linker */
++#ifdef FREEBSD_WORKAROUND
++static const void *lt_preloaded_setup() {
++  return lt__PROGRAM__LTX_preloaded_symbols;
++}
++#endif
++
++#ifdef __cplusplus
++}
++#endif
++_LT_EOF
++	  # Now try linking the two files.
++	  mv conftest.$ac_objext conftstm.$ac_objext
++	  lt_globsym_save_LIBS=$LIBS
++	  lt_globsym_save_CFLAGS=$CFLAGS
++	  LIBS="conftstm.$ac_objext"
++	  CFLAGS="$CFLAGS$_LT_TAGVAR(lt_prog_compiler_no_builtin_flag, $1)"
++	  if AC_TRY_EVAL(ac_link) && test -s conftest${ac_exeext}; then
++	    pipe_works=yes
++	  fi
++	  LIBS=$lt_globsym_save_LIBS
++	  CFLAGS=$lt_globsym_save_CFLAGS
++	else
++	  echo "cannot find nm_test_func in $nlist" >&AS_MESSAGE_LOG_FD
++	fi
++      else
++	echo "cannot find nm_test_var in $nlist" >&AS_MESSAGE_LOG_FD
++      fi
++    else
++      echo "cannot run $lt_cv_sys_global_symbol_pipe" >&AS_MESSAGE_LOG_FD
++    fi
++  else
++    echo "$progname: failed program was:" >&AS_MESSAGE_LOG_FD
++    cat conftest.$ac_ext >&5
++  fi
++  rm -rf conftest* conftst*
++
++  # Do not use the global_symbol_pipe unless it works.
++  if test "$pipe_works" = yes; then
++    break
++  else
++    lt_cv_sys_global_symbol_pipe=
++  fi
++done
++])
++if test -z "$lt_cv_sys_global_symbol_pipe"; then
++  lt_cv_sys_global_symbol_to_cdecl=
++fi
++if test -z "$lt_cv_sys_global_symbol_pipe$lt_cv_sys_global_symbol_to_cdecl"; then
++  AC_MSG_RESULT(failed)
++else
++  AC_MSG_RESULT(ok)
++fi
++
++# Response file support.
++if test "$lt_cv_nm_interface" = "MS dumpbin"; then
++  nm_file_list_spec='@'
++elif $NM --help 2>/dev/null | grep '[[@]]FILE' >/dev/null; then
++  nm_file_list_spec='@'
++fi
++
++_LT_DECL([global_symbol_pipe], [lt_cv_sys_global_symbol_pipe], [1],
++    [Take the output of nm and produce a listing of raw symbols and C names])
++_LT_DECL([global_symbol_to_cdecl], [lt_cv_sys_global_symbol_to_cdecl], [1],
++    [Transform the output of nm in a proper C declaration])
++_LT_DECL([global_symbol_to_c_name_address],
++    [lt_cv_sys_global_symbol_to_c_name_address], [1],
++    [Transform the output of nm in a C name address pair])
++_LT_DECL([global_symbol_to_c_name_address_lib_prefix],
++    [lt_cv_sys_global_symbol_to_c_name_address_lib_prefix], [1],
++    [Transform the output of nm in a C name address pair when lib prefix is needed])
++_LT_DECL([], [nm_file_list_spec], [1],
++    [Specify filename containing input files for $NM])
++]) # _LT_CMD_GLOBAL_SYMBOLS
++
++
++# _LT_COMPILER_PIC([TAGNAME])
++# ---------------------------
++m4_defun([_LT_COMPILER_PIC],
++[m4_require([_LT_TAG_COMPILER])dnl
++_LT_TAGVAR(lt_prog_compiler_wl, $1)=
++_LT_TAGVAR(lt_prog_compiler_pic, $1)=
++_LT_TAGVAR(lt_prog_compiler_static, $1)=
++
++m4_if([$1], [CXX], [
++  # C++ specific cases for pic, static, wl, etc.
++  if test "$GXX" = yes; then
++    _LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,'
++    _LT_TAGVAR(lt_prog_compiler_static, $1)='-static'
++
++    case $host_os in
++    aix*)
++      # All AIX code is PIC.
++      if test "$host_cpu" = ia64; then
++	# AIX 5 now supports IA64 processor
++	_LT_TAGVAR(lt_prog_compiler_static, $1)='-Bstatic'
++      fi
++      ;;
++
++    amigaos*)
++      case $host_cpu in
++      powerpc)
++            # see comment about AmigaOS4 .so support
++            _LT_TAGVAR(lt_prog_compiler_pic, $1)='-fPIC'
++        ;;
++      m68k)
++            # FIXME: we need at least 68020 code to build shared libraries, but
++            # adding the `-m68020' flag to GCC prevents building anything better,
++            # like `-m68040'.
++            _LT_TAGVAR(lt_prog_compiler_pic, $1)='-m68020 -resident32 -malways-restore-a4'
++        ;;
++      esac
++      ;;
++
++    beos* | irix5* | irix6* | nonstopux* | osf3* | osf4* | osf5*)
++      # PIC is the default for these OSes.
++      ;;
++    mingw* | cygwin* | os2* | pw32* | cegcc*)
++      # This hack is so that the source file can tell whether it is being
++      # built for inclusion in a dll (and should export symbols for example).
++      # Although the cygwin gcc ignores -fPIC, still need this for old-style
++      # (--disable-auto-import) libraries
++      m4_if([$1], [GCJ], [],
++	[_LT_TAGVAR(lt_prog_compiler_pic, $1)='-DDLL_EXPORT'])
++      ;;
++    darwin* | rhapsody*)
++      # PIC is the default on this platform
++      # Common symbols not allowed in MH_DYLIB files
++      _LT_TAGVAR(lt_prog_compiler_pic, $1)='-fno-common'
++      ;;
++    *djgpp*)
++      # DJGPP does not support shared libraries at all
++      _LT_TAGVAR(lt_prog_compiler_pic, $1)=
++      ;;
++    haiku*)
++      # PIC is the default for Haiku.
++      # The "-static" flag exists, but is broken.
++      _LT_TAGVAR(lt_prog_compiler_static, $1)=
++      ;;
++    interix[[3-9]]*)
++      # Interix 3.x gcc -fpic/-fPIC options generate broken code.
++      # Instead, we relocate shared libraries at runtime.
++      ;;
++    sysv4*MP*)
++      if test -d /usr/nec; then
++	_LT_TAGVAR(lt_prog_compiler_pic, $1)=-Kconform_pic
++      fi
++      ;;
++    hpux*)
++      # PIC is the default for 64-bit PA HP-UX, but not for 32-bit
++      # PA HP-UX.  On IA64 HP-UX, PIC is the default but the pic flag
++      # sets the default TLS model and affects inlining.
++      case $host_cpu in
++      hppa*64*)
++	;;
++      *)
++	_LT_TAGVAR(lt_prog_compiler_pic, $1)='-fPIC'
++	;;
++      esac
++      ;;
++    *qnx* | *nto*)
++      # QNX uses GNU C++, but need to define -shared option too, otherwise
++      # it will coredump.
++      _LT_TAGVAR(lt_prog_compiler_pic, $1)='-fPIC -shared'
++      ;;
++    *)
++      _LT_TAGVAR(lt_prog_compiler_pic, $1)='-fPIC'
++      ;;
++    esac
++  else
++    case $host_os in
++      aix[[4-9]]*)
++	# All AIX code is PIC.
++	if test "$host_cpu" = ia64; then
++	  # AIX 5 now supports IA64 processor
++	  _LT_TAGVAR(lt_prog_compiler_static, $1)='-Bstatic'
++	else
++	  _LT_TAGVAR(lt_prog_compiler_static, $1)='-bnso -bI:/lib/syscalls.exp'
++	fi
++	;;
++      chorus*)
++	case $cc_basename in
++	cxch68*)
++	  # Green Hills C++ Compiler
++	  # _LT_TAGVAR(lt_prog_compiler_static, $1)="--no_auto_instantiation -u __main -u __premain -u _abort -r $COOL_DIR/lib/libOrb.a $MVME_DIR/lib/CC/libC.a $MVME_DIR/lib/classix/libcx.s.a"
++	  ;;
++	esac
++	;;
++      mingw* | cygwin* | os2* | pw32* | cegcc*)
++	# This hack is so that the source file can tell whether it is being
++	# built for inclusion in a dll (and should export symbols for example).
++	m4_if([$1], [GCJ], [],
++	  [_LT_TAGVAR(lt_prog_compiler_pic, $1)='-DDLL_EXPORT'])
++	;;
++      dgux*)
++	case $cc_basename in
++	  ec++*)
++	    _LT_TAGVAR(lt_prog_compiler_pic, $1)='-KPIC'
++	    ;;
++	  ghcx*)
++	    # Green Hills C++ Compiler
++	    _LT_TAGVAR(lt_prog_compiler_pic, $1)='-pic'
++	    ;;
++	  *)
++	    ;;
++	esac
++	;;
++      freebsd* | dragonfly*)
++	# FreeBSD uses GNU C++
++	;;
++      hpux9* | hpux10* | hpux11*)
++	case $cc_basename in
++	  CC*)
++	    _LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,'
++	    _LT_TAGVAR(lt_prog_compiler_static, $1)='${wl}-a ${wl}archive'
++	    if test "$host_cpu" != ia64; then
++	      _LT_TAGVAR(lt_prog_compiler_pic, $1)='+Z'
++	    fi
++	    ;;
++	  aCC*)
++	    _LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,'
++	    _LT_TAGVAR(lt_prog_compiler_static, $1)='${wl}-a ${wl}archive'
++	    case $host_cpu in
++	    hppa*64*|ia64*)
++	      # +Z the default
++	      ;;
++	    *)
++	      _LT_TAGVAR(lt_prog_compiler_pic, $1)='+Z'
++	      ;;
++	    esac
++	    ;;
++	  *)
++	    ;;
++	esac
++	;;
++      interix*)
++	# This is c89, which is MS Visual C++ (no shared libs)
++	# Anyone wants to do a port?
++	;;
++      irix5* | irix6* | nonstopux*)
++	case $cc_basename in
++	  CC*)
++	    _LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,'
++	    _LT_TAGVAR(lt_prog_compiler_static, $1)='-non_shared'
++	    # CC pic flag -KPIC is the default.
++	    ;;
++	  *)
++	    ;;
++	esac
++	;;
++      linux* | k*bsd*-gnu | kopensolaris*-gnu | gnu*)
++	case $cc_basename in
++	  KCC*)
++	    # KAI C++ Compiler
++	    _LT_TAGVAR(lt_prog_compiler_wl, $1)='--backend -Wl,'
++	    _LT_TAGVAR(lt_prog_compiler_pic, $1)='-fPIC'
++	    ;;
++	  ecpc* )
++	    # old Intel C++ for x86_64 which still supported -KPIC.
++	    _LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,'
++	    _LT_TAGVAR(lt_prog_compiler_pic, $1)='-KPIC'
++	    _LT_TAGVAR(lt_prog_compiler_static, $1)='-static'
++	    ;;
++	  icpc* )
++	    # Intel C++, used to be incompatible with GCC.
++	    # ICC 10 doesn't accept -KPIC any more.
++	    _LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,'
++	    _LT_TAGVAR(lt_prog_compiler_pic, $1)='-fPIC'
++	    _LT_TAGVAR(lt_prog_compiler_static, $1)='-static'
++	    ;;
++	  pgCC* | pgcpp*)
++	    # Portland Group C++ compiler
++	    _LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,'
++	    _LT_TAGVAR(lt_prog_compiler_pic, $1)='-fpic'
++	    _LT_TAGVAR(lt_prog_compiler_static, $1)='-Bstatic'
++	    ;;
++	  cxx*)
++	    # Compaq C++
++	    # Make sure the PIC flag is empty.  It appears that all Alpha
++	    # Linux and Compaq Tru64 Unix objects are PIC.
++	    _LT_TAGVAR(lt_prog_compiler_pic, $1)=
++	    _LT_TAGVAR(lt_prog_compiler_static, $1)='-non_shared'
++	    ;;
++	  xlc* | xlC* | bgxl[[cC]]* | mpixl[[cC]]*)
++	    # IBM XL 8.0, 9.0 on PPC and BlueGene
++	    _LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,'
++	    _LT_TAGVAR(lt_prog_compiler_pic, $1)='-qpic'
++	    _LT_TAGVAR(lt_prog_compiler_static, $1)='-qstaticlink'
++	    ;;
++	  *)
++	    case `$CC -V 2>&1 | sed 5q` in
++	    *Sun\ C*)
++	      # Sun C++ 5.9
++	      _LT_TAGVAR(lt_prog_compiler_pic, $1)='-KPIC'
++	      _LT_TAGVAR(lt_prog_compiler_static, $1)='-Bstatic'
++	      _LT_TAGVAR(lt_prog_compiler_wl, $1)='-Qoption ld '
++	      ;;
++	    esac
++	    ;;
++	esac
++	;;
++      lynxos*)
++	;;
++      m88k*)
++	;;
++      mvs*)
++	case $cc_basename in
++	  cxx*)
++	    _LT_TAGVAR(lt_prog_compiler_pic, $1)='-W c,exportall'
++	    ;;
++	  *)
++	    ;;
++	esac
++	;;
++      netbsd* | netbsdelf*-gnu)
++	;;
++      *qnx* | *nto*)
++        # QNX uses GNU C++, but need to define -shared option too, otherwise
++        # it will coredump.
++        _LT_TAGVAR(lt_prog_compiler_pic, $1)='-fPIC -shared'
++        ;;
++      osf3* | osf4* | osf5*)
++	case $cc_basename in
++	  KCC*)
++	    _LT_TAGVAR(lt_prog_compiler_wl, $1)='--backend -Wl,'
++	    ;;
++	  RCC*)
++	    # Rational C++ 2.4.1
++	    _LT_TAGVAR(lt_prog_compiler_pic, $1)='-pic'
++	    ;;
++	  cxx*)
++	    # Digital/Compaq C++
++	    _LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,'
++	    # Make sure the PIC flag is empty.  It appears that all Alpha
++	    # Linux and Compaq Tru64 Unix objects are PIC.
++	    _LT_TAGVAR(lt_prog_compiler_pic, $1)=
++	    _LT_TAGVAR(lt_prog_compiler_static, $1)='-non_shared'
++	    ;;
++	  *)
++	    ;;
++	esac
++	;;
++      psos*)
++	;;
++      solaris*)
++	case $cc_basename in
++	  CC* | sunCC*)
++	    # Sun C++ 4.2, 5.x and Centerline C++
++	    _LT_TAGVAR(lt_prog_compiler_pic, $1)='-KPIC'
++	    _LT_TAGVAR(lt_prog_compiler_static, $1)='-Bstatic'
++	    _LT_TAGVAR(lt_prog_compiler_wl, $1)='-Qoption ld '
++	    ;;
++	  gcx*)
++	    # Green Hills C++ Compiler
++	    _LT_TAGVAR(lt_prog_compiler_pic, $1)='-PIC'
++	    ;;
++	  *)
++	    ;;
++	esac
++	;;
++      sunos4*)
++	case $cc_basename in
++	  CC*)
++	    # Sun C++ 4.x
++	    _LT_TAGVAR(lt_prog_compiler_pic, $1)='-pic'
++	    _LT_TAGVAR(lt_prog_compiler_static, $1)='-Bstatic'
++	    ;;
++	  lcc*)
++	    # Lucid
++	    _LT_TAGVAR(lt_prog_compiler_pic, $1)='-pic'
++	    ;;
++	  *)
++	    ;;
++	esac
++	;;
++      sysv5* | unixware* | sco3.2v5* | sco5v6* | OpenUNIX*)
++	case $cc_basename in
++	  CC*)
++	    _LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,'
++	    _LT_TAGVAR(lt_prog_compiler_pic, $1)='-KPIC'
++	    _LT_TAGVAR(lt_prog_compiler_static, $1)='-Bstatic'
++	    ;;
++	esac
++	;;
++      tandem*)
++	case $cc_basename in
++	  NCC*)
++	    # NonStop-UX NCC 3.20
++	    _LT_TAGVAR(lt_prog_compiler_pic, $1)='-KPIC'
++	    ;;
++	  *)
++	    ;;
++	esac
++	;;
++      vxworks*)
++	;;
++      *)
++	_LT_TAGVAR(lt_prog_compiler_can_build_shared, $1)=no
++	;;
++    esac
++  fi
++],
++[
++  if test "$GCC" = yes; then
++    _LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,'
++    _LT_TAGVAR(lt_prog_compiler_static, $1)='-static'
++
++    case $host_os in
++      aix*)
++      # All AIX code is PIC.
++      if test "$host_cpu" = ia64; then
++	# AIX 5 now supports IA64 processor
++	_LT_TAGVAR(lt_prog_compiler_static, $1)='-Bstatic'
++      fi
++      ;;
++
++    amigaos*)
++      case $host_cpu in
++      powerpc)
++            # see comment about AmigaOS4 .so support
++            _LT_TAGVAR(lt_prog_compiler_pic, $1)='-fPIC'
++        ;;
++      m68k)
++            # FIXME: we need at least 68020 code to build shared libraries, but
++            # adding the `-m68020' flag to GCC prevents building anything better,
++            # like `-m68040'.
++            _LT_TAGVAR(lt_prog_compiler_pic, $1)='-m68020 -resident32 -malways-restore-a4'
++        ;;
++      esac
++      ;;
++
++    beos* | irix5* | irix6* | nonstopux* | osf3* | osf4* | osf5*)
++      # PIC is the default for these OSes.
++      ;;
++
++    mingw* | cygwin* | pw32* | os2* | cegcc*)
++      # This hack is so that the source file can tell whether it is being
++      # built for inclusion in a dll (and should export symbols for example).
++      # Although the cygwin gcc ignores -fPIC, still need this for old-style
++      # (--disable-auto-import) libraries
++      m4_if([$1], [GCJ], [],
++	[_LT_TAGVAR(lt_prog_compiler_pic, $1)='-DDLL_EXPORT'])
++      ;;
++
++    darwin* | rhapsody*)
++      # PIC is the default on this platform
++      # Common symbols not allowed in MH_DYLIB files
++      _LT_TAGVAR(lt_prog_compiler_pic, $1)='-fno-common'
++      ;;
++
++    haiku*)
++      # PIC is the default for Haiku.
++      # The "-static" flag exists, but is broken.
++      _LT_TAGVAR(lt_prog_compiler_static, $1)=
++      ;;
++
++    hpux*)
++      # PIC is the default for 64-bit PA HP-UX, but not for 32-bit
++      # PA HP-UX.  On IA64 HP-UX, PIC is the default but the pic flag
++      # sets the default TLS model and affects inlining.
++      case $host_cpu in
++      hppa*64*)
++	# +Z the default
++	;;
++      *)
++	_LT_TAGVAR(lt_prog_compiler_pic, $1)='-fPIC'
++	;;
++      esac
++      ;;
++
++    interix[[3-9]]*)
++      # Interix 3.x gcc -fpic/-fPIC options generate broken code.
++      # Instead, we relocate shared libraries at runtime.
++      ;;
++
++    msdosdjgpp*)
++      # Just because we use GCC doesn't mean we suddenly get shared libraries
++      # on systems that don't support them.
++      _LT_TAGVAR(lt_prog_compiler_can_build_shared, $1)=no
++      enable_shared=no
++      ;;
++
++    *nto* | *qnx*)
++      # QNX uses GNU C++, but need to define -shared option too, otherwise
++      # it will coredump.
++      _LT_TAGVAR(lt_prog_compiler_pic, $1)='-fPIC -shared'
++      ;;
++
++    sysv4*MP*)
++      if test -d /usr/nec; then
++	_LT_TAGVAR(lt_prog_compiler_pic, $1)=-Kconform_pic
++      fi
++      ;;
++
++    *)
++      _LT_TAGVAR(lt_prog_compiler_pic, $1)='-fPIC'
++      ;;
++    esac
++
++    case $cc_basename in
++    nvcc*) # Cuda Compiler Driver 2.2
++      _LT_TAGVAR(lt_prog_compiler_wl, $1)='-Xlinker '
++      if test -n "$_LT_TAGVAR(lt_prog_compiler_pic, $1)"; then
++        _LT_TAGVAR(lt_prog_compiler_pic, $1)="-Xcompiler $_LT_TAGVAR(lt_prog_compiler_pic, $1)"
++      fi
++      ;;
++    esac
++  else
++    # PORTME Check for flag to pass linker flags through the system compiler.
++    case $host_os in
++    aix*)
++      _LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,'
++      if test "$host_cpu" = ia64; then
++	# AIX 5 now supports IA64 processor
++	_LT_TAGVAR(lt_prog_compiler_static, $1)='-Bstatic'
++      else
++	_LT_TAGVAR(lt_prog_compiler_static, $1)='-bnso -bI:/lib/syscalls.exp'
++      fi
++      ;;
++
++    mingw* | cygwin* | pw32* | os2* | cegcc*)
++      # This hack is so that the source file can tell whether it is being
++      # built for inclusion in a dll (and should export symbols for example).
++      m4_if([$1], [GCJ], [],
++	[_LT_TAGVAR(lt_prog_compiler_pic, $1)='-DDLL_EXPORT'])
++      ;;
++
++    hpux9* | hpux10* | hpux11*)
++      _LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,'
++      # PIC is the default for IA64 HP-UX and 64-bit HP-UX, but
++      # not for PA HP-UX.
++      case $host_cpu in
++      hppa*64*|ia64*)
++	# +Z the default
++	;;
++      *)
++	_LT_TAGVAR(lt_prog_compiler_pic, $1)='+Z'
++	;;
++      esac
++      # Is there a better lt_prog_compiler_static that works with the bundled CC?
++      _LT_TAGVAR(lt_prog_compiler_static, $1)='${wl}-a ${wl}archive'
++      ;;
++
++    irix5* | irix6* | nonstopux*)
++      _LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,'
++      # PIC (with -KPIC) is the default.
++      _LT_TAGVAR(lt_prog_compiler_static, $1)='-non_shared'
++      ;;
++
++    linux* | k*bsd*-gnu | kopensolaris*-gnu | gnu*)
++      case $cc_basename in
++      # old Intel for x86_64 which still supported -KPIC.
++      ecc*)
++	_LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,'
++	_LT_TAGVAR(lt_prog_compiler_pic, $1)='-KPIC'
++	_LT_TAGVAR(lt_prog_compiler_static, $1)='-static'
++        ;;
++      # icc used to be incompatible with GCC.
++      # ICC 10 doesn't accept -KPIC any more.
++      icc* | ifort*)
++	_LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,'
++	_LT_TAGVAR(lt_prog_compiler_pic, $1)='-fPIC'
++	_LT_TAGVAR(lt_prog_compiler_static, $1)='-static'
++        ;;
++      # Lahey Fortran 8.1.
++      lf95*)
++	_LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,'
++	_LT_TAGVAR(lt_prog_compiler_pic, $1)='--shared'
++	_LT_TAGVAR(lt_prog_compiler_static, $1)='--static'
++	;;
++      nagfor*)
++	# NAG Fortran compiler
++	_LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,-Wl,,'
++	_LT_TAGVAR(lt_prog_compiler_pic, $1)='-PIC'
++	_LT_TAGVAR(lt_prog_compiler_static, $1)='-Bstatic'
++	;;
++      pgcc* | pgf77* | pgf90* | pgf95* | pgfortran*)
++        # Portland Group compilers (*not* the Pentium gcc compiler,
++	# which looks to be a dead project)
++	_LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,'
++	_LT_TAGVAR(lt_prog_compiler_pic, $1)='-fpic'
++	_LT_TAGVAR(lt_prog_compiler_static, $1)='-Bstatic'
++        ;;
++      ccc*)
++        _LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,'
++        # All Alpha code is PIC.
++        _LT_TAGVAR(lt_prog_compiler_static, $1)='-non_shared'
++        ;;
++      xl* | bgxl* | bgf* | mpixl*)
++	# IBM XL C 8.0/Fortran 10.1, 11.1 on PPC and BlueGene
++	_LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,'
++	_LT_TAGVAR(lt_prog_compiler_pic, $1)='-qpic'
++	_LT_TAGVAR(lt_prog_compiler_static, $1)='-qstaticlink'
++	;;
++      *)
++	case `$CC -V 2>&1 | sed 5q` in
++	*Sun\ Ceres\ Fortran* | *Sun*Fortran*\ [[1-7]].* | *Sun*Fortran*\ 8.[[0-3]]*)
++	  # Sun Fortran 8.3 passes all unrecognized flags to the linker
++	  _LT_TAGVAR(lt_prog_compiler_pic, $1)='-KPIC'
++	  _LT_TAGVAR(lt_prog_compiler_static, $1)='-Bstatic'
++	  _LT_TAGVAR(lt_prog_compiler_wl, $1)=''
++	  ;;
++	*Sun\ F* | *Sun*Fortran*)
++	  _LT_TAGVAR(lt_prog_compiler_pic, $1)='-KPIC'
++	  _LT_TAGVAR(lt_prog_compiler_static, $1)='-Bstatic'
++	  _LT_TAGVAR(lt_prog_compiler_wl, $1)='-Qoption ld '
++	  ;;
++	*Sun\ C*)
++	  # Sun C 5.9
++	  _LT_TAGVAR(lt_prog_compiler_pic, $1)='-KPIC'
++	  _LT_TAGVAR(lt_prog_compiler_static, $1)='-Bstatic'
++	  _LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,'
++	  ;;
++        *Intel*\ [[CF]]*Compiler*)
++	  _LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,'
++	  _LT_TAGVAR(lt_prog_compiler_pic, $1)='-fPIC'
++	  _LT_TAGVAR(lt_prog_compiler_static, $1)='-static'
++	  ;;
++	*Portland\ Group*)
++	  _LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,'
++	  _LT_TAGVAR(lt_prog_compiler_pic, $1)='-fpic'
++	  _LT_TAGVAR(lt_prog_compiler_static, $1)='-Bstatic'
++	  ;;
++	esac
++	;;
++      esac
++      ;;
++
++    newsos6)
++      _LT_TAGVAR(lt_prog_compiler_pic, $1)='-KPIC'
++      _LT_TAGVAR(lt_prog_compiler_static, $1)='-Bstatic'
++      ;;
++
++    *nto* | *qnx*)
++      # QNX uses GNU C++, but need to define -shared option too, otherwise
++      # it will coredump.
++      _LT_TAGVAR(lt_prog_compiler_pic, $1)='-fPIC -shared'
++      ;;
++
++    osf3* | osf4* | osf5*)
++      _LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,'
++      # All OSF/1 code is PIC.
++      _LT_TAGVAR(lt_prog_compiler_static, $1)='-non_shared'
++      ;;
++
++    rdos*)
++      _LT_TAGVAR(lt_prog_compiler_static, $1)='-non_shared'
++      ;;
++
++    solaris*)
++      _LT_TAGVAR(lt_prog_compiler_pic, $1)='-KPIC'
++      _LT_TAGVAR(lt_prog_compiler_static, $1)='-Bstatic'
++      case $cc_basename in
++      f77* | f90* | f95* | sunf77* | sunf90* | sunf95*)
++	_LT_TAGVAR(lt_prog_compiler_wl, $1)='-Qoption ld ';;
++      *)
++	_LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,';;
++      esac
++      ;;
++
++    sunos4*)
++      _LT_TAGVAR(lt_prog_compiler_wl, $1)='-Qoption ld '
++      _LT_TAGVAR(lt_prog_compiler_pic, $1)='-PIC'
++      _LT_TAGVAR(lt_prog_compiler_static, $1)='-Bstatic'
++      ;;
++
++    sysv4 | sysv4.2uw2* | sysv4.3*)
++      _LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,'
++      _LT_TAGVAR(lt_prog_compiler_pic, $1)='-KPIC'
++      _LT_TAGVAR(lt_prog_compiler_static, $1)='-Bstatic'
++      ;;
++
++    sysv4*MP*)
++      if test -d /usr/nec ;then
++	_LT_TAGVAR(lt_prog_compiler_pic, $1)='-Kconform_pic'
++	_LT_TAGVAR(lt_prog_compiler_static, $1)='-Bstatic'
++      fi
++      ;;
++
++    sysv5* | unixware* | sco3.2v5* | sco5v6* | OpenUNIX*)
++      _LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,'
++      _LT_TAGVAR(lt_prog_compiler_pic, $1)='-KPIC'
++      _LT_TAGVAR(lt_prog_compiler_static, $1)='-Bstatic'
++      ;;
++
++    unicos*)
++      _LT_TAGVAR(lt_prog_compiler_wl, $1)='-Wl,'
++      _LT_TAGVAR(lt_prog_compiler_can_build_shared, $1)=no
++      ;;
++
++    uts4*)
++      _LT_TAGVAR(lt_prog_compiler_pic, $1)='-pic'
++      _LT_TAGVAR(lt_prog_compiler_static, $1)='-Bstatic'
++      ;;
++
++    *)
++      _LT_TAGVAR(lt_prog_compiler_can_build_shared, $1)=no
++      ;;
++    esac
++  fi
++])
++case $host_os in
++  # For platforms which do not support PIC, -DPIC is meaningless:
++  *djgpp*)
++    _LT_TAGVAR(lt_prog_compiler_pic, $1)=
++    ;;
++  *)
++    _LT_TAGVAR(lt_prog_compiler_pic, $1)="$_LT_TAGVAR(lt_prog_compiler_pic, $1)@&t@m4_if([$1],[],[ -DPIC],[m4_if([$1],[CXX],[ -DPIC],[])])"
++    ;;
++esac
++
++AC_CACHE_CHECK([for $compiler option to produce PIC],
++  [_LT_TAGVAR(lt_cv_prog_compiler_pic, $1)],
++  [_LT_TAGVAR(lt_cv_prog_compiler_pic, $1)=$_LT_TAGVAR(lt_prog_compiler_pic, $1)])
++_LT_TAGVAR(lt_prog_compiler_pic, $1)=$_LT_TAGVAR(lt_cv_prog_compiler_pic, $1)
++
++#
++# Check to make sure the PIC flag actually works.
++#
++if test -n "$_LT_TAGVAR(lt_prog_compiler_pic, $1)"; then
++  _LT_COMPILER_OPTION([if $compiler PIC flag $_LT_TAGVAR(lt_prog_compiler_pic, $1) works],
++    [_LT_TAGVAR(lt_cv_prog_compiler_pic_works, $1)],
++    [$_LT_TAGVAR(lt_prog_compiler_pic, $1)@&t@m4_if([$1],[],[ -DPIC],[m4_if([$1],[CXX],[ -DPIC],[])])], [],
++    [case $_LT_TAGVAR(lt_prog_compiler_pic, $1) in
++     "" | " "*) ;;
++     *) _LT_TAGVAR(lt_prog_compiler_pic, $1)=" $_LT_TAGVAR(lt_prog_compiler_pic, $1)" ;;
++     esac],
++    [_LT_TAGVAR(lt_prog_compiler_pic, $1)=
++     _LT_TAGVAR(lt_prog_compiler_can_build_shared, $1)=no])
++fi
++_LT_TAGDECL([pic_flag], [lt_prog_compiler_pic], [1],
++	[Additional compiler flags for building library objects])
++
++_LT_TAGDECL([wl], [lt_prog_compiler_wl], [1],
++	[How to pass a linker flag through the compiler])
++#
++# Check to make sure the static flag actually works.
++#
++wl=$_LT_TAGVAR(lt_prog_compiler_wl, $1) eval lt_tmp_static_flag=\"$_LT_TAGVAR(lt_prog_compiler_static, $1)\"
++_LT_LINKER_OPTION([if $compiler static flag $lt_tmp_static_flag works],
++  _LT_TAGVAR(lt_cv_prog_compiler_static_works, $1),
++  $lt_tmp_static_flag,
++  [],
++  [_LT_TAGVAR(lt_prog_compiler_static, $1)=])
++_LT_TAGDECL([link_static_flag], [lt_prog_compiler_static], [1],
++	[Compiler flag to prevent dynamic linking])
++])# _LT_COMPILER_PIC
++
++
++# _LT_LINKER_SHLIBS([TAGNAME])
++# ----------------------------
++# See if the linker supports building shared libraries.
++m4_defun([_LT_LINKER_SHLIBS],
++[AC_REQUIRE([LT_PATH_LD])dnl
++AC_REQUIRE([LT_PATH_NM])dnl
++m4_require([_LT_PATH_MANIFEST_TOOL])dnl
++m4_require([_LT_FILEUTILS_DEFAULTS])dnl
++m4_require([_LT_DECL_EGREP])dnl
++m4_require([_LT_DECL_SED])dnl
++m4_require([_LT_CMD_GLOBAL_SYMBOLS])dnl
++m4_require([_LT_TAG_COMPILER])dnl
++AC_MSG_CHECKING([whether the $compiler linker ($LD) supports shared libraries])
++m4_if([$1], [CXX], [
++  _LT_TAGVAR(export_symbols_cmds, $1)='$NM $libobjs $convenience | $global_symbol_pipe | $SED '\''s/.* //'\'' | sort | uniq > $export_symbols'
++  _LT_TAGVAR(exclude_expsyms, $1)=['_GLOBAL_OFFSET_TABLE_|_GLOBAL__F[ID]_.*']
++  case $host_os in
++  aix[[4-9]]*)
++    # If we're using GNU nm, then we don't want the "-C" option.
++    # -C means demangle to AIX nm, but means don't demangle with GNU nm
++    # Also, AIX nm treats weak defined symbols like other global defined
++    # symbols, whereas GNU nm marks them as "W".
++    if $NM -V 2>&1 | $GREP 'GNU' > /dev/null; then
++      _LT_TAGVAR(export_symbols_cmds, $1)='$NM -Bpg $libobjs $convenience | awk '\''{ if (((\$ 2 == "T") || (\$ 2 == "D") || (\$ 2 == "B") || (\$ 2 == "W")) && ([substr](\$ 3,1,1) != ".")) { print \$ 3 } }'\'' | sort -u > $export_symbols'
++    else
++      _LT_TAGVAR(export_symbols_cmds, $1)='$NM -BCpg $libobjs $convenience | awk '\''{ if (((\$ 2 == "T") || (\$ 2 == "D") || (\$ 2 == "B")) && ([substr](\$ 3,1,1) != ".")) { print \$ 3 } }'\'' | sort -u > $export_symbols'
++    fi
++    ;;
++  pw32*)
++    _LT_TAGVAR(export_symbols_cmds, $1)="$ltdll_cmds"
++    ;;
++  cygwin* | mingw* | cegcc*)
++    case $cc_basename in
++    cl*)
++      _LT_TAGVAR(exclude_expsyms, $1)='_NULL_IMPORT_DESCRIPTOR|_IMPORT_DESCRIPTOR_.*'
++      ;;
++    *)
++      _LT_TAGVAR(export_symbols_cmds, $1)='$NM $libobjs $convenience | $global_symbol_pipe | $SED -e '\''/^[[BCDGRS]][[ ]]/s/.*[[ ]]\([[^ ]]*\)/\1 DATA/;s/^.*[[ ]]__nm__\([[^ ]]*\)[[ ]][[^ ]]*/\1 DATA/;/^I[[ ]]/d;/^[[AITW]][[ ]]/s/.* //'\'' | sort | uniq > $export_symbols'
++      _LT_TAGVAR(exclude_expsyms, $1)=['[_]+GLOBAL_OFFSET_TABLE_|[_]+GLOBAL__[FID]_.*|[_]+head_[A-Za-z0-9_]+_dll|[A-Za-z0-9_]+_dll_iname']
++      ;;
++    esac
++    ;;
++  linux* | k*bsd*-gnu | gnu*)
++    _LT_TAGVAR(link_all_deplibs, $1)=no
++    ;;
++  *)
++    _LT_TAGVAR(export_symbols_cmds, $1)='$NM $libobjs $convenience | $global_symbol_pipe | $SED '\''s/.* //'\'' | sort | uniq > $export_symbols'
++    ;;
++  esac
++], [
++  runpath_var=
++  _LT_TAGVAR(allow_undefined_flag, $1)=
++  _LT_TAGVAR(always_export_symbols, $1)=no
++  _LT_TAGVAR(archive_cmds, $1)=
++  _LT_TAGVAR(archive_expsym_cmds, $1)=
++  _LT_TAGVAR(compiler_needs_object, $1)=no
++  _LT_TAGVAR(enable_shared_with_static_runtimes, $1)=no
++  _LT_TAGVAR(export_dynamic_flag_spec, $1)=
++  _LT_TAGVAR(export_symbols_cmds, $1)='$NM $libobjs $convenience | $global_symbol_pipe | $SED '\''s/.* //'\'' | sort | uniq > $export_symbols'
++  _LT_TAGVAR(hardcode_automatic, $1)=no
++  _LT_TAGVAR(hardcode_direct, $1)=no
++  _LT_TAGVAR(hardcode_direct_absolute, $1)=no
++  _LT_TAGVAR(hardcode_libdir_flag_spec, $1)=
++  _LT_TAGVAR(hardcode_libdir_separator, $1)=
++  _LT_TAGVAR(hardcode_minus_L, $1)=no
++  _LT_TAGVAR(hardcode_shlibpath_var, $1)=unsupported
++  _LT_TAGVAR(inherit_rpath, $1)=no
++  _LT_TAGVAR(link_all_deplibs, $1)=unknown
++  _LT_TAGVAR(module_cmds, $1)=
++  _LT_TAGVAR(module_expsym_cmds, $1)=
++  _LT_TAGVAR(old_archive_from_new_cmds, $1)=
++  _LT_TAGVAR(old_archive_from_expsyms_cmds, $1)=
++  _LT_TAGVAR(thread_safe_flag_spec, $1)=
++  _LT_TAGVAR(whole_archive_flag_spec, $1)=
++  # include_expsyms should be a list of space-separated symbols to be *always*
++  # included in the symbol list
++  _LT_TAGVAR(include_expsyms, $1)=
++  # exclude_expsyms can be an extended regexp of symbols to exclude
++  # it will be wrapped by ` (' and `)$', so one must not match beginning or
++  # end of line.  Example: `a|bc|.*d.*' will exclude the symbols `a' and `bc',
++  # as well as any symbol that contains `d'.
++  _LT_TAGVAR(exclude_expsyms, $1)=['_GLOBAL_OFFSET_TABLE_|_GLOBAL__F[ID]_.*']
++  # Although _GLOBAL_OFFSET_TABLE_ is a valid symbol C name, most a.out
++  # platforms (ab)use it in PIC code, but their linkers get confused if
++  # the symbol is explicitly referenced.  Since portable code cannot
++  # rely on this symbol name, it's probably fine to never include it in
++  # preloaded symbol tables.
++  # Exclude shared library initialization/finalization symbols.
++dnl Note also adjust exclude_expsyms for C++ above.
++  extract_expsyms_cmds=
++
++  case $host_os in
++  cygwin* | mingw* | pw32* | cegcc*)
++    # FIXME: the MSVC++ port hasn't been tested in a loooong time
++    # When not using gcc, we currently assume that we are using
++    # Microsoft Visual C++.
++    if test "$GCC" != yes; then
++      with_gnu_ld=no
++    fi
++    ;;
++  interix*)
++    # we just hope/assume this is gcc and not c89 (= MSVC++)
++    with_gnu_ld=yes
++    ;;
++  openbsd*)
++    with_gnu_ld=no
++    ;;
++  linux* | k*bsd*-gnu | gnu*)
++    _LT_TAGVAR(link_all_deplibs, $1)=no
++    ;;
++  esac
++
++  _LT_TAGVAR(ld_shlibs, $1)=yes
++
++  # On some targets, GNU ld is compatible enough with the native linker
++  # that we're better off using the native interface for both.
++  lt_use_gnu_ld_interface=no
++  if test "$with_gnu_ld" = yes; then
++    case $host_os in
++      aix*)
++	# The AIX port of GNU ld has always aspired to compatibility
++	# with the native linker.  However, as the warning in the GNU ld
++	# block says, versions before 2.19.5* couldn't really create working
++	# shared libraries, regardless of the interface used.
++	case `$LD -v 2>&1` in
++	  *\ \(GNU\ Binutils\)\ 2.19.5*) ;;
++	  *\ \(GNU\ Binutils\)\ 2.[[2-9]]*) ;;
++	  *\ \(GNU\ Binutils\)\ [[3-9]]*) ;;
++	  *)
++	    lt_use_gnu_ld_interface=yes
++	    ;;
++	esac
++	;;
++      *)
++	lt_use_gnu_ld_interface=yes
++	;;
++    esac
++  fi
++
++  if test "$lt_use_gnu_ld_interface" = yes; then
++    # If archive_cmds runs LD, not CC, wlarc should be empty
++    wlarc='${wl}'
++
++    # Set some defaults for GNU ld with shared library support. These
++    # are reset later if shared libraries are not supported. Putting them
++    # here allows them to be overridden if necessary.
++    runpath_var=LD_RUN_PATH
++    _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-rpath ${wl}$libdir'
++    _LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}--export-dynamic'
++    # ancient GNU ld didn't support --whole-archive et. al.
++    if $LD --help 2>&1 | $GREP 'no-whole-archive' > /dev/null; then
++      _LT_TAGVAR(whole_archive_flag_spec, $1)="$wlarc"'--whole-archive$convenience '"$wlarc"'--no-whole-archive'
++    else
++      _LT_TAGVAR(whole_archive_flag_spec, $1)=
++    fi
++    supports_anon_versioning=no
++    case `$LD -v 2>&1` in
++      *GNU\ gold*) supports_anon_versioning=yes ;;
++      *\ [[01]].* | *\ 2.[[0-9]].* | *\ 2.10.*) ;; # catch versions < 2.11
++      *\ 2.11.93.0.2\ *) supports_anon_versioning=yes ;; # RH7.3 ...
++      *\ 2.11.92.0.12\ *) supports_anon_versioning=yes ;; # Mandrake 8.2 ...
++      *\ 2.11.*) ;; # other 2.11 versions
++      *) supports_anon_versioning=yes ;;
++    esac
++
++    # See if GNU ld supports shared libraries.
++    case $host_os in
++    aix[[3-9]]*)
++      # On AIX/PPC, the GNU linker is very broken
++      if test "$host_cpu" != ia64; then
++	_LT_TAGVAR(ld_shlibs, $1)=no
++	cat <<_LT_EOF 1>&2
++
++*** Warning: the GNU linker, at least up to release 2.19, is reported
++*** to be unable to reliably create shared libraries on AIX.
++*** Therefore, libtool is disabling shared libraries support.  If you
++*** really care for shared libraries, you may want to install binutils
++*** 2.20 or above, or modify your PATH so that a non-GNU linker is found.
++*** You will then need to restart the configuration process.
++
++_LT_EOF
++      fi
++      ;;
++
++    amigaos*)
++      case $host_cpu in
++      powerpc)
++            # see comment about AmigaOS4 .so support
++            _LT_TAGVAR(archive_cmds, $1)='$CC -shared $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
++            _LT_TAGVAR(archive_expsym_cmds, $1)=''
++        ;;
++      m68k)
++            _LT_TAGVAR(archive_cmds, $1)='$RM $output_objdir/a2ixlibrary.data~$ECHO "#define NAME $libname" > $output_objdir/a2ixlibrary.data~$ECHO "#define LIBRARY_ID 1" >> $output_objdir/a2ixlibrary.data~$ECHO "#define VERSION $major" >> $output_objdir/a2ixlibrary.data~$ECHO "#define REVISION $revision" >> $output_objdir/a2ixlibrary.data~$AR $AR_FLAGS $lib $libobjs~$RANLIB $lib~(cd $output_objdir && a2ixlibrary -32)'
++            _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='-L$libdir'
++            _LT_TAGVAR(hardcode_minus_L, $1)=yes
++        ;;
++      esac
++      ;;
++
++    beos*)
++      if $LD --help 2>&1 | $GREP ': supported targets:.* elf' > /dev/null; then
++	_LT_TAGVAR(allow_undefined_flag, $1)=unsupported
++	# Joseph Beckenbach <jrb3@best.com> says some releases of gcc
++	# support --undefined.  This deserves some investigation.  FIXME
++	_LT_TAGVAR(archive_cmds, $1)='$CC -nostart $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
++      else
++	_LT_TAGVAR(ld_shlibs, $1)=no
++      fi
++      ;;
++
++    cygwin* | mingw* | pw32* | cegcc*)
++      # _LT_TAGVAR(hardcode_libdir_flag_spec, $1) is actually meaningless,
++      # as there is no search path for DLLs.
++      _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='-L$libdir'
++      _LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}--export-all-symbols'
++      _LT_TAGVAR(allow_undefined_flag, $1)=unsupported
++      _LT_TAGVAR(always_export_symbols, $1)=no
++      _LT_TAGVAR(enable_shared_with_static_runtimes, $1)=yes
++      _LT_TAGVAR(export_symbols_cmds, $1)='$NM $libobjs $convenience | $global_symbol_pipe | $SED -e '\''/^[[BCDGRS]][[ ]]/s/.*[[ ]]\([[^ ]]*\)/\1 DATA/;s/^.*[[ ]]__nm__\([[^ ]]*\)[[ ]][[^ ]]*/\1 DATA/;/^I[[ ]]/d;/^[[AITW]][[ ]]/s/.* //'\'' | sort | uniq > $export_symbols'
++      _LT_TAGVAR(exclude_expsyms, $1)=['[_]+GLOBAL_OFFSET_TABLE_|[_]+GLOBAL__[FID]_.*|[_]+head_[A-Za-z0-9_]+_dll|[A-Za-z0-9_]+_dll_iname']
++
++      if $LD --help 2>&1 | $GREP 'auto-import' > /dev/null; then
++        _LT_TAGVAR(archive_cmds, $1)='$CC -shared $libobjs $deplibs $compiler_flags -o $output_objdir/$soname ${wl}--enable-auto-image-base -Xlinker --out-implib -Xlinker $lib'
++	# If the export-symbols file already is a .def file (1st line
++	# is EXPORTS), use it as is; otherwise, prepend...
++	_LT_TAGVAR(archive_expsym_cmds, $1)='if test "x`$SED 1q $export_symbols`" = xEXPORTS; then
++	  cp $export_symbols $output_objdir/$soname.def;
++	else
++	  echo EXPORTS > $output_objdir/$soname.def;
++	  cat $export_symbols >> $output_objdir/$soname.def;
++	fi~
++	$CC -shared $output_objdir/$soname.def $libobjs $deplibs $compiler_flags -o $output_objdir/$soname ${wl}--enable-auto-image-base -Xlinker --out-implib -Xlinker $lib'
++      else
++	_LT_TAGVAR(ld_shlibs, $1)=no
++      fi
++      ;;
++
++    haiku*)
++      _LT_TAGVAR(archive_cmds, $1)='$CC -shared $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
++      _LT_TAGVAR(link_all_deplibs, $1)=yes
++      ;;
++
++    interix[[3-9]]*)
++      _LT_TAGVAR(hardcode_direct, $1)=no
++      _LT_TAGVAR(hardcode_shlibpath_var, $1)=no
++      _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-rpath,$libdir'
++      _LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}-E'
++      # Hack: On Interix 3.x, we cannot compile PIC because of a broken gcc.
++      # Instead, shared libraries are loaded at an image base (0x10000000 by
++      # default) and relocated if they conflict, which is a slow very memory
++      # consuming and fragmenting process.  To avoid this, we pick a random,
++      # 256 KiB-aligned image base between 0x50000000 and 0x6FFC0000 at link
++      # time.  Moving up from 0x10000000 also allows more sbrk(2) space.
++      _LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-h,$soname ${wl}--image-base,`expr ${RANDOM-$$} % 4096 / 2 \* 262144 + 1342177280` -o $lib'
++      _LT_TAGVAR(archive_expsym_cmds, $1)='sed "s,^,_," $export_symbols >$output_objdir/$soname.expsym~$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-h,$soname ${wl}--retain-symbols-file,$output_objdir/$soname.expsym ${wl}--image-base,`expr ${RANDOM-$$} % 4096 / 2 \* 262144 + 1342177280` -o $lib'
++      ;;
++
++    gnu* | linux* | tpf* | k*bsd*-gnu | kopensolaris*-gnu)
++      tmp_diet=no
++      if test "$host_os" = linux-dietlibc; then
++	case $cc_basename in
++	  diet\ *) tmp_diet=yes;;	# linux-dietlibc with static linking (!diet-dyn)
++	esac
++      fi
++      if $LD --help 2>&1 | $EGREP ': supported targets:.* elf' > /dev/null \
++	 && test "$tmp_diet" = no
++      then
++	tmp_addflag=' $pic_flag'
++	tmp_sharedflag='-shared'
++	case $cc_basename,$host_cpu in
++        pgcc*)				# Portland Group C compiler
++	  _LT_TAGVAR(whole_archive_flag_spec, $1)='${wl}--whole-archive`for conv in $convenience\"\"; do test  -n \"$conv\" && new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` ${wl}--no-whole-archive'
++	  tmp_addflag=' $pic_flag'
++	  ;;
++	pgf77* | pgf90* | pgf95* | pgfortran*)
++					# Portland Group f77 and f90 compilers
++	  _LT_TAGVAR(whole_archive_flag_spec, $1)='${wl}--whole-archive`for conv in $convenience\"\"; do test  -n \"$conv\" && new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` ${wl}--no-whole-archive'
++	  tmp_addflag=' $pic_flag -Mnomain' ;;
++	ecc*,ia64* | icc*,ia64*)	# Intel C compiler on ia64
++	  tmp_addflag=' -i_dynamic' ;;
++	efc*,ia64* | ifort*,ia64*)	# Intel Fortran compiler on ia64
++	  tmp_addflag=' -i_dynamic -nofor_main' ;;
++	ifc* | ifort*)			# Intel Fortran compiler
++	  tmp_addflag=' -nofor_main' ;;
++	lf95*)				# Lahey Fortran 8.1
++	  _LT_TAGVAR(whole_archive_flag_spec, $1)=
++	  tmp_sharedflag='--shared' ;;
++	xl[[cC]]* | bgxl[[cC]]* | mpixl[[cC]]*) # IBM XL C 8.0 on PPC (deal with xlf below)
++	  tmp_sharedflag='-qmkshrobj'
++	  tmp_addflag= ;;
++	nvcc*)	# Cuda Compiler Driver 2.2
++	  _LT_TAGVAR(whole_archive_flag_spec, $1)='${wl}--whole-archive`for conv in $convenience\"\"; do test  -n \"$conv\" && new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` ${wl}--no-whole-archive'
++	  _LT_TAGVAR(compiler_needs_object, $1)=yes
++	  ;;
++	esac
++	case `$CC -V 2>&1 | sed 5q` in
++	*Sun\ C*)			# Sun C 5.9
++	  _LT_TAGVAR(whole_archive_flag_spec, $1)='${wl}--whole-archive`new_convenience=; for conv in $convenience\"\"; do test -z \"$conv\" || new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` ${wl}--no-whole-archive'
++	  _LT_TAGVAR(compiler_needs_object, $1)=yes
++	  tmp_sharedflag='-G' ;;
++	*Sun\ F*)			# Sun Fortran 8.3
++	  tmp_sharedflag='-G' ;;
++	esac
++	_LT_TAGVAR(archive_cmds, $1)='$CC '"$tmp_sharedflag""$tmp_addflag"' $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
++
++        if test "x$supports_anon_versioning" = xyes; then
++          _LT_TAGVAR(archive_expsym_cmds, $1)='echo "{ global:" > $output_objdir/$libname.ver~
++	    cat $export_symbols | sed -e "s/\(.*\)/\1;/" >> $output_objdir/$libname.ver~
++	    echo "local: *; };" >> $output_objdir/$libname.ver~
++	    $CC '"$tmp_sharedflag""$tmp_addflag"' $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname ${wl}-version-script ${wl}$output_objdir/$libname.ver -o $lib'
++        fi
++
++	case $cc_basename in
++	xlf* | bgf* | bgxlf* | mpixlf*)
++	  # IBM XL Fortran 10.1 on PPC cannot create shared libs itself
++	  _LT_TAGVAR(whole_archive_flag_spec, $1)='--whole-archive$convenience --no-whole-archive'
++	  _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-rpath ${wl}$libdir'
++	  _LT_TAGVAR(archive_cmds, $1)='$LD -shared $libobjs $deplibs $linker_flags -soname $soname -o $lib'
++	  if test "x$supports_anon_versioning" = xyes; then
++	    _LT_TAGVAR(archive_expsym_cmds, $1)='echo "{ global:" > $output_objdir/$libname.ver~
++	      cat $export_symbols | sed -e "s/\(.*\)/\1;/" >> $output_objdir/$libname.ver~
++	      echo "local: *; };" >> $output_objdir/$libname.ver~
++	      $LD -shared $libobjs $deplibs $linker_flags -soname $soname -version-script $output_objdir/$libname.ver -o $lib'
++	  fi
++	  ;;
++	esac
++      else
++        _LT_TAGVAR(ld_shlibs, $1)=no
++      fi
++      ;;
++
++    netbsd* | netbsdelf*-gnu)
++      if echo __ELF__ | $CC -E - | $GREP __ELF__ >/dev/null; then
++	_LT_TAGVAR(archive_cmds, $1)='$LD -Bshareable $libobjs $deplibs $linker_flags -o $lib'
++	wlarc=
++      else
++	_LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
++	_LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname ${wl}-retain-symbols-file $wl$export_symbols -o $lib'
++      fi
++      ;;
++
++    solaris*)
++      if $LD -v 2>&1 | $GREP 'BFD 2\.8' > /dev/null; then
++	_LT_TAGVAR(ld_shlibs, $1)=no
++	cat <<_LT_EOF 1>&2
++
++*** Warning: The releases 2.8.* of the GNU linker cannot reliably
++*** create shared libraries on Solaris systems.  Therefore, libtool
++*** is disabling shared libraries support.  We urge you to upgrade GNU
++*** binutils to release 2.9.1 or newer.  Another option is to modify
++*** your PATH or compiler configuration so that the native linker is
++*** used, and then restart.
++
++_LT_EOF
++      elif $LD --help 2>&1 | $GREP ': supported targets:.* elf' > /dev/null; then
++	_LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
++	_LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname ${wl}-retain-symbols-file $wl$export_symbols -o $lib'
++      else
++	_LT_TAGVAR(ld_shlibs, $1)=no
++      fi
++      ;;
++
++    sysv5* | sco3.2v5* | sco5v6* | unixware* | OpenUNIX*)
++      case `$LD -v 2>&1` in
++        *\ [[01]].* | *\ 2.[[0-9]].* | *\ 2.1[[0-5]].*)
++	_LT_TAGVAR(ld_shlibs, $1)=no
++	cat <<_LT_EOF 1>&2
++
++*** Warning: Releases of the GNU linker prior to 2.16.91.0.3 can not
++*** reliably create shared libraries on SCO systems.  Therefore, libtool
++*** is disabling shared libraries support.  We urge you to upgrade GNU
++*** binutils to release 2.16.91.0.3 or newer.  Another option is to modify
++*** your PATH or compiler configuration so that the native linker is
++*** used, and then restart.
++
++_LT_EOF
++	;;
++	*)
++	  # For security reasons, it is highly recommended that you always
++	  # use absolute paths for naming shared libraries, and exclude the
++	  # DT_RUNPATH tag from executables and libraries.  But doing so
++	  # requires that you compile everything twice, which is a pain.
++	  if $LD --help 2>&1 | $GREP ': supported targets:.* elf' > /dev/null; then
++	    _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-rpath ${wl}$libdir'
++	    _LT_TAGVAR(archive_cmds, $1)='$CC -shared $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
++	    _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname ${wl}-retain-symbols-file $wl$export_symbols -o $lib'
++	  else
++	    _LT_TAGVAR(ld_shlibs, $1)=no
++	  fi
++	;;
++      esac
++      ;;
++
++    sunos4*)
++      _LT_TAGVAR(archive_cmds, $1)='$LD -assert pure-text -Bshareable -o $lib $libobjs $deplibs $linker_flags'
++      wlarc=
++      _LT_TAGVAR(hardcode_direct, $1)=yes
++      _LT_TAGVAR(hardcode_shlibpath_var, $1)=no
++      ;;
++
++    *)
++      if $LD --help 2>&1 | $GREP ': supported targets:.* elf' > /dev/null; then
++	_LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
++	_LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname ${wl}-retain-symbols-file $wl$export_symbols -o $lib'
++      else
++	_LT_TAGVAR(ld_shlibs, $1)=no
++      fi
++      ;;
++    esac
++
++    if test "$_LT_TAGVAR(ld_shlibs, $1)" = no; then
++      runpath_var=
++      _LT_TAGVAR(hardcode_libdir_flag_spec, $1)=
++      _LT_TAGVAR(export_dynamic_flag_spec, $1)=
++      _LT_TAGVAR(whole_archive_flag_spec, $1)=
++    fi
++  else
++    # PORTME fill in a description of your system's linker (not GNU ld)
++    case $host_os in
++    aix3*)
++      _LT_TAGVAR(allow_undefined_flag, $1)=unsupported
++      _LT_TAGVAR(always_export_symbols, $1)=yes
++      _LT_TAGVAR(archive_expsym_cmds, $1)='$LD -o $output_objdir/$soname $libobjs $deplibs $linker_flags -bE:$export_symbols -T512 -H512 -bM:SRE~$AR $AR_FLAGS $lib $output_objdir/$soname'
++      # Note: this linker hardcodes the directories in LIBPATH if there
++      # are no directories specified by -L.
++      _LT_TAGVAR(hardcode_minus_L, $1)=yes
++      if test "$GCC" = yes && test -z "$lt_prog_compiler_static"; then
++	# Neither direct hardcoding nor static linking is supported with a
++	# broken collect2.
++	_LT_TAGVAR(hardcode_direct, $1)=unsupported
++      fi
++      ;;
++
++    aix[[4-9]]*)
++      if test "$host_cpu" = ia64; then
++	# On IA64, the linker does run time linking by default, so we don't
++	# have to do anything special.
++	aix_use_runtimelinking=no
++	exp_sym_flag='-Bexport'
++	no_entry_flag=""
++      else
++	# If we're using GNU nm, then we don't want the "-C" option.
++	# -C means demangle to AIX nm, but means don't demangle with GNU nm
++	# Also, AIX nm treats weak defined symbols like other global
++	# defined symbols, whereas GNU nm marks them as "W".
++	if $NM -V 2>&1 | $GREP 'GNU' > /dev/null; then
++	  _LT_TAGVAR(export_symbols_cmds, $1)='$NM -Bpg $libobjs $convenience | awk '\''{ if (((\$ 2 == "T") || (\$ 2 == "D") || (\$ 2 == "B") || (\$ 2 == "W")) && ([substr](\$ 3,1,1) != ".")) { print \$ 3 } }'\'' | sort -u > $export_symbols'
++	else
++	  _LT_TAGVAR(export_symbols_cmds, $1)='$NM -BCpg $libobjs $convenience | awk '\''{ if (((\$ 2 == "T") || (\$ 2 == "D") || (\$ 2 == "B")) && ([substr](\$ 3,1,1) != ".")) { print \$ 3 } }'\'' | sort -u > $export_symbols'
++	fi
++	aix_use_runtimelinking=no
++
++	# Test if we are trying to use run time linking or normal
++	# AIX style linking. If -brtl is somewhere in LDFLAGS, we
++	# need to do runtime linking.
++	case $host_os in aix4.[[23]]|aix4.[[23]].*|aix[[5-9]]*)
++	  for ld_flag in $LDFLAGS; do
++	  if (test $ld_flag = "-brtl" || test $ld_flag = "-Wl,-brtl"); then
++	    aix_use_runtimelinking=yes
++	    break
++	  fi
++	  done
++	  ;;
++	esac
++
++	exp_sym_flag='-bexport'
++	no_entry_flag='-bnoentry'
++      fi
++
++      # When large executables or shared objects are built, AIX ld can
++      # have problems creating the table of contents.  If linking a library
++      # or program results in "error TOC overflow" add -mminimal-toc to
++      # CXXFLAGS/CFLAGS for g++/gcc.  In the cases where that is not
++      # enough to fix the problem, add -Wl,-bbigtoc to LDFLAGS.
++
++      _LT_TAGVAR(archive_cmds, $1)=''
++      _LT_TAGVAR(hardcode_direct, $1)=yes
++      _LT_TAGVAR(hardcode_direct_absolute, $1)=yes
++      _LT_TAGVAR(hardcode_libdir_separator, $1)=':'
++      _LT_TAGVAR(link_all_deplibs, $1)=yes
++      _LT_TAGVAR(file_list_spec, $1)='${wl}-f,'
++
++      if test "$GCC" = yes; then
++	case $host_os in aix4.[[012]]|aix4.[[012]].*)
++	# We only want to do this on AIX 4.2 and lower, the check
++	# below for broken collect2 doesn't work under 4.3+
++	  collect2name=`${CC} -print-prog-name=collect2`
++	  if test -f "$collect2name" &&
++	   strings "$collect2name" | $GREP resolve_lib_name >/dev/null
++	  then
++	  # We have reworked collect2
++	  :
++	  else
++	  # We have old collect2
++	  _LT_TAGVAR(hardcode_direct, $1)=unsupported
++	  # It fails to find uninstalled libraries when the uninstalled
++	  # path is not listed in the libpath.  Setting hardcode_minus_L
++	  # to unsupported forces relinking
++	  _LT_TAGVAR(hardcode_minus_L, $1)=yes
++	  _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='-L$libdir'
++	  _LT_TAGVAR(hardcode_libdir_separator, $1)=
++	  fi
++	  ;;
++	esac
++	shared_flag='-shared'
++	if test "$aix_use_runtimelinking" = yes; then
++	  shared_flag="$shared_flag "'${wl}-G'
++	fi
++	_LT_TAGVAR(link_all_deplibs, $1)=no
++      else
++	# not using gcc
++	if test "$host_cpu" = ia64; then
++	# VisualAge C++, Version 5.5 for AIX 5L for IA-64, Beta 3 Release
++	# chokes on -Wl,-G. The following line is correct:
++	  shared_flag='-G'
++	else
++	  if test "$aix_use_runtimelinking" = yes; then
++	    shared_flag='${wl}-G'
++	  else
++	    shared_flag='${wl}-bM:SRE'
++	  fi
++	fi
++      fi
++
++      _LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}-bexpall'
++      # It seems that -bexpall does not export symbols beginning with
++      # underscore (_), so it is better to generate a list of symbols to export.
++      _LT_TAGVAR(always_export_symbols, $1)=yes
++      if test "$aix_use_runtimelinking" = yes; then
++	# Warning - without using the other runtime loading flags (-brtl),
++	# -berok will link without error, but may produce a broken library.
++	_LT_TAGVAR(allow_undefined_flag, $1)='-berok'
++        # Determine the default libpath from the value encoded in an
++        # empty executable.
++        _LT_SYS_MODULE_PATH_AIX([$1])
++        _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-blibpath:$libdir:'"$aix_libpath"
++        _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -o $output_objdir/$soname $libobjs $deplibs '"\${wl}$no_entry_flag"' $compiler_flags `if test "x${allow_undefined_flag}" != "x"; then func_echo_all "${wl}${allow_undefined_flag}"; else :; fi` '"\${wl}$exp_sym_flag:\$export_symbols $shared_flag"
++      else
++	if test "$host_cpu" = ia64; then
++	  _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-R $libdir:/usr/lib:/lib'
++	  _LT_TAGVAR(allow_undefined_flag, $1)="-z nodefs"
++	  _LT_TAGVAR(archive_expsym_cmds, $1)="\$CC $shared_flag"' -o $output_objdir/$soname $libobjs $deplibs '"\${wl}$no_entry_flag"' $compiler_flags ${wl}${allow_undefined_flag} '"\${wl}$exp_sym_flag:\$export_symbols"
++	else
++	 # Determine the default libpath from the value encoded in an
++	 # empty executable.
++	 _LT_SYS_MODULE_PATH_AIX([$1])
++	 _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-blibpath:$libdir:'"$aix_libpath"
++	  # Warning - without using the other run time loading flags,
++	  # -berok will link without error, but may produce a broken library.
++	  _LT_TAGVAR(no_undefined_flag, $1)=' ${wl}-bernotok'
++	  _LT_TAGVAR(allow_undefined_flag, $1)=' ${wl}-berok'
++	  if test "$with_gnu_ld" = yes; then
++	    # We only use this code for GNU lds that support --whole-archive.
++	    _LT_TAGVAR(whole_archive_flag_spec, $1)='${wl}--whole-archive$convenience ${wl}--no-whole-archive'
++	  else
++	    # Exported symbols can be pulled into shared objects from archives
++	    _LT_TAGVAR(whole_archive_flag_spec, $1)='$convenience'
++	  fi
++	  _LT_TAGVAR(archive_cmds_need_lc, $1)=yes
++	  # This is similar to how AIX traditionally builds its shared libraries.
++	  _LT_TAGVAR(archive_expsym_cmds, $1)="\$CC $shared_flag"' -o $output_objdir/$soname $libobjs $deplibs ${wl}-bnoentry $compiler_flags ${wl}-bE:$export_symbols${allow_undefined_flag}~$AR $AR_FLAGS $output_objdir/$libname$release.a $output_objdir/$soname'
++	fi
++      fi
++      ;;
++
++    amigaos*)
++      case $host_cpu in
++      powerpc)
++            # see comment about AmigaOS4 .so support
++            _LT_TAGVAR(archive_cmds, $1)='$CC -shared $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
++            _LT_TAGVAR(archive_expsym_cmds, $1)=''
++        ;;
++      m68k)
++            _LT_TAGVAR(archive_cmds, $1)='$RM $output_objdir/a2ixlibrary.data~$ECHO "#define NAME $libname" > $output_objdir/a2ixlibrary.data~$ECHO "#define LIBRARY_ID 1" >> $output_objdir/a2ixlibrary.data~$ECHO "#define VERSION $major" >> $output_objdir/a2ixlibrary.data~$ECHO "#define REVISION $revision" >> $output_objdir/a2ixlibrary.data~$AR $AR_FLAGS $lib $libobjs~$RANLIB $lib~(cd $output_objdir && a2ixlibrary -32)'
++            _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='-L$libdir'
++            _LT_TAGVAR(hardcode_minus_L, $1)=yes
++        ;;
++      esac
++      ;;
++
++    bsdi[[45]]*)
++      _LT_TAGVAR(export_dynamic_flag_spec, $1)=-rdynamic
++      ;;
++
++    cygwin* | mingw* | pw32* | cegcc*)
++      # When not using gcc, we currently assume that we are using
++      # Microsoft Visual C++.
++      # hardcode_libdir_flag_spec is actually meaningless, as there is
++      # no search path for DLLs.
++      case $cc_basename in
++      cl*)
++	# Native MSVC
++	_LT_TAGVAR(hardcode_libdir_flag_spec, $1)=' '
++	_LT_TAGVAR(allow_undefined_flag, $1)=unsupported
++	_LT_TAGVAR(always_export_symbols, $1)=yes
++	_LT_TAGVAR(file_list_spec, $1)='@'
++	# Tell ltmain to make .lib files, not .a files.
++	libext=lib
++	# Tell ltmain to make .dll files, not .so files.
++	shrext_cmds=".dll"
++	# FIXME: Setting linknames here is a bad hack.
++	_LT_TAGVAR(archive_cmds, $1)='$CC -o $output_objdir/$soname $libobjs $compiler_flags $deplibs -Wl,-dll~linknames='
++	_LT_TAGVAR(archive_expsym_cmds, $1)='if test "x`$SED 1q $export_symbols`" = xEXPORTS; then
++	    sed -n -e 's/\\\\\\\(.*\\\\\\\)/-link\\\ -EXPORT:\\\\\\\1/' -e '1\\\!p' < $export_symbols > $output_objdir/$soname.exp;
++	  else
++	    sed -e 's/\\\\\\\(.*\\\\\\\)/-link\\\ -EXPORT:\\\\\\\1/' < $export_symbols > $output_objdir/$soname.exp;
++	  fi~
++	  $CC -o $tool_output_objdir$soname $libobjs $compiler_flags $deplibs "@$tool_output_objdir$soname.exp" -Wl,-DLL,-IMPLIB:"$tool_output_objdir$libname.dll.lib"~
++	  linknames='
++	# The linker will not automatically build a static lib if we build a DLL.
++	# _LT_TAGVAR(old_archive_from_new_cmds, $1)='true'
++	_LT_TAGVAR(enable_shared_with_static_runtimes, $1)=yes
++	_LT_TAGVAR(exclude_expsyms, $1)='_NULL_IMPORT_DESCRIPTOR|_IMPORT_DESCRIPTOR_.*'
++	_LT_TAGVAR(export_symbols_cmds, $1)='$NM $libobjs $convenience | $global_symbol_pipe | $SED -e '\''/^[[BCDGRS]][[ ]]/s/.*[[ ]]\([[^ ]]*\)/\1,DATA/'\'' | $SED -e '\''/^[[AITW]][[ ]]/s/.*[[ ]]//'\'' | sort | uniq > $export_symbols'
++	# Don't use ranlib
++	_LT_TAGVAR(old_postinstall_cmds, $1)='chmod 644 $oldlib'
++	_LT_TAGVAR(postlink_cmds, $1)='lt_outputfile="@OUTPUT@"~
++	  lt_tool_outputfile="@TOOL_OUTPUT@"~
++	  case $lt_outputfile in
++	    *.exe|*.EXE) ;;
++	    *)
++	      lt_outputfile="$lt_outputfile.exe"
++	      lt_tool_outputfile="$lt_tool_outputfile.exe"
++	      ;;
++	  esac~
++	  if test "$MANIFEST_TOOL" != ":" && test -f "$lt_outputfile.manifest"; then
++	    $MANIFEST_TOOL -manifest "$lt_tool_outputfile.manifest" -outputresource:"$lt_tool_outputfile" || exit 1;
++	    $RM "$lt_outputfile.manifest";
++	  fi'
++	;;
++      *)
++	# Assume MSVC wrapper
++	_LT_TAGVAR(hardcode_libdir_flag_spec, $1)=' '
++	_LT_TAGVAR(allow_undefined_flag, $1)=unsupported
++	# Tell ltmain to make .lib files, not .a files.
++	libext=lib
++	# Tell ltmain to make .dll files, not .so files.
++	shrext_cmds=".dll"
++	# FIXME: Setting linknames here is a bad hack.
++	_LT_TAGVAR(archive_cmds, $1)='$CC -o $lib $libobjs $compiler_flags `func_echo_all "$deplibs" | $SED '\''s/ -lc$//'\''` -link -dll~linknames='
++	# The linker will automatically build a .lib file if we build a DLL.
++	_LT_TAGVAR(old_archive_from_new_cmds, $1)='true'
++	# FIXME: Should let the user specify the lib program.
++	_LT_TAGVAR(old_archive_cmds, $1)='lib -OUT:$oldlib$oldobjs$old_deplibs'
++	_LT_TAGVAR(enable_shared_with_static_runtimes, $1)=yes
++	;;
++      esac
++      ;;
++
++    darwin* | rhapsody*)
++      _LT_DARWIN_LINKER_FEATURES($1)
++      ;;
++
++    dgux*)
++      _LT_TAGVAR(archive_cmds, $1)='$LD -G -h $soname -o $lib $libobjs $deplibs $linker_flags'
++      _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='-L$libdir'
++      _LT_TAGVAR(hardcode_shlibpath_var, $1)=no
++      ;;
++
++    # FreeBSD 2.2.[012] allows us to include c++rt0.o to get C++ constructor
++    # support.  Future versions do this automatically, but an explicit c++rt0.o
++    # does not break anything, and helps significantly (at the cost of a little
++    # extra space).
++    freebsd2.2*)
++      _LT_TAGVAR(archive_cmds, $1)='$LD -Bshareable -o $lib $libobjs $deplibs $linker_flags /usr/lib/c++rt0.o'
++      _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='-R$libdir'
++      _LT_TAGVAR(hardcode_direct, $1)=yes
++      _LT_TAGVAR(hardcode_shlibpath_var, $1)=no
++      ;;
++
++    # Unfortunately, older versions of FreeBSD 2 do not have this feature.
++    freebsd2.*)
++      _LT_TAGVAR(archive_cmds, $1)='$LD -Bshareable -o $lib $libobjs $deplibs $linker_flags'
++      _LT_TAGVAR(hardcode_direct, $1)=yes
++      _LT_TAGVAR(hardcode_minus_L, $1)=yes
++      _LT_TAGVAR(hardcode_shlibpath_var, $1)=no
++      ;;
++
++    # FreeBSD 3 and greater uses gcc -shared to do shared libraries.
++    freebsd* | dragonfly*)
++      _LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag -o $lib $libobjs $deplibs $compiler_flags'
++      _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='-R$libdir'
++      _LT_TAGVAR(hardcode_direct, $1)=yes
++      _LT_TAGVAR(hardcode_shlibpath_var, $1)=no
++      ;;
++
++    hpux9*)
++      if test "$GCC" = yes; then
++	_LT_TAGVAR(archive_cmds, $1)='$RM $output_objdir/$soname~$CC -shared $pic_flag ${wl}+b ${wl}$install_libdir -o $output_objdir/$soname $libobjs $deplibs $compiler_flags~test $output_objdir/$soname = $lib || mv $output_objdir/$soname $lib'
++      else
++	_LT_TAGVAR(archive_cmds, $1)='$RM $output_objdir/$soname~$LD -b +b $install_libdir -o $output_objdir/$soname $libobjs $deplibs $linker_flags~test $output_objdir/$soname = $lib || mv $output_objdir/$soname $lib'
++      fi
++      _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}+b ${wl}$libdir'
++      _LT_TAGVAR(hardcode_libdir_separator, $1)=:
++      _LT_TAGVAR(hardcode_direct, $1)=yes
++
++      # hardcode_minus_L: Not really in the search PATH,
++      # but as the default location of the library.
++      _LT_TAGVAR(hardcode_minus_L, $1)=yes
++      _LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}-E'
++      ;;
++
++    hpux10*)
++      if test "$GCC" = yes && test "$with_gnu_ld" = no; then
++	_LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag ${wl}+h ${wl}$soname ${wl}+b ${wl}$install_libdir -o $lib $libobjs $deplibs $compiler_flags'
++      else
++	_LT_TAGVAR(archive_cmds, $1)='$LD -b +h $soname +b $install_libdir -o $lib $libobjs $deplibs $linker_flags'
++      fi
++      if test "$with_gnu_ld" = no; then
++	_LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}+b ${wl}$libdir'
++	_LT_TAGVAR(hardcode_libdir_separator, $1)=:
++	_LT_TAGVAR(hardcode_direct, $1)=yes
++	_LT_TAGVAR(hardcode_direct_absolute, $1)=yes
++	_LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}-E'
++	# hardcode_minus_L: Not really in the search PATH,
++	# but as the default location of the library.
++	_LT_TAGVAR(hardcode_minus_L, $1)=yes
++      fi
++      ;;
++
++    hpux11*)
++      if test "$GCC" = yes && test "$with_gnu_ld" = no; then
++	case $host_cpu in
++	hppa*64*)
++	  _LT_TAGVAR(archive_cmds, $1)='$CC -shared ${wl}+h ${wl}$soname -o $lib $libobjs $deplibs $compiler_flags'
++	  ;;
++	ia64*)
++	  _LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag ${wl}+h ${wl}$soname ${wl}+nodefaultrpath -o $lib $libobjs $deplibs $compiler_flags'
++	  ;;
++	*)
++	  _LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag ${wl}+h ${wl}$soname ${wl}+b ${wl}$install_libdir -o $lib $libobjs $deplibs $compiler_flags'
++	  ;;
++	esac
++      else
++	case $host_cpu in
++	hppa*64*)
++	  _LT_TAGVAR(archive_cmds, $1)='$CC -b ${wl}+h ${wl}$soname -o $lib $libobjs $deplibs $compiler_flags'
++	  ;;
++	ia64*)
++	  _LT_TAGVAR(archive_cmds, $1)='$CC -b ${wl}+h ${wl}$soname ${wl}+nodefaultrpath -o $lib $libobjs $deplibs $compiler_flags'
++	  ;;
++	*)
++	m4_if($1, [], [
++	  # Older versions of the 11.00 compiler do not understand -b yet
++	  # (HP92453-01 A.11.01.20 doesn't, HP92453-01 B.11.X.35175-35176.GP does)
++	  _LT_LINKER_OPTION([if $CC understands -b],
++	    _LT_TAGVAR(lt_cv_prog_compiler__b, $1), [-b],
++	    [_LT_TAGVAR(archive_cmds, $1)='$CC -b ${wl}+h ${wl}$soname ${wl}+b ${wl}$install_libdir -o $lib $libobjs $deplibs $compiler_flags'],
++	    [_LT_TAGVAR(archive_cmds, $1)='$LD -b +h $soname +b $install_libdir -o $lib $libobjs $deplibs $linker_flags'])],
++	  [_LT_TAGVAR(archive_cmds, $1)='$CC -b ${wl}+h ${wl}$soname ${wl}+b ${wl}$install_libdir -o $lib $libobjs $deplibs $compiler_flags'])
++	  ;;
++	esac
++      fi
++      if test "$with_gnu_ld" = no; then
++	_LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}+b ${wl}$libdir'
++	_LT_TAGVAR(hardcode_libdir_separator, $1)=:
++
++	case $host_cpu in
++	hppa*64*|ia64*)
++	  _LT_TAGVAR(hardcode_direct, $1)=no
++	  _LT_TAGVAR(hardcode_shlibpath_var, $1)=no
++	  ;;
++	*)
++	  _LT_TAGVAR(hardcode_direct, $1)=yes
++	  _LT_TAGVAR(hardcode_direct_absolute, $1)=yes
++	  _LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}-E'
++
++	  # hardcode_minus_L: Not really in the search PATH,
++	  # but as the default location of the library.
++	  _LT_TAGVAR(hardcode_minus_L, $1)=yes
++	  ;;
++	esac
++      fi
++      ;;
++
++    irix5* | irix6* | nonstopux*)
++      if test "$GCC" = yes; then
++	_LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-soname ${wl}$soname `test -n "$verstring" && func_echo_all "${wl}-set_version ${wl}$verstring"` ${wl}-update_registry ${wl}${output_objdir}/so_locations -o $lib'
++	# Try to use the -exported_symbol ld option, if it does not
++	# work, assume that -exports_file does not work either and
++	# implicitly export all symbols.
++	# This should be the same for all languages, so no per-tag cache variable.
++	AC_CACHE_CHECK([whether the $host_os linker accepts -exported_symbol],
++	  [lt_cv_irix_exported_symbol],
++	  [save_LDFLAGS="$LDFLAGS"
++	   LDFLAGS="$LDFLAGS -shared ${wl}-exported_symbol ${wl}foo ${wl}-update_registry ${wl}/dev/null"
++	   AC_LINK_IFELSE(
++	     [AC_LANG_SOURCE(
++	        [AC_LANG_CASE([C], [[int foo (void) { return 0; }]],
++			      [C++], [[int foo (void) { return 0; }]],
++			      [Fortran 77], [[
++      subroutine foo
++      end]],
++			      [Fortran], [[
++      subroutine foo
++      end]])])],
++	      [lt_cv_irix_exported_symbol=yes],
++	      [lt_cv_irix_exported_symbol=no])
++           LDFLAGS="$save_LDFLAGS"])
++	if test "$lt_cv_irix_exported_symbol" = yes; then
++          _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-soname ${wl}$soname `test -n "$verstring" && func_echo_all "${wl}-set_version ${wl}$verstring"` ${wl}-update_registry ${wl}${output_objdir}/so_locations ${wl}-exports_file ${wl}$export_symbols -o $lib'
++	fi
++      else
++	_LT_TAGVAR(archive_cmds, $1)='$CC -shared $libobjs $deplibs $compiler_flags -soname $soname `test -n "$verstring" && func_echo_all "-set_version $verstring"` -update_registry ${output_objdir}/so_locations -o $lib'
++	_LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $libobjs $deplibs $compiler_flags -soname $soname `test -n "$verstring" && func_echo_all "-set_version $verstring"` -update_registry ${output_objdir}/so_locations -exports_file $export_symbols -o $lib'
++      fi
++      _LT_TAGVAR(archive_cmds_need_lc, $1)='no'
++      _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-rpath ${wl}$libdir'
++      _LT_TAGVAR(hardcode_libdir_separator, $1)=:
++      _LT_TAGVAR(inherit_rpath, $1)=yes
++      _LT_TAGVAR(link_all_deplibs, $1)=yes
++      ;;
++
++    netbsd* | netbsdelf*-gnu)
++      if echo __ELF__ | $CC -E - | $GREP __ELF__ >/dev/null; then
++	_LT_TAGVAR(archive_cmds, $1)='$LD -Bshareable -o $lib $libobjs $deplibs $linker_flags'  # a.out
++      else
++	_LT_TAGVAR(archive_cmds, $1)='$LD -shared -o $lib $libobjs $deplibs $linker_flags'      # ELF
++      fi
++      _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='-R$libdir'
++      _LT_TAGVAR(hardcode_direct, $1)=yes
++      _LT_TAGVAR(hardcode_shlibpath_var, $1)=no
++      ;;
++
++    newsos6)
++      _LT_TAGVAR(archive_cmds, $1)='$LD -G -h $soname -o $lib $libobjs $deplibs $linker_flags'
++      _LT_TAGVAR(hardcode_direct, $1)=yes
++      _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-rpath ${wl}$libdir'
++      _LT_TAGVAR(hardcode_libdir_separator, $1)=:
++      _LT_TAGVAR(hardcode_shlibpath_var, $1)=no
++      ;;
++
++    *nto* | *qnx*)
++      ;;
++
++    openbsd*)
++      if test -f /usr/libexec/ld.so; then
++	_LT_TAGVAR(hardcode_direct, $1)=yes
++	_LT_TAGVAR(hardcode_shlibpath_var, $1)=no
++	_LT_TAGVAR(hardcode_direct_absolute, $1)=yes
++	if test -z "`echo __ELF__ | $CC -E - | $GREP __ELF__`" || test "$host_os-$host_cpu" = "openbsd2.8-powerpc"; then
++	  _LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag -o $lib $libobjs $deplibs $compiler_flags'
++	  _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $pic_flag -o $lib $libobjs $deplibs $compiler_flags ${wl}-retain-symbols-file,$export_symbols'
++	  _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-rpath,$libdir'
++	  _LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}-E'
++	else
++	  case $host_os in
++	   openbsd[[01]].* | openbsd2.[[0-7]] | openbsd2.[[0-7]].*)
++	     _LT_TAGVAR(archive_cmds, $1)='$LD -Bshareable -o $lib $libobjs $deplibs $linker_flags'
++	     _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='-R$libdir'
++	     ;;
++	   *)
++	     _LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag -o $lib $libobjs $deplibs $compiler_flags'
++	     _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-rpath,$libdir'
++	     ;;
++	  esac
++	fi
++      else
++	_LT_TAGVAR(ld_shlibs, $1)=no
++      fi
++      ;;
++
++    os2*)
++      _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='-L$libdir'
++      _LT_TAGVAR(hardcode_minus_L, $1)=yes
++      _LT_TAGVAR(allow_undefined_flag, $1)=unsupported
++      _LT_TAGVAR(archive_cmds, $1)='$ECHO "LIBRARY $libname INITINSTANCE" > $output_objdir/$libname.def~$ECHO "DESCRIPTION \"$libname\"" >> $output_objdir/$libname.def~echo DATA >> $output_objdir/$libname.def~echo " SINGLE NONSHARED" >> $output_objdir/$libname.def~echo EXPORTS >> $output_objdir/$libname.def~emxexp $libobjs >> $output_objdir/$libname.def~$CC -Zdll -Zcrtdll -o $lib $libobjs $deplibs $compiler_flags $output_objdir/$libname.def'
++      _LT_TAGVAR(old_archive_from_new_cmds, $1)='emximp -o $output_objdir/$libname.a $output_objdir/$libname.def'
++      ;;
++
++    osf3*)
++      if test "$GCC" = yes; then
++	_LT_TAGVAR(allow_undefined_flag, $1)=' ${wl}-expect_unresolved ${wl}\*'
++	_LT_TAGVAR(archive_cmds, $1)='$CC -shared${allow_undefined_flag} $libobjs $deplibs $compiler_flags ${wl}-soname ${wl}$soname `test -n "$verstring" && func_echo_all "${wl}-set_version ${wl}$verstring"` ${wl}-update_registry ${wl}${output_objdir}/so_locations -o $lib'
++      else
++	_LT_TAGVAR(allow_undefined_flag, $1)=' -expect_unresolved \*'
++	_LT_TAGVAR(archive_cmds, $1)='$CC -shared${allow_undefined_flag} $libobjs $deplibs $compiler_flags -soname $soname `test -n "$verstring" && func_echo_all "-set_version $verstring"` -update_registry ${output_objdir}/so_locations -o $lib'
++      fi
++      _LT_TAGVAR(archive_cmds_need_lc, $1)='no'
++      _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-rpath ${wl}$libdir'
++      _LT_TAGVAR(hardcode_libdir_separator, $1)=:
++      ;;
++
++    osf4* | osf5*)	# as osf3* with the addition of -msym flag
++      if test "$GCC" = yes; then
++	_LT_TAGVAR(allow_undefined_flag, $1)=' ${wl}-expect_unresolved ${wl}\*'
++	_LT_TAGVAR(archive_cmds, $1)='$CC -shared${allow_undefined_flag} $pic_flag $libobjs $deplibs $compiler_flags ${wl}-msym ${wl}-soname ${wl}$soname `test -n "$verstring" && func_echo_all "${wl}-set_version ${wl}$verstring"` ${wl}-update_registry ${wl}${output_objdir}/so_locations -o $lib'
++	_LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-rpath ${wl}$libdir'
++      else
++	_LT_TAGVAR(allow_undefined_flag, $1)=' -expect_unresolved \*'
++	_LT_TAGVAR(archive_cmds, $1)='$CC -shared${allow_undefined_flag} $libobjs $deplibs $compiler_flags -msym -soname $soname `test -n "$verstring" && func_echo_all "-set_version $verstring"` -update_registry ${output_objdir}/so_locations -o $lib'
++	_LT_TAGVAR(archive_expsym_cmds, $1)='for i in `cat $export_symbols`; do printf "%s %s\\n" -exported_symbol "\$i" >> $lib.exp; done; printf "%s\\n" "-hidden">> $lib.exp~
++	$CC -shared${allow_undefined_flag} ${wl}-input ${wl}$lib.exp $compiler_flags $libobjs $deplibs -soname $soname `test -n "$verstring" && $ECHO "-set_version $verstring"` -update_registry ${output_objdir}/so_locations -o $lib~$RM $lib.exp'
++
++	# Both c and cxx compiler support -rpath directly
++	_LT_TAGVAR(hardcode_libdir_flag_spec, $1)='-rpath $libdir'
++      fi
++      _LT_TAGVAR(archive_cmds_need_lc, $1)='no'
++      _LT_TAGVAR(hardcode_libdir_separator, $1)=:
++      ;;
++
++    solaris*)
++      _LT_TAGVAR(no_undefined_flag, $1)=' -z defs'
++      if test "$GCC" = yes; then
++	wlarc='${wl}'
++	_LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag ${wl}-z ${wl}text ${wl}-h ${wl}$soname -o $lib $libobjs $deplibs $compiler_flags'
++	_LT_TAGVAR(archive_expsym_cmds, $1)='echo "{ global:" > $lib.exp~cat $export_symbols | $SED -e "s/\(.*\)/\1;/" >> $lib.exp~echo "local: *; };" >> $lib.exp~
++	  $CC -shared $pic_flag ${wl}-z ${wl}text ${wl}-M ${wl}$lib.exp ${wl}-h ${wl}$soname -o $lib $libobjs $deplibs $compiler_flags~$RM $lib.exp'
++      else
++	case `$CC -V 2>&1` in
++	*"Compilers 5.0"*)
++	  wlarc=''
++	  _LT_TAGVAR(archive_cmds, $1)='$LD -G${allow_undefined_flag} -h $soname -o $lib $libobjs $deplibs $linker_flags'
++	  _LT_TAGVAR(archive_expsym_cmds, $1)='echo "{ global:" > $lib.exp~cat $export_symbols | $SED -e "s/\(.*\)/\1;/" >> $lib.exp~echo "local: *; };" >> $lib.exp~
++	  $LD -G${allow_undefined_flag} -M $lib.exp -h $soname -o $lib $libobjs $deplibs $linker_flags~$RM $lib.exp'
++	  ;;
++	*)
++	  wlarc='${wl}'
++	  _LT_TAGVAR(archive_cmds, $1)='$CC -G${allow_undefined_flag} -h $soname -o $lib $libobjs $deplibs $compiler_flags'
++	  _LT_TAGVAR(archive_expsym_cmds, $1)='echo "{ global:" > $lib.exp~cat $export_symbols | $SED -e "s/\(.*\)/\1;/" >> $lib.exp~echo "local: *; };" >> $lib.exp~
++	  $CC -G${allow_undefined_flag} -M $lib.exp -h $soname -o $lib $libobjs $deplibs $compiler_flags~$RM $lib.exp'
++	  ;;
++	esac
++      fi
++      _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='-R$libdir'
++      _LT_TAGVAR(hardcode_shlibpath_var, $1)=no
++      case $host_os in
++      solaris2.[[0-5]] | solaris2.[[0-5]].*) ;;
++      *)
++	# The compiler driver will combine and reorder linker options,
++	# but understands `-z linker_flag'.  GCC discards it without `$wl',
++	# but is careful enough not to reorder.
++	# Supported since Solaris 2.6 (maybe 2.5.1?)
++	if test "$GCC" = yes; then
++	  _LT_TAGVAR(whole_archive_flag_spec, $1)='${wl}-z ${wl}allextract$convenience ${wl}-z ${wl}defaultextract'
++	else
++	  _LT_TAGVAR(whole_archive_flag_spec, $1)='-z allextract$convenience -z defaultextract'
++	fi
++	;;
++      esac
++      _LT_TAGVAR(link_all_deplibs, $1)=yes
++      ;;
++
++    sunos4*)
++      if test "x$host_vendor" = xsequent; then
++	# Use $CC to link under sequent, because it throws in some extra .o
++	# files that make .init and .fini sections work.
++	_LT_TAGVAR(archive_cmds, $1)='$CC -G ${wl}-h $soname -o $lib $libobjs $deplibs $compiler_flags'
++      else
++	_LT_TAGVAR(archive_cmds, $1)='$LD -assert pure-text -Bstatic -o $lib $libobjs $deplibs $linker_flags'
++      fi
++      _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='-L$libdir'
++      _LT_TAGVAR(hardcode_direct, $1)=yes
++      _LT_TAGVAR(hardcode_minus_L, $1)=yes
++      _LT_TAGVAR(hardcode_shlibpath_var, $1)=no
++      ;;
++
++    sysv4)
++      case $host_vendor in
++	sni)
++	  _LT_TAGVAR(archive_cmds, $1)='$LD -G -h $soname -o $lib $libobjs $deplibs $linker_flags'
++	  _LT_TAGVAR(hardcode_direct, $1)=yes # is this really true???
++	;;
++	siemens)
++	  ## LD is ld it makes a PLAMLIB
++	  ## CC just makes a GrossModule.
++	  _LT_TAGVAR(archive_cmds, $1)='$LD -G -o $lib $libobjs $deplibs $linker_flags'
++	  _LT_TAGVAR(reload_cmds, $1)='$CC -r -o $output$reload_objs'
++	  _LT_TAGVAR(hardcode_direct, $1)=no
++        ;;
++	motorola)
++	  _LT_TAGVAR(archive_cmds, $1)='$LD -G -h $soname -o $lib $libobjs $deplibs $linker_flags'
++	  _LT_TAGVAR(hardcode_direct, $1)=no #Motorola manual says yes, but my tests say they lie
++	;;
++      esac
++      runpath_var='LD_RUN_PATH'
++      _LT_TAGVAR(hardcode_shlibpath_var, $1)=no
++      ;;
++
++    sysv4.3*)
++      _LT_TAGVAR(archive_cmds, $1)='$LD -G -h $soname -o $lib $libobjs $deplibs $linker_flags'
++      _LT_TAGVAR(hardcode_shlibpath_var, $1)=no
++      _LT_TAGVAR(export_dynamic_flag_spec, $1)='-Bexport'
++      ;;
++
++    sysv4*MP*)
++      if test -d /usr/nec; then
++	_LT_TAGVAR(archive_cmds, $1)='$LD -G -h $soname -o $lib $libobjs $deplibs $linker_flags'
++	_LT_TAGVAR(hardcode_shlibpath_var, $1)=no
++	runpath_var=LD_RUN_PATH
++	hardcode_runpath_var=yes
++	_LT_TAGVAR(ld_shlibs, $1)=yes
++      fi
++      ;;
++
++    sysv4*uw2* | sysv5OpenUNIX* | sysv5UnixWare7.[[01]].[[10]]* | unixware7* | sco3.2v5.0.[[024]]*)
++      _LT_TAGVAR(no_undefined_flag, $1)='${wl}-z,text'
++      _LT_TAGVAR(archive_cmds_need_lc, $1)=no
++      _LT_TAGVAR(hardcode_shlibpath_var, $1)=no
++      runpath_var='LD_RUN_PATH'
++
++      if test "$GCC" = yes; then
++	_LT_TAGVAR(archive_cmds, $1)='$CC -shared ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++	_LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared ${wl}-Bexport:$export_symbols ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++      else
++	_LT_TAGVAR(archive_cmds, $1)='$CC -G ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++	_LT_TAGVAR(archive_expsym_cmds, $1)='$CC -G ${wl}-Bexport:$export_symbols ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++      fi
++      ;;
++
++    sysv5* | sco3.2v5* | sco5v6*)
++      # Note: We can NOT use -z defs as we might desire, because we do not
++      # link with -lc, and that would cause any symbols used from libc to
++      # always be unresolved, which means just about no library would
++      # ever link correctly.  If we're not using GNU ld we use -z text
++      # though, which does catch some bad symbols but isn't as heavy-handed
++      # as -z defs.
++      _LT_TAGVAR(no_undefined_flag, $1)='${wl}-z,text'
++      _LT_TAGVAR(allow_undefined_flag, $1)='${wl}-z,nodefs'
++      _LT_TAGVAR(archive_cmds_need_lc, $1)=no
++      _LT_TAGVAR(hardcode_shlibpath_var, $1)=no
++      _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-R,$libdir'
++      _LT_TAGVAR(hardcode_libdir_separator, $1)=':'
++      _LT_TAGVAR(link_all_deplibs, $1)=yes
++      _LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}-Bexport'
++      runpath_var='LD_RUN_PATH'
++
++      if test "$GCC" = yes; then
++	_LT_TAGVAR(archive_cmds, $1)='$CC -shared ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++	_LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared ${wl}-Bexport:$export_symbols ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++      else
++	_LT_TAGVAR(archive_cmds, $1)='$CC -G ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++	_LT_TAGVAR(archive_expsym_cmds, $1)='$CC -G ${wl}-Bexport:$export_symbols ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++      fi
++      ;;
++
++    uts4*)
++      _LT_TAGVAR(archive_cmds, $1)='$LD -G -h $soname -o $lib $libobjs $deplibs $linker_flags'
++      _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='-L$libdir'
++      _LT_TAGVAR(hardcode_shlibpath_var, $1)=no
++      ;;
++
++    *)
++      _LT_TAGVAR(ld_shlibs, $1)=no
++      ;;
++    esac
++
++    if test x$host_vendor = xsni; then
++      case $host in
++      sysv4 | sysv4.2uw2* | sysv4.3* | sysv5*)
++	_LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}-Blargedynsym'
++	;;
++      esac
++    fi
++  fi
++])
++AC_MSG_RESULT([$_LT_TAGVAR(ld_shlibs, $1)])
++test "$_LT_TAGVAR(ld_shlibs, $1)" = no && can_build_shared=no
++
++_LT_TAGVAR(with_gnu_ld, $1)=$with_gnu_ld
++
++_LT_DECL([], [libext], [0], [Old archive suffix (normally "a")])dnl
++_LT_DECL([], [shrext_cmds], [1], [Shared library suffix (normally ".so")])dnl
++_LT_DECL([], [extract_expsyms_cmds], [2],
++    [The commands to extract the exported symbol list from a shared archive])
++
++#
++# Do we need to explicitly link libc?
++#
++case "x$_LT_TAGVAR(archive_cmds_need_lc, $1)" in
++x|xyes)
++  # Assume -lc should be added
++  _LT_TAGVAR(archive_cmds_need_lc, $1)=yes
++
++  if test "$enable_shared" = yes && test "$GCC" = yes; then
++    case $_LT_TAGVAR(archive_cmds, $1) in
++    *'~'*)
++      # FIXME: we may have to deal with multi-command sequences.
++      ;;
++    '$CC '*)
++      # Test whether the compiler implicitly links with -lc since on some
++      # systems, -lgcc has to come before -lc. If gcc already passes -lc
++      # to ld, don't add -lc before -lgcc.
++      AC_CACHE_CHECK([whether -lc should be explicitly linked in],
++	[lt_cv_]_LT_TAGVAR(archive_cmds_need_lc, $1),
++	[$RM conftest*
++	echo "$lt_simple_compile_test_code" > conftest.$ac_ext
++
++	if AC_TRY_EVAL(ac_compile) 2>conftest.err; then
++	  soname=conftest
++	  lib=conftest
++	  libobjs=conftest.$ac_objext
++	  deplibs=
++	  wl=$_LT_TAGVAR(lt_prog_compiler_wl, $1)
++	  pic_flag=$_LT_TAGVAR(lt_prog_compiler_pic, $1)
++	  compiler_flags=-v
++	  linker_flags=-v
++	  verstring=
++	  output_objdir=.
++	  libname=conftest
++	  lt_save_allow_undefined_flag=$_LT_TAGVAR(allow_undefined_flag, $1)
++	  _LT_TAGVAR(allow_undefined_flag, $1)=
++	  if AC_TRY_EVAL(_LT_TAGVAR(archive_cmds, $1) 2\>\&1 \| $GREP \" -lc \" \>/dev/null 2\>\&1)
++	  then
++	    lt_cv_[]_LT_TAGVAR(archive_cmds_need_lc, $1)=no
++	  else
++	    lt_cv_[]_LT_TAGVAR(archive_cmds_need_lc, $1)=yes
++	  fi
++	  _LT_TAGVAR(allow_undefined_flag, $1)=$lt_save_allow_undefined_flag
++	else
++	  cat conftest.err 1>&5
++	fi
++	$RM conftest*
++	])
++      _LT_TAGVAR(archive_cmds_need_lc, $1)=$lt_cv_[]_LT_TAGVAR(archive_cmds_need_lc, $1)
++      ;;
++    esac
++  fi
++  ;;
++esac
++
++_LT_TAGDECL([build_libtool_need_lc], [archive_cmds_need_lc], [0],
++    [Whether or not to add -lc for building shared libraries])
++_LT_TAGDECL([allow_libtool_libs_with_static_runtimes],
++    [enable_shared_with_static_runtimes], [0],
++    [Whether or not to disallow shared libs when runtime libs are static])
++_LT_TAGDECL([], [export_dynamic_flag_spec], [1],
++    [Compiler flag to allow reflexive dlopens])
++_LT_TAGDECL([], [whole_archive_flag_spec], [1],
++    [Compiler flag to generate shared objects directly from archives])
++_LT_TAGDECL([], [compiler_needs_object], [1],
++    [Whether the compiler copes with passing no objects directly])
++_LT_TAGDECL([], [old_archive_from_new_cmds], [2],
++    [Create an old-style archive from a shared archive])
++_LT_TAGDECL([], [old_archive_from_expsyms_cmds], [2],
++    [Create a temporary old-style archive to link instead of a shared archive])
++_LT_TAGDECL([], [archive_cmds], [2], [Commands used to build a shared archive])
++_LT_TAGDECL([], [archive_expsym_cmds], [2])
++_LT_TAGDECL([], [module_cmds], [2],
++    [Commands used to build a loadable module if different from building
++    a shared archive.])
++_LT_TAGDECL([], [module_expsym_cmds], [2])
++_LT_TAGDECL([], [with_gnu_ld], [1],
++    [Whether we are building with GNU ld or not])
++_LT_TAGDECL([], [allow_undefined_flag], [1],
++    [Flag that allows shared libraries with undefined symbols to be built])
++_LT_TAGDECL([], [no_undefined_flag], [1],
++    [Flag that enforces no undefined symbols])
++_LT_TAGDECL([], [hardcode_libdir_flag_spec], [1],
++    [Flag to hardcode $libdir into a binary during linking.
++    This must work even if $libdir does not exist])
++_LT_TAGDECL([], [hardcode_libdir_separator], [1],
++    [Whether we need a single "-rpath" flag with a separated argument])
++_LT_TAGDECL([], [hardcode_direct], [0],
++    [Set to "yes" if using DIR/libNAME${shared_ext} during linking hardcodes
++    DIR into the resulting binary])
++_LT_TAGDECL([], [hardcode_direct_absolute], [0],
++    [Set to "yes" if using DIR/libNAME${shared_ext} during linking hardcodes
++    DIR into the resulting binary and the resulting library dependency is
++    "absolute", i.e impossible to change by setting ${shlibpath_var} if the
++    library is relocated])
++_LT_TAGDECL([], [hardcode_minus_L], [0],
++    [Set to "yes" if using the -LDIR flag during linking hardcodes DIR
++    into the resulting binary])
++_LT_TAGDECL([], [hardcode_shlibpath_var], [0],
++    [Set to "yes" if using SHLIBPATH_VAR=DIR during linking hardcodes DIR
++    into the resulting binary])
++_LT_TAGDECL([], [hardcode_automatic], [0],
++    [Set to "yes" if building a shared library automatically hardcodes DIR
++    into the library and all subsequent libraries and executables linked
++    against it])
++_LT_TAGDECL([], [inherit_rpath], [0],
++    [Set to yes if linker adds runtime paths of dependent libraries
++    to runtime path list])
++_LT_TAGDECL([], [link_all_deplibs], [0],
++    [Whether libtool must link a program against all its dependency libraries])
++_LT_TAGDECL([], [always_export_symbols], [0],
++    [Set to "yes" if exported symbols are required])
++_LT_TAGDECL([], [export_symbols_cmds], [2],
++    [The commands to list exported symbols])
++_LT_TAGDECL([], [exclude_expsyms], [1],
++    [Symbols that should not be listed in the preloaded symbols])
++_LT_TAGDECL([], [include_expsyms], [1],
++    [Symbols that must always be exported])
++_LT_TAGDECL([], [prelink_cmds], [2],
++    [Commands necessary for linking programs (against libraries) with templates])
++_LT_TAGDECL([], [postlink_cmds], [2],
++    [Commands necessary for finishing linking programs])
++_LT_TAGDECL([], [file_list_spec], [1],
++    [Specify filename containing input files])
++dnl FIXME: Not yet implemented
++dnl _LT_TAGDECL([], [thread_safe_flag_spec], [1],
++dnl    [Compiler flag to generate thread safe objects])
++])# _LT_LINKER_SHLIBS
++
++
++# _LT_LANG_C_CONFIG([TAG])
++# ------------------------
++# Ensure that the configuration variables for a C compiler are suitably
++# defined.  These variables are subsequently used by _LT_CONFIG to write
++# the compiler configuration to `libtool'.
++m4_defun([_LT_LANG_C_CONFIG],
++[m4_require([_LT_DECL_EGREP])dnl
++lt_save_CC="$CC"
++AC_LANG_PUSH(C)
++
++# Source file extension for C test sources.
++ac_ext=c
++
++# Object file extension for compiled C test sources.
++objext=o
++_LT_TAGVAR(objext, $1)=$objext
++
++# Code to be used in simple compile tests
++lt_simple_compile_test_code="int some_variable = 0;"
++
++# Code to be used in simple link tests
++lt_simple_link_test_code='int main(){return(0);}'
++
++_LT_TAG_COMPILER
++# Save the default compiler, since it gets overwritten when the other
++# tags are being tested, and _LT_TAGVAR(compiler, []) is a NOP.
++compiler_DEFAULT=$CC
++
++# save warnings/boilerplate of simple test code
++_LT_COMPILER_BOILERPLATE
++_LT_LINKER_BOILERPLATE
++
++if test -n "$compiler"; then
++  _LT_COMPILER_NO_RTTI($1)
++  _LT_COMPILER_PIC($1)
++  _LT_COMPILER_C_O($1)
++  _LT_COMPILER_FILE_LOCKS($1)
++  _LT_LINKER_SHLIBS($1)
++  _LT_SYS_DYNAMIC_LINKER($1)
++  _LT_LINKER_HARDCODE_LIBPATH($1)
++  LT_SYS_DLOPEN_SELF
++  _LT_CMD_STRIPLIB
++
++  # Report which library types will actually be built
++  AC_MSG_CHECKING([if libtool supports shared libraries])
++  AC_MSG_RESULT([$can_build_shared])
++
++  AC_MSG_CHECKING([whether to build shared libraries])
++  test "$can_build_shared" = "no" && enable_shared=no
++
++  # On AIX, shared libraries and static libraries use the same namespace, and
++  # are all built from PIC.
++  case $host_os in
++  aix3*)
++    test "$enable_shared" = yes && enable_static=no
++    if test -n "$RANLIB"; then
++      archive_cmds="$archive_cmds~\$RANLIB \$lib"
++      postinstall_cmds='$RANLIB $lib'
++    fi
++    ;;
++
++  aix[[4-9]]*)
++    if test "$host_cpu" != ia64 && test "$aix_use_runtimelinking" = no ; then
++      test "$enable_shared" = yes && enable_static=no
++    fi
++    ;;
++  esac
++  AC_MSG_RESULT([$enable_shared])
++
++  AC_MSG_CHECKING([whether to build static libraries])
++  # Make sure either enable_shared or enable_static is yes.
++  test "$enable_shared" = yes || enable_static=yes
++  AC_MSG_RESULT([$enable_static])
++
++  _LT_CONFIG($1)
++fi
++AC_LANG_POP
++CC="$lt_save_CC"
++])# _LT_LANG_C_CONFIG
++
++
++# _LT_LANG_CXX_CONFIG([TAG])
++# --------------------------
++# Ensure that the configuration variables for a C++ compiler are suitably
++# defined.  These variables are subsequently used by _LT_CONFIG to write
++# the compiler configuration to `libtool'.
++m4_defun([_LT_LANG_CXX_CONFIG],
++[m4_require([_LT_FILEUTILS_DEFAULTS])dnl
++m4_require([_LT_DECL_EGREP])dnl
++m4_require([_LT_PATH_MANIFEST_TOOL])dnl
++if test -n "$CXX" && ( test "X$CXX" != "Xno" &&
++    ( (test "X$CXX" = "Xg++" && `g++ -v >/dev/null 2>&1` ) ||
++    (test "X$CXX" != "Xg++"))) ; then
++  AC_PROG_CXXCPP
++else
++  _lt_caught_CXX_error=yes
++fi
++
++AC_LANG_PUSH(C++)
++_LT_TAGVAR(archive_cmds_need_lc, $1)=no
++_LT_TAGVAR(allow_undefined_flag, $1)=
++_LT_TAGVAR(always_export_symbols, $1)=no
++_LT_TAGVAR(archive_expsym_cmds, $1)=
++_LT_TAGVAR(compiler_needs_object, $1)=no
++_LT_TAGVAR(export_dynamic_flag_spec, $1)=
++_LT_TAGVAR(hardcode_direct, $1)=no
++_LT_TAGVAR(hardcode_direct_absolute, $1)=no
++_LT_TAGVAR(hardcode_libdir_flag_spec, $1)=
++_LT_TAGVAR(hardcode_libdir_separator, $1)=
++_LT_TAGVAR(hardcode_minus_L, $1)=no
++_LT_TAGVAR(hardcode_shlibpath_var, $1)=unsupported
++_LT_TAGVAR(hardcode_automatic, $1)=no
++_LT_TAGVAR(inherit_rpath, $1)=no
++_LT_TAGVAR(module_cmds, $1)=
++_LT_TAGVAR(module_expsym_cmds, $1)=
++_LT_TAGVAR(link_all_deplibs, $1)=unknown
++_LT_TAGVAR(old_archive_cmds, $1)=$old_archive_cmds
++_LT_TAGVAR(reload_flag, $1)=$reload_flag
++_LT_TAGVAR(reload_cmds, $1)=$reload_cmds
++_LT_TAGVAR(no_undefined_flag, $1)=
++_LT_TAGVAR(whole_archive_flag_spec, $1)=
++_LT_TAGVAR(enable_shared_with_static_runtimes, $1)=no
++
++# Source file extension for C++ test sources.
++ac_ext=cpp
++
++# Object file extension for compiled C++ test sources.
++objext=o
++_LT_TAGVAR(objext, $1)=$objext
++
++# No sense in running all these tests if we already determined that
++# the CXX compiler isn't working.  Some variables (like enable_shared)
++# are currently assumed to apply to all compilers on this platform,
++# and will be corrupted by setting them based on a non-working compiler.
++if test "$_lt_caught_CXX_error" != yes; then
++  # Code to be used in simple compile tests
++  lt_simple_compile_test_code="int some_variable = 0;"
++
++  # Code to be used in simple link tests
++  lt_simple_link_test_code='int main(int, char *[[]]) { return(0); }'
++
++  # ltmain only uses $CC for tagged configurations so make sure $CC is set.
++  _LT_TAG_COMPILER
++
++  # save warnings/boilerplate of simple test code
++  _LT_COMPILER_BOILERPLATE
++  _LT_LINKER_BOILERPLATE
++
++  # Allow CC to be a program name with arguments.
++  lt_save_CC=$CC
++  lt_save_CFLAGS=$CFLAGS
++  lt_save_LD=$LD
++  lt_save_GCC=$GCC
++  GCC=$GXX
++  lt_save_with_gnu_ld=$with_gnu_ld
++  lt_save_path_LD=$lt_cv_path_LD
++  if test -n "${lt_cv_prog_gnu_ldcxx+set}"; then
++    lt_cv_prog_gnu_ld=$lt_cv_prog_gnu_ldcxx
++  else
++    $as_unset lt_cv_prog_gnu_ld
++  fi
++  if test -n "${lt_cv_path_LDCXX+set}"; then
++    lt_cv_path_LD=$lt_cv_path_LDCXX
++  else
++    $as_unset lt_cv_path_LD
++  fi
++  test -z "${LDCXX+set}" || LD=$LDCXX
++  CC=${CXX-"c++"}
++  CFLAGS=$CXXFLAGS
++  compiler=$CC
++  _LT_TAGVAR(compiler, $1)=$CC
++  _LT_CC_BASENAME([$compiler])
++
++  if test -n "$compiler"; then
++    # We don't want -fno-exception when compiling C++ code, so set the
++    # no_builtin_flag separately
++    if test "$GXX" = yes; then
++      _LT_TAGVAR(lt_prog_compiler_no_builtin_flag, $1)=' -fno-builtin'
++    else
++      _LT_TAGVAR(lt_prog_compiler_no_builtin_flag, $1)=
++    fi
++
++    if test "$GXX" = yes; then
++      # Set up default GNU C++ configuration
++
++      LT_PATH_LD
++
++      # Check if GNU C++ uses GNU ld as the underlying linker, since the
++      # archiving commands below assume that GNU ld is being used.
++      if test "$with_gnu_ld" = yes; then
++        _LT_TAGVAR(archive_cmds, $1)='$CC $pic_flag -shared -nostdlib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname $wl$soname -o $lib'
++        _LT_TAGVAR(archive_expsym_cmds, $1)='$CC $pic_flag -shared -nostdlib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname $wl$soname ${wl}-retain-symbols-file $wl$export_symbols -o $lib'
++
++        _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-rpath ${wl}$libdir'
++        _LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}--export-dynamic'
++
++        # If archive_cmds runs LD, not CC, wlarc should be empty
++        # XXX I think wlarc can be eliminated in ltcf-cxx, but I need to
++        #     investigate it a little bit more. (MM)
++        wlarc='${wl}'
++
++        # ancient GNU ld didn't support --whole-archive et. al.
++        if eval "`$CC -print-prog-name=ld` --help 2>&1" |
++	  $GREP 'no-whole-archive' > /dev/null; then
++          _LT_TAGVAR(whole_archive_flag_spec, $1)="$wlarc"'--whole-archive$convenience '"$wlarc"'--no-whole-archive'
++        else
++          _LT_TAGVAR(whole_archive_flag_spec, $1)=
++        fi
++      else
++        with_gnu_ld=no
++        wlarc=
++
++        # A generic and very simple default shared library creation
++        # command for GNU C++ for the case where it uses the native
++        # linker, instead of GNU ld.  If possible, this setting should
++        # overridden to take advantage of the native linker features on
++        # the platform it is being used on.
++        _LT_TAGVAR(archive_cmds, $1)='$CC -shared -nostdlib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags -o $lib'
++      fi
++
++      # Commands to make compiler produce verbose output that lists
++      # what "hidden" libraries, object files and flags are used when
++      # linking a shared library.
++      output_verbose_link_cmd='$CC -shared $CFLAGS -v conftest.$objext 2>&1 | $GREP -v "^Configured with:" | $GREP "\-L"'
++
++    else
++      GXX=no
++      with_gnu_ld=no
++      wlarc=
++    fi
++
++    # PORTME: fill in a description of your system's C++ link characteristics
++    AC_MSG_CHECKING([whether the $compiler linker ($LD) supports shared libraries])
++    _LT_TAGVAR(ld_shlibs, $1)=yes
++    case $host_os in
++      aix3*)
++        # FIXME: insert proper C++ library support
++        _LT_TAGVAR(ld_shlibs, $1)=no
++        ;;
++      aix[[4-9]]*)
++        if test "$host_cpu" = ia64; then
++          # On IA64, the linker does run time linking by default, so we don't
++          # have to do anything special.
++          aix_use_runtimelinking=no
++          exp_sym_flag='-Bexport'
++          no_entry_flag=""
++        else
++          aix_use_runtimelinking=no
++
++          # Test if we are trying to use run time linking or normal
++          # AIX style linking. If -brtl is somewhere in LDFLAGS, we
++          # need to do runtime linking.
++          case $host_os in aix4.[[23]]|aix4.[[23]].*|aix[[5-9]]*)
++	    for ld_flag in $LDFLAGS; do
++	      case $ld_flag in
++	      *-brtl*)
++	        aix_use_runtimelinking=yes
++	        break
++	        ;;
++	      esac
++	    done
++	    ;;
++          esac
++
++          exp_sym_flag='-bexport'
++          no_entry_flag='-bnoentry'
++        fi
++
++        # When large executables or shared objects are built, AIX ld can
++        # have problems creating the table of contents.  If linking a library
++        # or program results in "error TOC overflow" add -mminimal-toc to
++        # CXXFLAGS/CFLAGS for g++/gcc.  In the cases where that is not
++        # enough to fix the problem, add -Wl,-bbigtoc to LDFLAGS.
++
++        _LT_TAGVAR(archive_cmds, $1)=''
++        _LT_TAGVAR(hardcode_direct, $1)=yes
++        _LT_TAGVAR(hardcode_direct_absolute, $1)=yes
++        _LT_TAGVAR(hardcode_libdir_separator, $1)=':'
++        _LT_TAGVAR(link_all_deplibs, $1)=yes
++        _LT_TAGVAR(file_list_spec, $1)='${wl}-f,'
++
++        if test "$GXX" = yes; then
++          case $host_os in aix4.[[012]]|aix4.[[012]].*)
++          # We only want to do this on AIX 4.2 and lower, the check
++          # below for broken collect2 doesn't work under 4.3+
++	  collect2name=`${CC} -print-prog-name=collect2`
++	  if test -f "$collect2name" &&
++	     strings "$collect2name" | $GREP resolve_lib_name >/dev/null
++	  then
++	    # We have reworked collect2
++	    :
++	  else
++	    # We have old collect2
++	    _LT_TAGVAR(hardcode_direct, $1)=unsupported
++	    # It fails to find uninstalled libraries when the uninstalled
++	    # path is not listed in the libpath.  Setting hardcode_minus_L
++	    # to unsupported forces relinking
++	    _LT_TAGVAR(hardcode_minus_L, $1)=yes
++	    _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='-L$libdir'
++	    _LT_TAGVAR(hardcode_libdir_separator, $1)=
++	  fi
++          esac
++          shared_flag='-shared'
++	  if test "$aix_use_runtimelinking" = yes; then
++	    shared_flag="$shared_flag "'${wl}-G'
++	  fi
++        else
++          # not using gcc
++          if test "$host_cpu" = ia64; then
++	  # VisualAge C++, Version 5.5 for AIX 5L for IA-64, Beta 3 Release
++	  # chokes on -Wl,-G. The following line is correct:
++	  shared_flag='-G'
++          else
++	    if test "$aix_use_runtimelinking" = yes; then
++	      shared_flag='${wl}-G'
++	    else
++	      shared_flag='${wl}-bM:SRE'
++	    fi
++          fi
++        fi
++
++        _LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}-bexpall'
++        # It seems that -bexpall does not export symbols beginning with
++        # underscore (_), so it is better to generate a list of symbols to
++	# export.
++        _LT_TAGVAR(always_export_symbols, $1)=yes
++        if test "$aix_use_runtimelinking" = yes; then
++          # Warning - without using the other runtime loading flags (-brtl),
++          # -berok will link without error, but may produce a broken library.
++          _LT_TAGVAR(allow_undefined_flag, $1)='-berok'
++          # Determine the default libpath from the value encoded in an empty
++          # executable.
++          _LT_SYS_MODULE_PATH_AIX([$1])
++          _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-blibpath:$libdir:'"$aix_libpath"
++
++          _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -o $output_objdir/$soname $libobjs $deplibs '"\${wl}$no_entry_flag"' $compiler_flags `if test "x${allow_undefined_flag}" != "x"; then func_echo_all "${wl}${allow_undefined_flag}"; else :; fi` '"\${wl}$exp_sym_flag:\$export_symbols $shared_flag"
++        else
++          if test "$host_cpu" = ia64; then
++	    _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-R $libdir:/usr/lib:/lib'
++	    _LT_TAGVAR(allow_undefined_flag, $1)="-z nodefs"
++	    _LT_TAGVAR(archive_expsym_cmds, $1)="\$CC $shared_flag"' -o $output_objdir/$soname $libobjs $deplibs '"\${wl}$no_entry_flag"' $compiler_flags ${wl}${allow_undefined_flag} '"\${wl}$exp_sym_flag:\$export_symbols"
++          else
++	    # Determine the default libpath from the value encoded in an
++	    # empty executable.
++	    _LT_SYS_MODULE_PATH_AIX([$1])
++	    _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-blibpath:$libdir:'"$aix_libpath"
++	    # Warning - without using the other run time loading flags,
++	    # -berok will link without error, but may produce a broken library.
++	    _LT_TAGVAR(no_undefined_flag, $1)=' ${wl}-bernotok'
++	    _LT_TAGVAR(allow_undefined_flag, $1)=' ${wl}-berok'
++	    if test "$with_gnu_ld" = yes; then
++	      # We only use this code for GNU lds that support --whole-archive.
++	      _LT_TAGVAR(whole_archive_flag_spec, $1)='${wl}--whole-archive$convenience ${wl}--no-whole-archive'
++	    else
++	      # Exported symbols can be pulled into shared objects from archives
++	      _LT_TAGVAR(whole_archive_flag_spec, $1)='$convenience'
++	    fi
++	    _LT_TAGVAR(archive_cmds_need_lc, $1)=yes
++	    # This is similar to how AIX traditionally builds its shared
++	    # libraries.
++	    _LT_TAGVAR(archive_expsym_cmds, $1)="\$CC $shared_flag"' -o $output_objdir/$soname $libobjs $deplibs ${wl}-bnoentry $compiler_flags ${wl}-bE:$export_symbols${allow_undefined_flag}~$AR $AR_FLAGS $output_objdir/$libname$release.a $output_objdir/$soname'
++          fi
++        fi
++        ;;
++
++      beos*)
++	if $LD --help 2>&1 | $GREP ': supported targets:.* elf' > /dev/null; then
++	  _LT_TAGVAR(allow_undefined_flag, $1)=unsupported
++	  # Joseph Beckenbach <jrb3@best.com> says some releases of gcc
++	  # support --undefined.  This deserves some investigation.  FIXME
++	  _LT_TAGVAR(archive_cmds, $1)='$CC -nostart $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
++	else
++	  _LT_TAGVAR(ld_shlibs, $1)=no
++	fi
++	;;
++
++      chorus*)
++        case $cc_basename in
++          *)
++	  # FIXME: insert proper C++ library support
++	  _LT_TAGVAR(ld_shlibs, $1)=no
++	  ;;
++        esac
++        ;;
++
++      cygwin* | mingw* | pw32* | cegcc*)
++	case $GXX,$cc_basename in
++	,cl* | no,cl*)
++	  # Native MSVC
++	  # hardcode_libdir_flag_spec is actually meaningless, as there is
++	  # no search path for DLLs.
++	  _LT_TAGVAR(hardcode_libdir_flag_spec, $1)=' '
++	  _LT_TAGVAR(allow_undefined_flag, $1)=unsupported
++	  _LT_TAGVAR(always_export_symbols, $1)=yes
++	  _LT_TAGVAR(file_list_spec, $1)='@'
++	  # Tell ltmain to make .lib files, not .a files.
++	  libext=lib
++	  # Tell ltmain to make .dll files, not .so files.
++	  shrext_cmds=".dll"
++	  # FIXME: Setting linknames here is a bad hack.
++	  _LT_TAGVAR(archive_cmds, $1)='$CC -o $output_objdir/$soname $libobjs $compiler_flags $deplibs -Wl,-dll~linknames='
++	  _LT_TAGVAR(archive_expsym_cmds, $1)='if test "x`$SED 1q $export_symbols`" = xEXPORTS; then
++	      $SED -n -e 's/\\\\\\\(.*\\\\\\\)/-link\\\ -EXPORT:\\\\\\\1/' -e '1\\\!p' < $export_symbols > $output_objdir/$soname.exp;
++	    else
++	      $SED -e 's/\\\\\\\(.*\\\\\\\)/-link\\\ -EXPORT:\\\\\\\1/' < $export_symbols > $output_objdir/$soname.exp;
++	    fi~
++	    $CC -o $tool_output_objdir$soname $libobjs $compiler_flags $deplibs "@$tool_output_objdir$soname.exp" -Wl,-DLL,-IMPLIB:"$tool_output_objdir$libname.dll.lib"~
++	    linknames='
++	  # The linker will not automatically build a static lib if we build a DLL.
++	  # _LT_TAGVAR(old_archive_from_new_cmds, $1)='true'
++	  _LT_TAGVAR(enable_shared_with_static_runtimes, $1)=yes
++	  # Don't use ranlib
++	  _LT_TAGVAR(old_postinstall_cmds, $1)='chmod 644 $oldlib'
++	  _LT_TAGVAR(postlink_cmds, $1)='lt_outputfile="@OUTPUT@"~
++	    lt_tool_outputfile="@TOOL_OUTPUT@"~
++	    case $lt_outputfile in
++	      *.exe|*.EXE) ;;
++	      *)
++		lt_outputfile="$lt_outputfile.exe"
++		lt_tool_outputfile="$lt_tool_outputfile.exe"
++		;;
++	    esac~
++	    func_to_tool_file "$lt_outputfile"~
++	    if test "$MANIFEST_TOOL" != ":" && test -f "$lt_outputfile.manifest"; then
++	      $MANIFEST_TOOL -manifest "$lt_tool_outputfile.manifest" -outputresource:"$lt_tool_outputfile" || exit 1;
++	      $RM "$lt_outputfile.manifest";
++	    fi'
++	  ;;
++	*)
++	  # g++
++	  # _LT_TAGVAR(hardcode_libdir_flag_spec, $1) is actually meaningless,
++	  # as there is no search path for DLLs.
++	  _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='-L$libdir'
++	  _LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}--export-all-symbols'
++	  _LT_TAGVAR(allow_undefined_flag, $1)=unsupported
++	  _LT_TAGVAR(always_export_symbols, $1)=no
++	  _LT_TAGVAR(enable_shared_with_static_runtimes, $1)=yes
++
++	  if $LD --help 2>&1 | $GREP 'auto-import' > /dev/null; then
++	    _LT_TAGVAR(archive_cmds, $1)='$CC -shared -nostdlib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags -o $output_objdir/$soname ${wl}--enable-auto-image-base -Xlinker --out-implib -Xlinker $lib'
++	    # If the export-symbols file already is a .def file (1st line
++	    # is EXPORTS), use it as is; otherwise, prepend...
++	    _LT_TAGVAR(archive_expsym_cmds, $1)='if test "x`$SED 1q $export_symbols`" = xEXPORTS; then
++	      cp $export_symbols $output_objdir/$soname.def;
++	    else
++	      echo EXPORTS > $output_objdir/$soname.def;
++	      cat $export_symbols >> $output_objdir/$soname.def;
++	    fi~
++	    $CC -shared -nostdlib $output_objdir/$soname.def $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags -o $output_objdir/$soname ${wl}--enable-auto-image-base -Xlinker --out-implib -Xlinker $lib'
++	  else
++	    _LT_TAGVAR(ld_shlibs, $1)=no
++	  fi
++	  ;;
++	esac
++	;;
++      darwin* | rhapsody*)
++        _LT_DARWIN_LINKER_FEATURES($1)
++	;;
++
++      dgux*)
++        case $cc_basename in
++          ec++*)
++	    # FIXME: insert proper C++ library support
++	    _LT_TAGVAR(ld_shlibs, $1)=no
++	    ;;
++          ghcx*)
++	    # Green Hills C++ Compiler
++	    # FIXME: insert proper C++ library support
++	    _LT_TAGVAR(ld_shlibs, $1)=no
++	    ;;
++          *)
++	    # FIXME: insert proper C++ library support
++	    _LT_TAGVAR(ld_shlibs, $1)=no
++	    ;;
++        esac
++        ;;
++
++      freebsd2.*)
++        # C++ shared libraries reported to be fairly broken before
++	# switch to ELF
++        _LT_TAGVAR(ld_shlibs, $1)=no
++        ;;
++
++      freebsd-elf*)
++        _LT_TAGVAR(archive_cmds_need_lc, $1)=no
++        ;;
++
++      freebsd* | dragonfly*)
++        # FreeBSD 3 and later use GNU C++ and GNU ld with standard ELF
++        # conventions
++        _LT_TAGVAR(ld_shlibs, $1)=yes
++        ;;
++
++      haiku*)
++        _LT_TAGVAR(archive_cmds, $1)='$CC -shared $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
++        _LT_TAGVAR(link_all_deplibs, $1)=yes
++        ;;
++
++      hpux9*)
++        _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}+b ${wl}$libdir'
++        _LT_TAGVAR(hardcode_libdir_separator, $1)=:
++        _LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}-E'
++        _LT_TAGVAR(hardcode_direct, $1)=yes
++        _LT_TAGVAR(hardcode_minus_L, $1)=yes # Not in the search PATH,
++				             # but as the default
++				             # location of the library.
++
++        case $cc_basename in
++          CC*)
++            # FIXME: insert proper C++ library support
++            _LT_TAGVAR(ld_shlibs, $1)=no
++            ;;
++          aCC*)
++            _LT_TAGVAR(archive_cmds, $1)='$RM $output_objdir/$soname~$CC -b ${wl}+b ${wl}$install_libdir -o $output_objdir/$soname $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags~test $output_objdir/$soname = $lib || mv $output_objdir/$soname $lib'
++            # Commands to make compiler produce verbose output that lists
++            # what "hidden" libraries, object files and flags are used when
++            # linking a shared library.
++            #
++            # There doesn't appear to be a way to prevent this compiler from
++            # explicitly linking system object files so we need to strip them
++            # from the output so that they don't get included in the library
++            # dependencies.
++            output_verbose_link_cmd='templist=`($CC -b $CFLAGS -v conftest.$objext 2>&1) | $EGREP "\-L"`; list=""; for z in $templist; do case $z in conftest.$objext) list="$list $z";; *.$objext);; *) list="$list $z";;esac; done; func_echo_all "$list"'
++            ;;
++          *)
++            if test "$GXX" = yes; then
++              _LT_TAGVAR(archive_cmds, $1)='$RM $output_objdir/$soname~$CC -shared -nostdlib $pic_flag ${wl}+b ${wl}$install_libdir -o $output_objdir/$soname $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags~test $output_objdir/$soname = $lib || mv $output_objdir/$soname $lib'
++            else
++              # FIXME: insert proper C++ library support
++              _LT_TAGVAR(ld_shlibs, $1)=no
++            fi
++            ;;
++        esac
++        ;;
++
++      hpux10*|hpux11*)
++        if test $with_gnu_ld = no; then
++	  _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}+b ${wl}$libdir'
++	  _LT_TAGVAR(hardcode_libdir_separator, $1)=:
++
++          case $host_cpu in
++            hppa*64*|ia64*)
++              ;;
++            *)
++	      _LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}-E'
++              ;;
++          esac
++        fi
++        case $host_cpu in
++          hppa*64*|ia64*)
++            _LT_TAGVAR(hardcode_direct, $1)=no
++            _LT_TAGVAR(hardcode_shlibpath_var, $1)=no
++            ;;
++          *)
++            _LT_TAGVAR(hardcode_direct, $1)=yes
++            _LT_TAGVAR(hardcode_direct_absolute, $1)=yes
++            _LT_TAGVAR(hardcode_minus_L, $1)=yes # Not in the search PATH,
++					         # but as the default
++					         # location of the library.
++            ;;
++        esac
++
++        case $cc_basename in
++          CC*)
++	    # FIXME: insert proper C++ library support
++	    _LT_TAGVAR(ld_shlibs, $1)=no
++	    ;;
++          aCC*)
++	    case $host_cpu in
++	      hppa*64*)
++	        _LT_TAGVAR(archive_cmds, $1)='$CC -b ${wl}+h ${wl}$soname -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags'
++	        ;;
++	      ia64*)
++	        _LT_TAGVAR(archive_cmds, $1)='$CC -b ${wl}+h ${wl}$soname ${wl}+nodefaultrpath -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags'
++	        ;;
++	      *)
++	        _LT_TAGVAR(archive_cmds, $1)='$CC -b ${wl}+h ${wl}$soname ${wl}+b ${wl}$install_libdir -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags'
++	        ;;
++	    esac
++	    # Commands to make compiler produce verbose output that lists
++	    # what "hidden" libraries, object files and flags are used when
++	    # linking a shared library.
++	    #
++	    # There doesn't appear to be a way to prevent this compiler from
++	    # explicitly linking system object files so we need to strip them
++	    # from the output so that they don't get included in the library
++	    # dependencies.
++	    output_verbose_link_cmd='templist=`($CC -b $CFLAGS -v conftest.$objext 2>&1) | $GREP "\-L"`; list=""; for z in $templist; do case $z in conftest.$objext) list="$list $z";; *.$objext);; *) list="$list $z";;esac; done; func_echo_all "$list"'
++	    ;;
++          *)
++	    if test "$GXX" = yes; then
++	      if test $with_gnu_ld = no; then
++	        case $host_cpu in
++	          hppa*64*)
++	            _LT_TAGVAR(archive_cmds, $1)='$CC -shared -nostdlib -fPIC ${wl}+h ${wl}$soname -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags'
++	            ;;
++	          ia64*)
++	            _LT_TAGVAR(archive_cmds, $1)='$CC -shared -nostdlib $pic_flag ${wl}+h ${wl}$soname ${wl}+nodefaultrpath -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags'
++	            ;;
++	          *)
++	            _LT_TAGVAR(archive_cmds, $1)='$CC -shared -nostdlib $pic_flag ${wl}+h ${wl}$soname ${wl}+b ${wl}$install_libdir -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags'
++	            ;;
++	        esac
++	      fi
++	    else
++	      # FIXME: insert proper C++ library support
++	      _LT_TAGVAR(ld_shlibs, $1)=no
++	    fi
++	    ;;
++        esac
++        ;;
++
++      interix[[3-9]]*)
++	_LT_TAGVAR(hardcode_direct, $1)=no
++	_LT_TAGVAR(hardcode_shlibpath_var, $1)=no
++	_LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-rpath,$libdir'
++	_LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}-E'
++	# Hack: On Interix 3.x, we cannot compile PIC because of a broken gcc.
++	# Instead, shared libraries are loaded at an image base (0x10000000 by
++	# default) and relocated if they conflict, which is a slow very memory
++	# consuming and fragmenting process.  To avoid this, we pick a random,
++	# 256 KiB-aligned image base between 0x50000000 and 0x6FFC0000 at link
++	# time.  Moving up from 0x10000000 also allows more sbrk(2) space.
++	_LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-h,$soname ${wl}--image-base,`expr ${RANDOM-$$} % 4096 / 2 \* 262144 + 1342177280` -o $lib'
++	_LT_TAGVAR(archive_expsym_cmds, $1)='sed "s,^,_," $export_symbols >$output_objdir/$soname.expsym~$CC -shared $pic_flag $libobjs $deplibs $compiler_flags ${wl}-h,$soname ${wl}--retain-symbols-file,$output_objdir/$soname.expsym ${wl}--image-base,`expr ${RANDOM-$$} % 4096 / 2 \* 262144 + 1342177280` -o $lib'
++	;;
++      irix5* | irix6*)
++        case $cc_basename in
++          CC*)
++	    # SGI C++
++	    _LT_TAGVAR(archive_cmds, $1)='$CC -shared -all -multigot $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags -soname $soname `test -n "$verstring" && func_echo_all "-set_version $verstring"` -update_registry ${output_objdir}/so_locations -o $lib'
++
++	    # Archives containing C++ object files must be created using
++	    # "CC -ar", where "CC" is the IRIX C++ compiler.  This is
++	    # necessary to make sure instantiated templates are included
++	    # in the archive.
++	    _LT_TAGVAR(old_archive_cmds, $1)='$CC -ar -WR,-u -o $oldlib $oldobjs'
++	    ;;
++          *)
++	    if test "$GXX" = yes; then
++	      if test "$with_gnu_ld" = no; then
++	        _LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag -nostdlib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname `test -n "$verstring" && func_echo_all "${wl}-set_version ${wl}$verstring"` ${wl}-update_registry ${wl}${output_objdir}/so_locations -o $lib'
++	      else
++	        _LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag -nostdlib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname `test -n "$verstring" && func_echo_all "${wl}-set_version ${wl}$verstring"` -o $lib'
++	      fi
++	    fi
++	    _LT_TAGVAR(link_all_deplibs, $1)=yes
++	    ;;
++        esac
++        _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-rpath ${wl}$libdir'
++        _LT_TAGVAR(hardcode_libdir_separator, $1)=:
++        _LT_TAGVAR(inherit_rpath, $1)=yes
++        ;;
++
++      linux* | k*bsd*-gnu | kopensolaris*-gnu | gnu*)
++        case $cc_basename in
++          KCC*)
++	    # Kuck and Associates, Inc. (KAI) C++ Compiler
++
++	    # KCC will only create a shared library if the output file
++	    # ends with ".so" (or ".sl" for HP-UX), so rename the library
++	    # to its proper name (with version) after linking.
++	    _LT_TAGVAR(archive_cmds, $1)='tempext=`echo $shared_ext | $SED -e '\''s/\([[^()0-9A-Za-z{}]]\)/\\\\\1/g'\''`; templib=`echo $lib | $SED -e "s/\${tempext}\..*/.so/"`; $CC $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags --soname $soname -o \$templib; mv \$templib $lib'
++	    _LT_TAGVAR(archive_expsym_cmds, $1)='tempext=`echo $shared_ext | $SED -e '\''s/\([[^()0-9A-Za-z{}]]\)/\\\\\1/g'\''`; templib=`echo $lib | $SED -e "s/\${tempext}\..*/.so/"`; $CC $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags --soname $soname -o \$templib ${wl}-retain-symbols-file,$export_symbols; mv \$templib $lib'
++	    # Commands to make compiler produce verbose output that lists
++	    # what "hidden" libraries, object files and flags are used when
++	    # linking a shared library.
++	    #
++	    # There doesn't appear to be a way to prevent this compiler from
++	    # explicitly linking system object files so we need to strip them
++	    # from the output so that they don't get included in the library
++	    # dependencies.
++	    output_verbose_link_cmd='templist=`$CC $CFLAGS -v conftest.$objext -o libconftest$shared_ext 2>&1 | $GREP "ld"`; rm -f libconftest$shared_ext; list=""; for z in $templist; do case $z in conftest.$objext) list="$list $z";; *.$objext);; *) list="$list $z";;esac; done; func_echo_all "$list"'
++
++	    _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-rpath,$libdir'
++	    _LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}--export-dynamic'
++
++	    # Archives containing C++ object files must be created using
++	    # "CC -Bstatic", where "CC" is the KAI C++ compiler.
++	    _LT_TAGVAR(old_archive_cmds, $1)='$CC -Bstatic -o $oldlib $oldobjs'
++	    ;;
++	  icpc* | ecpc* )
++	    # Intel C++
++	    with_gnu_ld=yes
++	    # version 8.0 and above of icpc choke on multiply defined symbols
++	    # if we add $predep_objects and $postdep_objects, however 7.1 and
++	    # earlier do not add the objects themselves.
++	    case `$CC -V 2>&1` in
++	      *"Version 7."*)
++	        _LT_TAGVAR(archive_cmds, $1)='$CC -shared $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname $wl$soname -o $lib'
++		_LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname $wl$soname ${wl}-retain-symbols-file $wl$export_symbols -o $lib'
++		;;
++	      *)  # Version 8.0 or newer
++	        tmp_idyn=
++	        case $host_cpu in
++		  ia64*) tmp_idyn=' -i_dynamic';;
++		esac
++	        _LT_TAGVAR(archive_cmds, $1)='$CC -shared'"$tmp_idyn"' $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
++		_LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared'"$tmp_idyn"' $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname ${wl}-retain-symbols-file $wl$export_symbols -o $lib'
++		;;
++	    esac
++	    _LT_TAGVAR(archive_cmds_need_lc, $1)=no
++	    _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-rpath,$libdir'
++	    _LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}--export-dynamic'
++	    _LT_TAGVAR(whole_archive_flag_spec, $1)='${wl}--whole-archive$convenience ${wl}--no-whole-archive'
++	    ;;
++          pgCC* | pgcpp*)
++            # Portland Group C++ compiler
++	    case `$CC -V` in
++	    *pgCC\ [[1-5]].* | *pgcpp\ [[1-5]].*)
++	      _LT_TAGVAR(prelink_cmds, $1)='tpldir=Template.dir~
++		rm -rf $tpldir~
++		$CC --prelink_objects --instantiation_dir $tpldir $objs $libobjs $compile_deplibs~
++		compile_command="$compile_command `find $tpldir -name \*.o | sort | $NL2SP`"'
++	      _LT_TAGVAR(old_archive_cmds, $1)='tpldir=Template.dir~
++		rm -rf $tpldir~
++		$CC --prelink_objects --instantiation_dir $tpldir $oldobjs$old_deplibs~
++		$AR $AR_FLAGS $oldlib$oldobjs$old_deplibs `find $tpldir -name \*.o | sort | $NL2SP`~
++		$RANLIB $oldlib'
++	      _LT_TAGVAR(archive_cmds, $1)='tpldir=Template.dir~
++		rm -rf $tpldir~
++		$CC --prelink_objects --instantiation_dir $tpldir $predep_objects $libobjs $deplibs $convenience $postdep_objects~
++		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | sort | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
++	      _LT_TAGVAR(archive_expsym_cmds, $1)='tpldir=Template.dir~
++		rm -rf $tpldir~
++		$CC --prelink_objects --instantiation_dir $tpldir $predep_objects $libobjs $deplibs $convenience $postdep_objects~
++		$CC -shared $pic_flag $predep_objects $libobjs $deplibs `find $tpldir -name \*.o | sort | $NL2SP` $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname ${wl}-retain-symbols-file ${wl}$export_symbols -o $lib'
++	      ;;
++	    *) # Version 6 and above use weak symbols
++	      _LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname -o $lib'
++	      _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $pic_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname ${wl}-retain-symbols-file ${wl}$export_symbols -o $lib'
++	      ;;
++	    esac
++
++	    _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}--rpath ${wl}$libdir'
++	    _LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}--export-dynamic'
++	    _LT_TAGVAR(whole_archive_flag_spec, $1)='${wl}--whole-archive`for conv in $convenience\"\"; do test  -n \"$conv\" && new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` ${wl}--no-whole-archive'
++            ;;
++	  cxx*)
++	    # Compaq C++
++	    _LT_TAGVAR(archive_cmds, $1)='$CC -shared $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname $wl$soname -o $lib'
++	    _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname $wl$soname  -o $lib ${wl}-retain-symbols-file $wl$export_symbols'
++
++	    runpath_var=LD_RUN_PATH
++	    _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='-rpath $libdir'
++	    _LT_TAGVAR(hardcode_libdir_separator, $1)=:
++
++	    # Commands to make compiler produce verbose output that lists
++	    # what "hidden" libraries, object files and flags are used when
++	    # linking a shared library.
++	    #
++	    # There doesn't appear to be a way to prevent this compiler from
++	    # explicitly linking system object files so we need to strip them
++	    # from the output so that they don't get included in the library
++	    # dependencies.
++	    output_verbose_link_cmd='templist=`$CC -shared $CFLAGS -v conftest.$objext 2>&1 | $GREP "ld"`; templist=`func_echo_all "$templist" | $SED "s/\(^.*ld.*\)\( .*ld .*$\)/\1/"`; list=""; for z in $templist; do case $z in conftest.$objext) list="$list $z";; *.$objext);; *) list="$list $z";;esac; done; func_echo_all "X$list" | $Xsed'
++	    ;;
++	  xl* | mpixl* | bgxl*)
++	    # IBM XL 8.0 on PPC, with GNU ld
++	    _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-rpath ${wl}$libdir'
++	    _LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}--export-dynamic'
++	    _LT_TAGVAR(archive_cmds, $1)='$CC -qmkshrobj $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname -o $lib'
++	    if test "x$supports_anon_versioning" = xyes; then
++	      _LT_TAGVAR(archive_expsym_cmds, $1)='echo "{ global:" > $output_objdir/$libname.ver~
++		cat $export_symbols | sed -e "s/\(.*\)/\1;/" >> $output_objdir/$libname.ver~
++		echo "local: *; };" >> $output_objdir/$libname.ver~
++		$CC -qmkshrobj $libobjs $deplibs $compiler_flags ${wl}-soname $wl$soname ${wl}-version-script ${wl}$output_objdir/$libname.ver -o $lib'
++	    fi
++	    ;;
++	  *)
++	    case `$CC -V 2>&1 | sed 5q` in
++	    *Sun\ C*)
++	      # Sun C++ 5.9
++	      _LT_TAGVAR(no_undefined_flag, $1)=' -zdefs'
++	      _LT_TAGVAR(archive_cmds, $1)='$CC -G${allow_undefined_flag} -h$soname -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags'
++	      _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -G${allow_undefined_flag} -h$soname -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-retain-symbols-file ${wl}$export_symbols'
++	      _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='-R$libdir'
++	      _LT_TAGVAR(whole_archive_flag_spec, $1)='${wl}--whole-archive`new_convenience=; for conv in $convenience\"\"; do test -z \"$conv\" || new_convenience=\"$new_convenience,$conv\"; done; func_echo_all \"$new_convenience\"` ${wl}--no-whole-archive'
++	      _LT_TAGVAR(compiler_needs_object, $1)=yes
++
++	      # Not sure whether something based on
++	      # $CC $CFLAGS -v conftest.$objext -o libconftest$shared_ext 2>&1
++	      # would be better.
++	      output_verbose_link_cmd='func_echo_all'
++
++	      # Archives containing C++ object files must be created using
++	      # "CC -xar", where "CC" is the Sun C++ compiler.  This is
++	      # necessary to make sure instantiated templates are included
++	      # in the archive.
++	      _LT_TAGVAR(old_archive_cmds, $1)='$CC -xar -o $oldlib $oldobjs'
++	      ;;
++	    esac
++	    ;;
++	esac
++	;;
++
++      lynxos*)
++        # FIXME: insert proper C++ library support
++	_LT_TAGVAR(ld_shlibs, $1)=no
++	;;
++
++      m88k*)
++        # FIXME: insert proper C++ library support
++        _LT_TAGVAR(ld_shlibs, $1)=no
++	;;
++
++      mvs*)
++        case $cc_basename in
++          cxx*)
++	    # FIXME: insert proper C++ library support
++	    _LT_TAGVAR(ld_shlibs, $1)=no
++	    ;;
++	  *)
++	    # FIXME: insert proper C++ library support
++	    _LT_TAGVAR(ld_shlibs, $1)=no
++	    ;;
++	esac
++	;;
++
++      netbsd*)
++        if echo __ELF__ | $CC -E - | $GREP __ELF__ >/dev/null; then
++	  _LT_TAGVAR(archive_cmds, $1)='$LD -Bshareable  -o $lib $predep_objects $libobjs $deplibs $postdep_objects $linker_flags'
++	  wlarc=
++	  _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='-R$libdir'
++	  _LT_TAGVAR(hardcode_direct, $1)=yes
++	  _LT_TAGVAR(hardcode_shlibpath_var, $1)=no
++	fi
++	# Workaround some broken pre-1.5 toolchains
++	output_verbose_link_cmd='$CC -shared $CFLAGS -v conftest.$objext 2>&1 | $GREP conftest.$objext | $SED -e "s:-lgcc -lc -lgcc::"'
++	;;
++
++      *nto* | *qnx*)
++        _LT_TAGVAR(ld_shlibs, $1)=yes
++	;;
++
++      openbsd2*)
++        # C++ shared libraries are fairly broken
++	_LT_TAGVAR(ld_shlibs, $1)=no
++	;;
++
++      openbsd*)
++	if test -f /usr/libexec/ld.so; then
++	  _LT_TAGVAR(hardcode_direct, $1)=yes
++	  _LT_TAGVAR(hardcode_shlibpath_var, $1)=no
++	  _LT_TAGVAR(hardcode_direct_absolute, $1)=yes
++	  _LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags -o $lib'
++	  _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-rpath,$libdir'
++	  if test -z "`echo __ELF__ | $CC -E - | grep __ELF__`" || test "$host_os-$host_cpu" = "openbsd2.8-powerpc"; then
++	    _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared $pic_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-retain-symbols-file,$export_symbols -o $lib'
++	    _LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}-E'
++	    _LT_TAGVAR(whole_archive_flag_spec, $1)="$wlarc"'--whole-archive$convenience '"$wlarc"'--no-whole-archive'
++	  fi
++	  output_verbose_link_cmd=func_echo_all
++	else
++	  _LT_TAGVAR(ld_shlibs, $1)=no
++	fi
++	;;
++
++      osf3* | osf4* | osf5*)
++        case $cc_basename in
++          KCC*)
++	    # Kuck and Associates, Inc. (KAI) C++ Compiler
++
++	    # KCC will only create a shared library if the output file
++	    # ends with ".so" (or ".sl" for HP-UX), so rename the library
++	    # to its proper name (with version) after linking.
++	    _LT_TAGVAR(archive_cmds, $1)='tempext=`echo $shared_ext | $SED -e '\''s/\([[^()0-9A-Za-z{}]]\)/\\\\\1/g'\''`; templib=`echo "$lib" | $SED -e "s/\${tempext}\..*/.so/"`; $CC $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags --soname $soname -o \$templib; mv \$templib $lib'
++
++	    _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-rpath,$libdir'
++	    _LT_TAGVAR(hardcode_libdir_separator, $1)=:
++
++	    # Archives containing C++ object files must be created using
++	    # the KAI C++ compiler.
++	    case $host in
++	      osf3*) _LT_TAGVAR(old_archive_cmds, $1)='$CC -Bstatic -o $oldlib $oldobjs' ;;
++	      *) _LT_TAGVAR(old_archive_cmds, $1)='$CC -o $oldlib $oldobjs' ;;
++	    esac
++	    ;;
++          RCC*)
++	    # Rational C++ 2.4.1
++	    # FIXME: insert proper C++ library support
++	    _LT_TAGVAR(ld_shlibs, $1)=no
++	    ;;
++          cxx*)
++	    case $host in
++	      osf3*)
++	        _LT_TAGVAR(allow_undefined_flag, $1)=' ${wl}-expect_unresolved ${wl}\*'
++	        _LT_TAGVAR(archive_cmds, $1)='$CC -shared${allow_undefined_flag} $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname $soname `test -n "$verstring" && func_echo_all "${wl}-set_version $verstring"` -update_registry ${output_objdir}/so_locations -o $lib'
++	        _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-rpath ${wl}$libdir'
++		;;
++	      *)
++	        _LT_TAGVAR(allow_undefined_flag, $1)=' -expect_unresolved \*'
++	        _LT_TAGVAR(archive_cmds, $1)='$CC -shared${allow_undefined_flag} $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags -msym -soname $soname `test -n "$verstring" && func_echo_all "-set_version $verstring"` -update_registry ${output_objdir}/so_locations -o $lib'
++	        _LT_TAGVAR(archive_expsym_cmds, $1)='for i in `cat $export_symbols`; do printf "%s %s\\n" -exported_symbol "\$i" >> $lib.exp; done~
++	          echo "-hidden">> $lib.exp~
++	          $CC -shared$allow_undefined_flag $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags -msym -soname $soname ${wl}-input ${wl}$lib.exp  `test -n "$verstring" && $ECHO "-set_version $verstring"` -update_registry ${output_objdir}/so_locations -o $lib~
++	          $RM $lib.exp'
++	        _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='-rpath $libdir'
++		;;
++	    esac
++
++	    _LT_TAGVAR(hardcode_libdir_separator, $1)=:
++
++	    # Commands to make compiler produce verbose output that lists
++	    # what "hidden" libraries, object files and flags are used when
++	    # linking a shared library.
++	    #
++	    # There doesn't appear to be a way to prevent this compiler from
++	    # explicitly linking system object files so we need to strip them
++	    # from the output so that they don't get included in the library
++	    # dependencies.
++	    output_verbose_link_cmd='templist=`$CC -shared $CFLAGS -v conftest.$objext 2>&1 | $GREP "ld" | $GREP -v "ld:"`; templist=`func_echo_all "$templist" | $SED "s/\(^.*ld.*\)\( .*ld.*$\)/\1/"`; list=""; for z in $templist; do case $z in conftest.$objext) list="$list $z";; *.$objext);; *) list="$list $z";;esac; done; func_echo_all "$list"'
++	    ;;
++	  *)
++	    if test "$GXX" = yes && test "$with_gnu_ld" = no; then
++	      _LT_TAGVAR(allow_undefined_flag, $1)=' ${wl}-expect_unresolved ${wl}\*'
++	      case $host in
++	        osf3*)
++	          _LT_TAGVAR(archive_cmds, $1)='$CC -shared -nostdlib ${allow_undefined_flag} $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-soname ${wl}$soname `test -n "$verstring" && func_echo_all "${wl}-set_version ${wl}$verstring"` ${wl}-update_registry ${wl}${output_objdir}/so_locations -o $lib'
++		  ;;
++	        *)
++	          _LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag -nostdlib ${allow_undefined_flag} $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-msym ${wl}-soname ${wl}$soname `test -n "$verstring" && func_echo_all "${wl}-set_version ${wl}$verstring"` ${wl}-update_registry ${wl}${output_objdir}/so_locations -o $lib'
++		  ;;
++	      esac
++
++	      _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-rpath ${wl}$libdir'
++	      _LT_TAGVAR(hardcode_libdir_separator, $1)=:
++
++	      # Commands to make compiler produce verbose output that lists
++	      # what "hidden" libraries, object files and flags are used when
++	      # linking a shared library.
++	      output_verbose_link_cmd='$CC -shared $CFLAGS -v conftest.$objext 2>&1 | $GREP -v "^Configured with:" | $GREP "\-L"'
++
++	    else
++	      # FIXME: insert proper C++ library support
++	      _LT_TAGVAR(ld_shlibs, $1)=no
++	    fi
++	    ;;
++        esac
++        ;;
++
++      psos*)
++        # FIXME: insert proper C++ library support
++        _LT_TAGVAR(ld_shlibs, $1)=no
++        ;;
++
++      sunos4*)
++        case $cc_basename in
++          CC*)
++	    # Sun C++ 4.x
++	    # FIXME: insert proper C++ library support
++	    _LT_TAGVAR(ld_shlibs, $1)=no
++	    ;;
++          lcc*)
++	    # Lucid
++	    # FIXME: insert proper C++ library support
++	    _LT_TAGVAR(ld_shlibs, $1)=no
++	    ;;
++          *)
++	    # FIXME: insert proper C++ library support
++	    _LT_TAGVAR(ld_shlibs, $1)=no
++	    ;;
++        esac
++        ;;
++
++      solaris*)
++        case $cc_basename in
++          CC* | sunCC*)
++	    # Sun C++ 4.2, 5.x and Centerline C++
++            _LT_TAGVAR(archive_cmds_need_lc,$1)=yes
++	    _LT_TAGVAR(no_undefined_flag, $1)=' -zdefs'
++	    _LT_TAGVAR(archive_cmds, $1)='$CC -G${allow_undefined_flag}  -h$soname -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags'
++	    _LT_TAGVAR(archive_expsym_cmds, $1)='echo "{ global:" > $lib.exp~cat $export_symbols | $SED -e "s/\(.*\)/\1;/" >> $lib.exp~echo "local: *; };" >> $lib.exp~
++	      $CC -G${allow_undefined_flag} ${wl}-M ${wl}$lib.exp -h$soname -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags~$RM $lib.exp'
++
++	    _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='-R$libdir'
++	    _LT_TAGVAR(hardcode_shlibpath_var, $1)=no
++	    case $host_os in
++	      solaris2.[[0-5]] | solaris2.[[0-5]].*) ;;
++	      *)
++		# The compiler driver will combine and reorder linker options,
++		# but understands `-z linker_flag'.
++	        # Supported since Solaris 2.6 (maybe 2.5.1?)
++		_LT_TAGVAR(whole_archive_flag_spec, $1)='-z allextract$convenience -z defaultextract'
++	        ;;
++	    esac
++	    _LT_TAGVAR(link_all_deplibs, $1)=yes
++
++	    output_verbose_link_cmd='func_echo_all'
++
++	    # Archives containing C++ object files must be created using
++	    # "CC -xar", where "CC" is the Sun C++ compiler.  This is
++	    # necessary to make sure instantiated templates are included
++	    # in the archive.
++	    _LT_TAGVAR(old_archive_cmds, $1)='$CC -xar -o $oldlib $oldobjs'
++	    ;;
++          gcx*)
++	    # Green Hills C++ Compiler
++	    _LT_TAGVAR(archive_cmds, $1)='$CC -shared $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-h $wl$soname -o $lib'
++
++	    # The C++ compiler must be used to create the archive.
++	    _LT_TAGVAR(old_archive_cmds, $1)='$CC $LDFLAGS -archive -o $oldlib $oldobjs'
++	    ;;
++          *)
++	    # GNU C++ compiler with Solaris linker
++	    if test "$GXX" = yes && test "$with_gnu_ld" = no; then
++	      _LT_TAGVAR(no_undefined_flag, $1)=' ${wl}-z ${wl}defs'
++	      if $CC --version | $GREP -v '^2\.7' > /dev/null; then
++	        _LT_TAGVAR(archive_cmds, $1)='$CC -shared $pic_flag -nostdlib $LDFLAGS $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-h $wl$soname -o $lib'
++	        _LT_TAGVAR(archive_expsym_cmds, $1)='echo "{ global:" > $lib.exp~cat $export_symbols | $SED -e "s/\(.*\)/\1;/" >> $lib.exp~echo "local: *; };" >> $lib.exp~
++		  $CC -shared $pic_flag -nostdlib ${wl}-M $wl$lib.exp -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags~$RM $lib.exp'
++
++	        # Commands to make compiler produce verbose output that lists
++	        # what "hidden" libraries, object files and flags are used when
++	        # linking a shared library.
++	        output_verbose_link_cmd='$CC -shared $CFLAGS -v conftest.$objext 2>&1 | $GREP -v "^Configured with:" | $GREP "\-L"'
++	      else
++	        # g++ 2.7 appears to require `-G' NOT `-shared' on this
++	        # platform.
++	        _LT_TAGVAR(archive_cmds, $1)='$CC -G -nostdlib $LDFLAGS $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags ${wl}-h $wl$soname -o $lib'
++	        _LT_TAGVAR(archive_expsym_cmds, $1)='echo "{ global:" > $lib.exp~cat $export_symbols | $SED -e "s/\(.*\)/\1;/" >> $lib.exp~echo "local: *; };" >> $lib.exp~
++		  $CC -G -nostdlib ${wl}-M $wl$lib.exp -o $lib $predep_objects $libobjs $deplibs $postdep_objects $compiler_flags~$RM $lib.exp'
++
++	        # Commands to make compiler produce verbose output that lists
++	        # what "hidden" libraries, object files and flags are used when
++	        # linking a shared library.
++	        output_verbose_link_cmd='$CC -G $CFLAGS -v conftest.$objext 2>&1 | $GREP -v "^Configured with:" | $GREP "\-L"'
++	      fi
++
++	      _LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-R $wl$libdir'
++	      case $host_os in
++		solaris2.[[0-5]] | solaris2.[[0-5]].*) ;;
++		*)
++		  _LT_TAGVAR(whole_archive_flag_spec, $1)='${wl}-z ${wl}allextract$convenience ${wl}-z ${wl}defaultextract'
++		  ;;
++	      esac
++	    fi
++	    ;;
++        esac
++        ;;
++
++    sysv4*uw2* | sysv5OpenUNIX* | sysv5UnixWare7.[[01]].[[10]]* | unixware7* | sco3.2v5.0.[[024]]*)
++      _LT_TAGVAR(no_undefined_flag, $1)='${wl}-z,text'
++      _LT_TAGVAR(archive_cmds_need_lc, $1)=no
++      _LT_TAGVAR(hardcode_shlibpath_var, $1)=no
++      runpath_var='LD_RUN_PATH'
++
++      case $cc_basename in
++        CC*)
++	  _LT_TAGVAR(archive_cmds, $1)='$CC -G ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++	  _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -G ${wl}-Bexport:$export_symbols ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++	  ;;
++	*)
++	  _LT_TAGVAR(archive_cmds, $1)='$CC -shared ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++	  _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared ${wl}-Bexport:$export_symbols ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++	  ;;
++      esac
++      ;;
++
++      sysv5* | sco3.2v5* | sco5v6*)
++	# Note: We can NOT use -z defs as we might desire, because we do not
++	# link with -lc, and that would cause any symbols used from libc to
++	# always be unresolved, which means just about no library would
++	# ever link correctly.  If we're not using GNU ld we use -z text
++	# though, which does catch some bad symbols but isn't as heavy-handed
++	# as -z defs.
++	_LT_TAGVAR(no_undefined_flag, $1)='${wl}-z,text'
++	_LT_TAGVAR(allow_undefined_flag, $1)='${wl}-z,nodefs'
++	_LT_TAGVAR(archive_cmds_need_lc, $1)=no
++	_LT_TAGVAR(hardcode_shlibpath_var, $1)=no
++	_LT_TAGVAR(hardcode_libdir_flag_spec, $1)='${wl}-R,$libdir'
++	_LT_TAGVAR(hardcode_libdir_separator, $1)=':'
++	_LT_TAGVAR(link_all_deplibs, $1)=yes
++	_LT_TAGVAR(export_dynamic_flag_spec, $1)='${wl}-Bexport'
++	runpath_var='LD_RUN_PATH'
++
++	case $cc_basename in
++          CC*)
++	    _LT_TAGVAR(archive_cmds, $1)='$CC -G ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++	    _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -G ${wl}-Bexport:$export_symbols ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++	    _LT_TAGVAR(old_archive_cmds, $1)='$CC -Tprelink_objects $oldobjs~
++	      '"$_LT_TAGVAR(old_archive_cmds, $1)"
++	    _LT_TAGVAR(reload_cmds, $1)='$CC -Tprelink_objects $reload_objs~
++	      '"$_LT_TAGVAR(reload_cmds, $1)"
++	    ;;
++	  *)
++	    _LT_TAGVAR(archive_cmds, $1)='$CC -shared ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++	    _LT_TAGVAR(archive_expsym_cmds, $1)='$CC -shared ${wl}-Bexport:$export_symbols ${wl}-h,$soname -o $lib $libobjs $deplibs $compiler_flags'
++	    ;;
++	esac
++      ;;
++
++      tandem*)
++        case $cc_basename in
++          NCC*)
++	    # NonStop-UX NCC 3.20
++	    # FIXME: insert proper C++ library support
++	    _LT_TAGVAR(ld_shlibs, $1)=no
++	    ;;
++          *)
++	    # FIXME: insert proper C++ library support
++	    _LT_TAGVAR(ld_shlibs, $1)=no
++	    ;;
++        esac
++        ;;
++
++      vxworks*)
++        # FIXME: insert proper C++ library support
++        _LT_TAGVAR(ld_shlibs, $1)=no
++        ;;
++
++      *)
++        # FIXME: insert proper C++ library support
++        _LT_TAGVAR(ld_shlibs, $1)=no
++        ;;
++    esac
++
++    AC_MSG_RESULT([$_LT_TAGVAR(ld_shlibs, $1)])
++    test "$_LT_TAGVAR(ld_shlibs, $1)" = no && can_build_shared=no
++
++    _LT_TAGVAR(GCC, $1)="$GXX"
++    _LT_TAGVAR(LD, $1)="$LD"
++
++    ## CAVEAT EMPTOR:
++    ## There is no encapsulation within the following macros, do not change
++    ## the running order or otherwise move them around unless you know exactly
++    ## what you are doing...
++    _LT_SYS_HIDDEN_LIBDEPS($1)
++    _LT_COMPILER_PIC($1)
++    _LT_COMPILER_C_O($1)
++    _LT_COMPILER_FILE_LOCKS($1)
++    _LT_LINKER_SHLIBS($1)
++    _LT_SYS_DYNAMIC_LINKER($1)
++    _LT_LINKER_HARDCODE_LIBPATH($1)
++
++    _LT_CONFIG($1)
++  fi # test -n "$compiler"
++
++  CC=$lt_save_CC
++  CFLAGS=$lt_save_CFLAGS
++  LDCXX=$LD
++  LD=$lt_save_LD
++  GCC=$lt_save_GCC
++  with_gnu_ld=$lt_save_with_gnu_ld
++  lt_cv_path_LDCXX=$lt_cv_path_LD
++  lt_cv_path_LD=$lt_save_path_LD
++  lt_cv_prog_gnu_ldcxx=$lt_cv_prog_gnu_ld
++  lt_cv_prog_gnu_ld=$lt_save_with_gnu_ld
++fi # test "$_lt_caught_CXX_error" != yes
++
++AC_LANG_POP
++])# _LT_LANG_CXX_CONFIG
++
++
++# _LT_FUNC_STRIPNAME_CNF
++# ----------------------
++# func_stripname_cnf prefix suffix name
++# strip PREFIX and SUFFIX off of NAME.
++# PREFIX and SUFFIX must not contain globbing or regex special
++# characters, hashes, percent signs, but SUFFIX may contain a leading
++# dot (in which case that matches only a dot).
++#
++# This function is identical to the (non-XSI) version of func_stripname,
++# except this one can be used by m4 code that may be executed by configure,
++# rather than the libtool script.
++m4_defun([_LT_FUNC_STRIPNAME_CNF],[dnl
++AC_REQUIRE([_LT_DECL_SED])
++AC_REQUIRE([_LT_PROG_ECHO_BACKSLASH])
++func_stripname_cnf ()
++{
++  case ${2} in
++  .*) func_stripname_result=`$ECHO "${3}" | $SED "s%^${1}%%; s%\\\\${2}\$%%"`;;
++  *)  func_stripname_result=`$ECHO "${3}" | $SED "s%^${1}%%; s%${2}\$%%"`;;
++  esac
++} # func_stripname_cnf
++])# _LT_FUNC_STRIPNAME_CNF
++
++# _LT_SYS_HIDDEN_LIBDEPS([TAGNAME])
++# ---------------------------------
++# Figure out "hidden" library dependencies from verbose
++# compiler output when linking a shared library.
++# Parse the compiler output and extract the necessary
++# objects, libraries and library flags.
++m4_defun([_LT_SYS_HIDDEN_LIBDEPS],
++[m4_require([_LT_FILEUTILS_DEFAULTS])dnl
++AC_REQUIRE([_LT_FUNC_STRIPNAME_CNF])dnl
++# Dependencies to place before and after the object being linked:
++_LT_TAGVAR(predep_objects, $1)=
++_LT_TAGVAR(postdep_objects, $1)=
++_LT_TAGVAR(predeps, $1)=
++_LT_TAGVAR(postdeps, $1)=
++_LT_TAGVAR(compiler_lib_search_path, $1)=
++
++dnl we can't use the lt_simple_compile_test_code here,
++dnl because it contains code intended for an executable,
++dnl not a library.  It's possible we should let each
++dnl tag define a new lt_????_link_test_code variable,
++dnl but it's only used here...
++m4_if([$1], [], [cat > conftest.$ac_ext <<_LT_EOF
++int a;
++void foo (void) { a = 0; }
++_LT_EOF
++], [$1], [CXX], [cat > conftest.$ac_ext <<_LT_EOF
++class Foo
++{
++public:
++  Foo (void) { a = 0; }
++private:
++  int a;
++};
++_LT_EOF
++], [$1], [F77], [cat > conftest.$ac_ext <<_LT_EOF
++      subroutine foo
++      implicit none
++      integer*4 a
++      a=0
++      return
++      end
++_LT_EOF
++], [$1], [FC], [cat > conftest.$ac_ext <<_LT_EOF
++      subroutine foo
++      implicit none
++      integer a
++      a=0
++      return
++      end
++_LT_EOF
++], [$1], [GCJ], [cat > conftest.$ac_ext <<_LT_EOF
++public class foo {
++  private int a;
++  public void bar (void) {
++    a = 0;
++  }
++};
++_LT_EOF
++], [$1], [GO], [cat > conftest.$ac_ext <<_LT_EOF
++package foo
++func foo() {
++}
++_LT_EOF
++])
++
++_lt_libdeps_save_CFLAGS=$CFLAGS
++case "$CC $CFLAGS " in #(
++*\ -flto*\ *) CFLAGS="$CFLAGS -fno-lto" ;;
++*\ -fwhopr*\ *) CFLAGS="$CFLAGS -fno-whopr" ;;
++*\ -fuse-linker-plugin*\ *) CFLAGS="$CFLAGS -fno-use-linker-plugin" ;;
++esac
++
++dnl Parse the compiler output and extract the necessary
++dnl objects, libraries and library flags.
++if AC_TRY_EVAL(ac_compile); then
++  # Parse the compiler output and extract the necessary
++  # objects, libraries and library flags.
++
++  # Sentinel used to keep track of whether or not we are before
++  # the conftest object file.
++  pre_test_object_deps_done=no
++
++  for p in `eval "$output_verbose_link_cmd"`; do
++    case ${prev}${p} in
++
++    -L* | -R* | -l*)
++       # Some compilers place space between "-{L,R}" and the path.
++       # Remove the space.
++       if test $p = "-L" ||
++          test $p = "-R"; then
++	 prev=$p
++	 continue
++       fi
++
++       # Expand the sysroot to ease extracting the directories later.
++       if test -z "$prev"; then
++         case $p in
++         -L*) func_stripname_cnf '-L' '' "$p"; prev=-L; p=$func_stripname_result ;;
++         -R*) func_stripname_cnf '-R' '' "$p"; prev=-R; p=$func_stripname_result ;;
++         -l*) func_stripname_cnf '-l' '' "$p"; prev=-l; p=$func_stripname_result ;;
++         esac
++       fi
++       case $p in
++       =*) func_stripname_cnf '=' '' "$p"; p=$lt_sysroot$func_stripname_result ;;
++       esac
++       if test "$pre_test_object_deps_done" = no; then
++	 case ${prev} in
++	 -L | -R)
++	   # Internal compiler library paths should come after those
++	   # provided the user.  The postdeps already come after the
++	   # user supplied libs so there is no need to process them.
++	   if test -z "$_LT_TAGVAR(compiler_lib_search_path, $1)"; then
++	     _LT_TAGVAR(compiler_lib_search_path, $1)="${prev}${p}"
++	   else
++	     _LT_TAGVAR(compiler_lib_search_path, $1)="${_LT_TAGVAR(compiler_lib_search_path, $1)} ${prev}${p}"
++	   fi
++	   ;;
++	 # The "-l" case would never come before the object being
++	 # linked, so don't bother handling this case.
++	 esac
++       else
++	 if test -z "$_LT_TAGVAR(postdeps, $1)"; then
++	   _LT_TAGVAR(postdeps, $1)="${prev}${p}"
++	 else
++	   _LT_TAGVAR(postdeps, $1)="${_LT_TAGVAR(postdeps, $1)} ${prev}${p}"
++	 fi
++       fi
++       prev=
++       ;;
++
++    *.lto.$objext) ;; # Ignore GCC LTO objects
++    *.$objext)
++       # This assumes that the test object file only shows up
++       # once in the compiler output.
++       if test "$p" = "conftest.$objext"; then
++	 pre_test_object_deps_done=yes
++	 continue
++       fi
++
++       if test "$pre_test_object_deps_done" = no; then
++	 if test -z "$_LT_TAGVAR(predep_objects, $1)"; then
++	   _LT_TAGVAR(predep_objects, $1)="$p"
++	 else
++	   _LT_TAGVAR(predep_objects, $1)="$_LT_TAGVAR(predep_objects, $1) $p"
++	 fi
++       else
++	 if test -z "$_LT_TAGVAR(postdep_objects, $1)"; then
++	   _LT_TAGVAR(postdep_objects, $1)="$p"
++	 else
++	   _LT_TAGVAR(postdep_objects, $1)="$_LT_TAGVAR(postdep_objects, $1) $p"
++	 fi
++       fi
++       ;;
++
++    *) ;; # Ignore the rest.
++
++    esac
++  done
++
++  # Clean up.
++  rm -f a.out a.exe
++else
++  echo "libtool.m4: error: problem compiling $1 test program"
++fi
++
++$RM -f confest.$objext
++CFLAGS=$_lt_libdeps_save_CFLAGS
++
++# PORTME: override above test on systems where it is broken
++m4_if([$1], [CXX],
++[case $host_os in
++interix[[3-9]]*)
++  # Interix 3.5 installs completely hosed .la files for C++, so rather than
++  # hack all around it, let's just trust "g++" to DTRT.
++  _LT_TAGVAR(predep_objects,$1)=
++  _LT_TAGVAR(postdep_objects,$1)=
++  _LT_TAGVAR(postdeps,$1)=
++  ;;
++
++linux*)
++  case `$CC -V 2>&1 | sed 5q` in
++  *Sun\ C*)
++    # Sun C++ 5.9
++
++    # The more standards-conforming stlport4 library is
++    # incompatible with the Cstd library. Avoid specifying
++    # it if it's in CXXFLAGS. Ignore libCrun as
++    # -library=stlport4 depends on it.
++    case " $CXX $CXXFLAGS " in
++    *" -library=stlport4 "*)
++      solaris_use_stlport4=yes
++      ;;
++    esac
++
++    if test "$solaris_use_stlport4" != yes; then
++      _LT_TAGVAR(postdeps,$1)='-library=Cstd -library=Crun'
++    fi
++    ;;
++  esac
++  ;;
++
++solaris*)
++  case $cc_basename in
++  CC* | sunCC*)
++    # The more standards-conforming stlport4 library is
++    # incompatible with the Cstd library. Avoid specifying
++    # it if it's in CXXFLAGS. Ignore libCrun as
++    # -library=stlport4 depends on it.
++    case " $CXX $CXXFLAGS " in
++    *" -library=stlport4 "*)
++      solaris_use_stlport4=yes
++      ;;
++    esac
++
++    # Adding this requires a known-good setup of shared libraries for
++    # Sun compiler versions before 5.6, else PIC objects from an old
++    # archive will be linked into the output, leading to subtle bugs.
++    if test "$solaris_use_stlport4" != yes; then
++      _LT_TAGVAR(postdeps,$1)='-library=Cstd -library=Crun'
++    fi
++    ;;
++  esac
++  ;;
++esac
++])
++
++case " $_LT_TAGVAR(postdeps, $1) " in
++*" -lc "*) _LT_TAGVAR(archive_cmds_need_lc, $1)=no ;;
++esac
++ _LT_TAGVAR(compiler_lib_search_dirs, $1)=
++if test -n "${_LT_TAGVAR(compiler_lib_search_path, $1)}"; then
++ _LT_TAGVAR(compiler_lib_search_dirs, $1)=`echo " ${_LT_TAGVAR(compiler_lib_search_path, $1)}" | ${SED} -e 's! -L! !g' -e 's!^ !!'`
++fi
++_LT_TAGDECL([], [compiler_lib_search_dirs], [1],
++    [The directories searched by this compiler when creating a shared library])
++_LT_TAGDECL([], [predep_objects], [1],
++    [Dependencies to place before and after the objects being linked to
++    create a shared library])
++_LT_TAGDECL([], [postdep_objects], [1])
++_LT_TAGDECL([], [predeps], [1])
++_LT_TAGDECL([], [postdeps], [1])
++_LT_TAGDECL([], [compiler_lib_search_path], [1],
++    [The library search path used internally by the compiler when linking
++    a shared library])
++])# _LT_SYS_HIDDEN_LIBDEPS
++
++
++# _LT_LANG_F77_CONFIG([TAG])
++# --------------------------
++# Ensure that the configuration variables for a Fortran 77 compiler are
++# suitably defined.  These variables are subsequently used by _LT_CONFIG
++# to write the compiler configuration to `libtool'.
++m4_defun([_LT_LANG_F77_CONFIG],
++[AC_LANG_PUSH(Fortran 77)
++if test -z "$F77" || test "X$F77" = "Xno"; then
++  _lt_disable_F77=yes
++fi
++
++_LT_TAGVAR(archive_cmds_need_lc, $1)=no
++_LT_TAGVAR(allow_undefined_flag, $1)=
++_LT_TAGVAR(always_export_symbols, $1)=no
++_LT_TAGVAR(archive_expsym_cmds, $1)=
++_LT_TAGVAR(export_dynamic_flag_spec, $1)=
++_LT_TAGVAR(hardcode_direct, $1)=no
++_LT_TAGVAR(hardcode_direct_absolute, $1)=no
++_LT_TAGVAR(hardcode_libdir_flag_spec, $1)=
++_LT_TAGVAR(hardcode_libdir_separator, $1)=
++_LT_TAGVAR(hardcode_minus_L, $1)=no
++_LT_TAGVAR(hardcode_automatic, $1)=no
++_LT_TAGVAR(inherit_rpath, $1)=no
++_LT_TAGVAR(module_cmds, $1)=
++_LT_TAGVAR(module_expsym_cmds, $1)=
++_LT_TAGVAR(link_all_deplibs, $1)=unknown
++_LT_TAGVAR(old_archive_cmds, $1)=$old_archive_cmds
++_LT_TAGVAR(reload_flag, $1)=$reload_flag
++_LT_TAGVAR(reload_cmds, $1)=$reload_cmds
++_LT_TAGVAR(no_undefined_flag, $1)=
++_LT_TAGVAR(whole_archive_flag_spec, $1)=
++_LT_TAGVAR(enable_shared_with_static_runtimes, $1)=no
++
++# Source file extension for f77 test sources.
++ac_ext=f
++
++# Object file extension for compiled f77 test sources.
++objext=o
++_LT_TAGVAR(objext, $1)=$objext
++
++# No sense in running all these tests if we already determined that
++# the F77 compiler isn't working.  Some variables (like enable_shared)
++# are currently assumed to apply to all compilers on this platform,
++# and will be corrupted by setting them based on a non-working compiler.
++if test "$_lt_disable_F77" != yes; then
++  # Code to be used in simple compile tests
++  lt_simple_compile_test_code="\
++      subroutine t
++      return
++      end
++"
++
++  # Code to be used in simple link tests
++  lt_simple_link_test_code="\
++      program t
++      end
++"
++
++  # ltmain only uses $CC for tagged configurations so make sure $CC is set.
++  _LT_TAG_COMPILER
++
++  # save warnings/boilerplate of simple test code
++  _LT_COMPILER_BOILERPLATE
++  _LT_LINKER_BOILERPLATE
++
++  # Allow CC to be a program name with arguments.
++  lt_save_CC="$CC"
++  lt_save_GCC=$GCC
++  lt_save_CFLAGS=$CFLAGS
++  CC=${F77-"f77"}
++  CFLAGS=$FFLAGS
++  compiler=$CC
++  _LT_TAGVAR(compiler, $1)=$CC
++  _LT_CC_BASENAME([$compiler])
++  GCC=$G77
++  if test -n "$compiler"; then
++    AC_MSG_CHECKING([if libtool supports shared libraries])
++    AC_MSG_RESULT([$can_build_shared])
++
++    AC_MSG_CHECKING([whether to build shared libraries])
++    test "$can_build_shared" = "no" && enable_shared=no
++
++    # On AIX, shared libraries and static libraries use the same namespace, and
++    # are all built from PIC.
++    case $host_os in
++      aix3*)
++        test "$enable_shared" = yes && enable_static=no
++        if test -n "$RANLIB"; then
++          archive_cmds="$archive_cmds~\$RANLIB \$lib"
++          postinstall_cmds='$RANLIB $lib'
++        fi
++        ;;
++      aix[[4-9]]*)
++	if test "$host_cpu" != ia64 && test "$aix_use_runtimelinking" = no ; then
++	  test "$enable_shared" = yes && enable_static=no
++	fi
++        ;;
++    esac
++    AC_MSG_RESULT([$enable_shared])
++
++    AC_MSG_CHECKING([whether to build static libraries])
++    # Make sure either enable_shared or enable_static is yes.
++    test "$enable_shared" = yes || enable_static=yes
++    AC_MSG_RESULT([$enable_static])
++
++    _LT_TAGVAR(GCC, $1)="$G77"
++    _LT_TAGVAR(LD, $1)="$LD"
++
++    ## CAVEAT EMPTOR:
++    ## There is no encapsulation within the following macros, do not change
++    ## the running order or otherwise move them around unless you know exactly
++    ## what you are doing...
++    _LT_COMPILER_PIC($1)
++    _LT_COMPILER_C_O($1)
++    _LT_COMPILER_FILE_LOCKS($1)
++    _LT_LINKER_SHLIBS($1)
++    _LT_SYS_DYNAMIC_LINKER($1)
++    _LT_LINKER_HARDCODE_LIBPATH($1)
++
++    _LT_CONFIG($1)
++  fi # test -n "$compiler"
++
++  GCC=$lt_save_GCC
++  CC="$lt_save_CC"
++  CFLAGS="$lt_save_CFLAGS"
++fi # test "$_lt_disable_F77" != yes
++
++AC_LANG_POP
++])# _LT_LANG_F77_CONFIG
++
++
++# _LT_LANG_FC_CONFIG([TAG])
++# -------------------------
++# Ensure that the configuration variables for a Fortran compiler are
++# suitably defined.  These variables are subsequently used by _LT_CONFIG
++# to write the compiler configuration to `libtool'.
++m4_defun([_LT_LANG_FC_CONFIG],
++[AC_LANG_PUSH(Fortran)
++
++if test -z "$FC" || test "X$FC" = "Xno"; then
++  _lt_disable_FC=yes
++fi
++
++_LT_TAGVAR(archive_cmds_need_lc, $1)=no
++_LT_TAGVAR(allow_undefined_flag, $1)=
++_LT_TAGVAR(always_export_symbols, $1)=no
++_LT_TAGVAR(archive_expsym_cmds, $1)=
++_LT_TAGVAR(export_dynamic_flag_spec, $1)=
++_LT_TAGVAR(hardcode_direct, $1)=no
++_LT_TAGVAR(hardcode_direct_absolute, $1)=no
++_LT_TAGVAR(hardcode_libdir_flag_spec, $1)=
++_LT_TAGVAR(hardcode_libdir_separator, $1)=
++_LT_TAGVAR(hardcode_minus_L, $1)=no
++_LT_TAGVAR(hardcode_automatic, $1)=no
++_LT_TAGVAR(inherit_rpath, $1)=no
++_LT_TAGVAR(module_cmds, $1)=
++_LT_TAGVAR(module_expsym_cmds, $1)=
++_LT_TAGVAR(link_all_deplibs, $1)=unknown
++_LT_TAGVAR(old_archive_cmds, $1)=$old_archive_cmds
++_LT_TAGVAR(reload_flag, $1)=$reload_flag
++_LT_TAGVAR(reload_cmds, $1)=$reload_cmds
++_LT_TAGVAR(no_undefined_flag, $1)=
++_LT_TAGVAR(whole_archive_flag_spec, $1)=
++_LT_TAGVAR(enable_shared_with_static_runtimes, $1)=no
++
++# Source file extension for fc test sources.
++ac_ext=${ac_fc_srcext-f}
++
++# Object file extension for compiled fc test sources.
++objext=o
++_LT_TAGVAR(objext, $1)=$objext
++
++# No sense in running all these tests if we already determined that
++# the FC compiler isn't working.  Some variables (like enable_shared)
++# are currently assumed to apply to all compilers on this platform,
++# and will be corrupted by setting them based on a non-working compiler.
++if test "$_lt_disable_FC" != yes; then
++  # Code to be used in simple compile tests
++  lt_simple_compile_test_code="\
++      subroutine t
++      return
++      end
++"
++
++  # Code to be used in simple link tests
++  lt_simple_link_test_code="\
++      program t
++      end
++"
++
++  # ltmain only uses $CC for tagged configurations so make sure $CC is set.
++  _LT_TAG_COMPILER
++
++  # save warnings/boilerplate of simple test code
++  _LT_COMPILER_BOILERPLATE
++  _LT_LINKER_BOILERPLATE
++
++  # Allow CC to be a program name with arguments.
++  lt_save_CC="$CC"
++  lt_save_GCC=$GCC
++  lt_save_CFLAGS=$CFLAGS
++  CC=${FC-"f95"}
++  CFLAGS=$FCFLAGS
++  compiler=$CC
++  GCC=$ac_cv_fc_compiler_gnu
++
++  _LT_TAGVAR(compiler, $1)=$CC
++  _LT_CC_BASENAME([$compiler])
++
++  if test -n "$compiler"; then
++    AC_MSG_CHECKING([if libtool supports shared libraries])
++    AC_MSG_RESULT([$can_build_shared])
++
++    AC_MSG_CHECKING([whether to build shared libraries])
++    test "$can_build_shared" = "no" && enable_shared=no
++
++    # On AIX, shared libraries and static libraries use the same namespace, and
++    # are all built from PIC.
++    case $host_os in
++      aix3*)
++        test "$enable_shared" = yes && enable_static=no
++        if test -n "$RANLIB"; then
++          archive_cmds="$archive_cmds~\$RANLIB \$lib"
++          postinstall_cmds='$RANLIB $lib'
++        fi
++        ;;
++      aix[[4-9]]*)
++	if test "$host_cpu" != ia64 && test "$aix_use_runtimelinking" = no ; then
++	  test "$enable_shared" = yes && enable_static=no
++	fi
++        ;;
++    esac
++    AC_MSG_RESULT([$enable_shared])
++
++    AC_MSG_CHECKING([whether to build static libraries])
++    # Make sure either enable_shared or enable_static is yes.
++    test "$enable_shared" = yes || enable_static=yes
++    AC_MSG_RESULT([$enable_static])
++
++    _LT_TAGVAR(GCC, $1)="$ac_cv_fc_compiler_gnu"
++    _LT_TAGVAR(LD, $1)="$LD"
++
++    ## CAVEAT EMPTOR:
++    ## There is no encapsulation within the following macros, do not change
++    ## the running order or otherwise move them around unless you know exactly
++    ## what you are doing...
++    _LT_SYS_HIDDEN_LIBDEPS($1)
++    _LT_COMPILER_PIC($1)
++    _LT_COMPILER_C_O($1)
++    _LT_COMPILER_FILE_LOCKS($1)
++    _LT_LINKER_SHLIBS($1)
++    _LT_SYS_DYNAMIC_LINKER($1)
++    _LT_LINKER_HARDCODE_LIBPATH($1)
++
++    _LT_CONFIG($1)
++  fi # test -n "$compiler"
++
++  GCC=$lt_save_GCC
++  CC=$lt_save_CC
++  CFLAGS=$lt_save_CFLAGS
++fi # test "$_lt_disable_FC" != yes
++
++AC_LANG_POP
++])# _LT_LANG_FC_CONFIG
++
++
++# _LT_LANG_GCJ_CONFIG([TAG])
++# --------------------------
++# Ensure that the configuration variables for the GNU Java Compiler compiler
++# are suitably defined.  These variables are subsequently used by _LT_CONFIG
++# to write the compiler configuration to `libtool'.
++m4_defun([_LT_LANG_GCJ_CONFIG],
++[AC_REQUIRE([LT_PROG_GCJ])dnl
++AC_LANG_SAVE
++
++# Source file extension for Java test sources.
++ac_ext=java
++
++# Object file extension for compiled Java test sources.
++objext=o
++_LT_TAGVAR(objext, $1)=$objext
++
++# Code to be used in simple compile tests
++lt_simple_compile_test_code="class foo {}"
++
++# Code to be used in simple link tests
++lt_simple_link_test_code='public class conftest { public static void main(String[[]] argv) {}; }'
++
++# ltmain only uses $CC for tagged configurations so make sure $CC is set.
++_LT_TAG_COMPILER
++
++# save warnings/boilerplate of simple test code
++_LT_COMPILER_BOILERPLATE
++_LT_LINKER_BOILERPLATE
++
++# Allow CC to be a program name with arguments.
++lt_save_CC=$CC
++lt_save_CFLAGS=$CFLAGS
++lt_save_GCC=$GCC
++GCC=yes
++CC=${GCJ-"gcj"}
++CFLAGS=$GCJFLAGS
++compiler=$CC
++_LT_TAGVAR(compiler, $1)=$CC
++_LT_TAGVAR(LD, $1)="$LD"
++_LT_CC_BASENAME([$compiler])
++
++# GCJ did not exist at the time GCC didn't implicitly link libc in.
++_LT_TAGVAR(archive_cmds_need_lc, $1)=no
++
++_LT_TAGVAR(old_archive_cmds, $1)=$old_archive_cmds
++_LT_TAGVAR(reload_flag, $1)=$reload_flag
++_LT_TAGVAR(reload_cmds, $1)=$reload_cmds
++
++if test -n "$compiler"; then
++  _LT_COMPILER_NO_RTTI($1)
++  _LT_COMPILER_PIC($1)
++  _LT_COMPILER_C_O($1)
++  _LT_COMPILER_FILE_LOCKS($1)
++  _LT_LINKER_SHLIBS($1)
++  _LT_LINKER_HARDCODE_LIBPATH($1)
++
++  _LT_CONFIG($1)
++fi
++
++AC_LANG_RESTORE
++
++GCC=$lt_save_GCC
++CC=$lt_save_CC
++CFLAGS=$lt_save_CFLAGS
++])# _LT_LANG_GCJ_CONFIG
++
++
++# _LT_LANG_GO_CONFIG([TAG])
++# --------------------------
++# Ensure that the configuration variables for the GNU Go compiler
++# are suitably defined.  These variables are subsequently used by _LT_CONFIG
++# to write the compiler configuration to `libtool'.
++m4_defun([_LT_LANG_GO_CONFIG],
++[AC_REQUIRE([LT_PROG_GO])dnl
++AC_LANG_SAVE
++
++# Source file extension for Go test sources.
++ac_ext=go
++
++# Object file extension for compiled Go test sources.
++objext=o
++_LT_TAGVAR(objext, $1)=$objext
++
++# Code to be used in simple compile tests
++lt_simple_compile_test_code="package main; func main() { }"
++
++# Code to be used in simple link tests
++lt_simple_link_test_code='package main; func main() { }'
++
++# ltmain only uses $CC for tagged configurations so make sure $CC is set.
++_LT_TAG_COMPILER
++
++# save warnings/boilerplate of simple test code
++_LT_COMPILER_BOILERPLATE
++_LT_LINKER_BOILERPLATE
++
++# Allow CC to be a program name with arguments.
++lt_save_CC=$CC
++lt_save_CFLAGS=$CFLAGS
++lt_save_GCC=$GCC
++GCC=yes
++CC=${GOC-"gccgo"}
++CFLAGS=$GOFLAGS
++compiler=$CC
++_LT_TAGVAR(compiler, $1)=$CC
++_LT_TAGVAR(LD, $1)="$LD"
++_LT_CC_BASENAME([$compiler])
++
++# Go did not exist at the time GCC didn't implicitly link libc in.
++_LT_TAGVAR(archive_cmds_need_lc, $1)=no
++
++_LT_TAGVAR(old_archive_cmds, $1)=$old_archive_cmds
++_LT_TAGVAR(reload_flag, $1)=$reload_flag
++_LT_TAGVAR(reload_cmds, $1)=$reload_cmds
++
++if test -n "$compiler"; then
++  _LT_COMPILER_NO_RTTI($1)
++  _LT_COMPILER_PIC($1)
++  _LT_COMPILER_C_O($1)
++  _LT_COMPILER_FILE_LOCKS($1)
++  _LT_LINKER_SHLIBS($1)
++  _LT_LINKER_HARDCODE_LIBPATH($1)
++
++  _LT_CONFIG($1)
++fi
++
++AC_LANG_RESTORE
++
++GCC=$lt_save_GCC
++CC=$lt_save_CC
++CFLAGS=$lt_save_CFLAGS
++])# _LT_LANG_GO_CONFIG
++
++
++# _LT_LANG_RC_CONFIG([TAG])
++# -------------------------
++# Ensure that the configuration variables for the Windows resource compiler
++# are suitably defined.  These variables are subsequently used by _LT_CONFIG
++# to write the compiler configuration to `libtool'.
++m4_defun([_LT_LANG_RC_CONFIG],
++[AC_REQUIRE([LT_PROG_RC])dnl
++AC_LANG_SAVE
++
++# Source file extension for RC test sources.
++ac_ext=rc
++
++# Object file extension for compiled RC test sources.
++objext=o
++_LT_TAGVAR(objext, $1)=$objext
++
++# Code to be used in simple compile tests
++lt_simple_compile_test_code='sample MENU { MENUITEM "&Soup", 100, CHECKED }'
++
++# Code to be used in simple link tests
++lt_simple_link_test_code="$lt_simple_compile_test_code"
++
++# ltmain only uses $CC for tagged configurations so make sure $CC is set.
++_LT_TAG_COMPILER
++
++# save warnings/boilerplate of simple test code
++_LT_COMPILER_BOILERPLATE
++_LT_LINKER_BOILERPLATE
++
++# Allow CC to be a program name with arguments.
++lt_save_CC="$CC"
++lt_save_CFLAGS=$CFLAGS
++lt_save_GCC=$GCC
++GCC=
++CC=${RC-"windres"}
++CFLAGS=
++compiler=$CC
++_LT_TAGVAR(compiler, $1)=$CC
++_LT_CC_BASENAME([$compiler])
++_LT_TAGVAR(lt_cv_prog_compiler_c_o, $1)=yes
++
++if test -n "$compiler"; then
++  :
++  _LT_CONFIG($1)
++fi
++
++GCC=$lt_save_GCC
++AC_LANG_RESTORE
++CC=$lt_save_CC
++CFLAGS=$lt_save_CFLAGS
++])# _LT_LANG_RC_CONFIG
++
++
++# LT_PROG_GCJ
++# -----------
++AC_DEFUN([LT_PROG_GCJ],
++[m4_ifdef([AC_PROG_GCJ], [AC_PROG_GCJ],
++  [m4_ifdef([A][M_PROG_GCJ], [A][M_PROG_GCJ],
++    [AC_CHECK_TOOL(GCJ, gcj,)
++      test "x${GCJFLAGS+set}" = xset || GCJFLAGS="-g -O2"
++      AC_SUBST(GCJFLAGS)])])[]dnl
++])
++
++# Old name:
++AU_ALIAS([LT_AC_PROG_GCJ], [LT_PROG_GCJ])
++dnl aclocal-1.4 backwards compatibility:
++dnl AC_DEFUN([LT_AC_PROG_GCJ], [])
++
++
++# LT_PROG_GO
++# ----------
++AC_DEFUN([LT_PROG_GO],
++[AC_CHECK_TOOL(GOC, gccgo,)
++])
++
++
++# LT_PROG_RC
++# ----------
++AC_DEFUN([LT_PROG_RC],
++[AC_CHECK_TOOL(RC, windres,)
++])
++
++# Old name:
++AU_ALIAS([LT_AC_PROG_RC], [LT_PROG_RC])
++dnl aclocal-1.4 backwards compatibility:
++dnl AC_DEFUN([LT_AC_PROG_RC], [])
++
++
++# _LT_DECL_EGREP
++# --------------
++# If we don't have a new enough Autoconf to choose the best grep
++# available, choose the one first in the user's PATH.
++m4_defun([_LT_DECL_EGREP],
++[AC_REQUIRE([AC_PROG_EGREP])dnl
++AC_REQUIRE([AC_PROG_FGREP])dnl
++test -z "$GREP" && GREP=grep
++_LT_DECL([], [GREP], [1], [A grep program that handles long lines])
++_LT_DECL([], [EGREP], [1], [An ERE matcher])
++_LT_DECL([], [FGREP], [1], [A literal string matcher])
++dnl Non-bleeding-edge autoconf doesn't subst GREP, so do it here too
++AC_SUBST([GREP])
++])
++
++
++# _LT_DECL_OBJDUMP
++# --------------
++# If we don't have a new enough Autoconf to choose the best objdump
++# available, choose the one first in the user's PATH.
++m4_defun([_LT_DECL_OBJDUMP],
++[AC_CHECK_TOOL(OBJDUMP, objdump, false)
++test -z "$OBJDUMP" && OBJDUMP=objdump
++_LT_DECL([], [OBJDUMP], [1], [An object symbol dumper])
++AC_SUBST([OBJDUMP])
++])
++
++# _LT_DECL_DLLTOOL
++# ----------------
++# Ensure DLLTOOL variable is set.
++m4_defun([_LT_DECL_DLLTOOL],
++[AC_CHECK_TOOL(DLLTOOL, dlltool, false)
++test -z "$DLLTOOL" && DLLTOOL=dlltool
++_LT_DECL([], [DLLTOOL], [1], [DLL creation program])
++AC_SUBST([DLLTOOL])
++])
++
++# _LT_DECL_SED
++# ------------
++# Check for a fully-functional sed program, that truncates
++# as few characters as possible.  Prefer GNU sed if found.
++m4_defun([_LT_DECL_SED],
++[AC_PROG_SED
++test -z "$SED" && SED=sed
++Xsed="$SED -e 1s/^X//"
++_LT_DECL([], [SED], [1], [A sed program that does not truncate output])
++_LT_DECL([], [Xsed], ["\$SED -e 1s/^X//"],
++    [Sed that helps us avoid accidentally triggering echo(1) options like -n])
++])# _LT_DECL_SED
++
++m4_ifndef([AC_PROG_SED], [
++# NOTE: This macro has been submitted for inclusion into   #
++#  GNU Autoconf as AC_PROG_SED.  When it is available in   #
++#  a released version of Autoconf we should remove this    #
++#  macro and use it instead.                               #
++
++m4_defun([AC_PROG_SED],
++[AC_MSG_CHECKING([for a sed that does not truncate output])
++AC_CACHE_VAL(lt_cv_path_SED,
++[# Loop through the user's path and test for sed and gsed.
++# Then use that list of sed's as ones to test for truncation.
++as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
++for as_dir in $PATH
++do
++  IFS=$as_save_IFS
++  test -z "$as_dir" && as_dir=.
++  for lt_ac_prog in sed gsed; do
++    for ac_exec_ext in '' $ac_executable_extensions; do
++      if $as_executable_p "$as_dir/$lt_ac_prog$ac_exec_ext"; then
++        lt_ac_sed_list="$lt_ac_sed_list $as_dir/$lt_ac_prog$ac_exec_ext"
++      fi
++    done
++  done
++done
++IFS=$as_save_IFS
++lt_ac_max=0
++lt_ac_count=0
++# Add /usr/xpg4/bin/sed as it is typically found on Solaris
++# along with /bin/sed that truncates output.
++for lt_ac_sed in $lt_ac_sed_list /usr/xpg4/bin/sed; do
++  test ! -f $lt_ac_sed && continue
++  cat /dev/null > conftest.in
++  lt_ac_count=0
++  echo $ECHO_N "0123456789$ECHO_C" >conftest.in
++  # Check for GNU sed and select it if it is found.
++  if "$lt_ac_sed" --version 2>&1 < /dev/null | grep 'GNU' > /dev/null; then
++    lt_cv_path_SED=$lt_ac_sed
++    break
++  fi
++  while true; do
++    cat conftest.in conftest.in >conftest.tmp
++    mv conftest.tmp conftest.in
++    cp conftest.in conftest.nl
++    echo >>conftest.nl
++    $lt_ac_sed -e 's/a$//' < conftest.nl >conftest.out || break
++    cmp -s conftest.out conftest.nl || break
++    # 10000 chars as input seems more than enough
++    test $lt_ac_count -gt 10 && break
++    lt_ac_count=`expr $lt_ac_count + 1`
++    if test $lt_ac_count -gt $lt_ac_max; then
++      lt_ac_max=$lt_ac_count
++      lt_cv_path_SED=$lt_ac_sed
++    fi
++  done
++done
++])
++SED=$lt_cv_path_SED
++AC_SUBST([SED])
++AC_MSG_RESULT([$SED])
++])#AC_PROG_SED
++])#m4_ifndef
++
++# Old name:
++AU_ALIAS([LT_AC_PROG_SED], [AC_PROG_SED])
++dnl aclocal-1.4 backwards compatibility:
++dnl AC_DEFUN([LT_AC_PROG_SED], [])
++
++
++# _LT_CHECK_SHELL_FEATURES
++# ------------------------
++# Find out whether the shell is Bourne or XSI compatible,
++# or has some other useful features.
++m4_defun([_LT_CHECK_SHELL_FEATURES],
++[AC_MSG_CHECKING([whether the shell understands some XSI constructs])
++# Try some XSI features
++xsi_shell=no
++( _lt_dummy="a/b/c"
++  test "${_lt_dummy##*/},${_lt_dummy%/*},${_lt_dummy#??}"${_lt_dummy%"$_lt_dummy"}, \
++      = c,a/b,b/c, \
++    && eval 'test $(( 1 + 1 )) -eq 2 \
++    && test "${#_lt_dummy}" -eq 5' ) >/dev/null 2>&1 \
++  && xsi_shell=yes
++AC_MSG_RESULT([$xsi_shell])
++_LT_CONFIG_LIBTOOL_INIT([xsi_shell='$xsi_shell'])
++
++AC_MSG_CHECKING([whether the shell understands "+="])
++lt_shell_append=no
++( foo=bar; set foo baz; eval "$[1]+=\$[2]" && test "$foo" = barbaz ) \
++    >/dev/null 2>&1 \
++  && lt_shell_append=yes
++AC_MSG_RESULT([$lt_shell_append])
++_LT_CONFIG_LIBTOOL_INIT([lt_shell_append='$lt_shell_append'])
++
++if ( (MAIL=60; unset MAIL) || exit) >/dev/null 2>&1; then
++  lt_unset=unset
++else
++  lt_unset=false
++fi
++_LT_DECL([], [lt_unset], [0], [whether the shell understands "unset"])dnl
++
++# test EBCDIC or ASCII
++case `echo X|tr X '\101'` in
++ A) # ASCII based system
++    # \n is not interpreted correctly by Solaris 8 /usr/ucb/tr
++  lt_SP2NL='tr \040 \012'
++  lt_NL2SP='tr \015\012 \040\040'
++  ;;
++ *) # EBCDIC based system
++  lt_SP2NL='tr \100 \n'
++  lt_NL2SP='tr \r\n \100\100'
++  ;;
++esac
++_LT_DECL([SP2NL], [lt_SP2NL], [1], [turn spaces into newlines])dnl
++_LT_DECL([NL2SP], [lt_NL2SP], [1], [turn newlines into spaces])dnl
++])# _LT_CHECK_SHELL_FEATURES
++
++
++# _LT_PROG_FUNCTION_REPLACE (FUNCNAME, REPLACEMENT-BODY)
++# ------------------------------------------------------
++# In `$cfgfile', look for function FUNCNAME delimited by `^FUNCNAME ()$' and
++# '^} FUNCNAME ', and replace its body with REPLACEMENT-BODY.
++m4_defun([_LT_PROG_FUNCTION_REPLACE],
++[dnl {
++sed -e '/^$1 ()$/,/^} # $1 /c\
++$1 ()\
++{\
++m4_bpatsubsts([$2], [$], [\\], [^\([	 ]\)], [\\\1])
++} # Extended-shell $1 implementation' "$cfgfile" > $cfgfile.tmp \
++  && mv -f "$cfgfile.tmp" "$cfgfile" \
++    || (rm -f "$cfgfile" && cp "$cfgfile.tmp" "$cfgfile" && rm -f "$cfgfile.tmp")
++test 0 -eq $? || _lt_function_replace_fail=:
++])
++
++
++# _LT_PROG_REPLACE_SHELLFNS
++# -------------------------
++# Replace existing portable implementations of several shell functions with
++# equivalent extended shell implementations where those features are available..
++m4_defun([_LT_PROG_REPLACE_SHELLFNS],
++[if test x"$xsi_shell" = xyes; then
++  _LT_PROG_FUNCTION_REPLACE([func_dirname], [dnl
++    case ${1} in
++      */*) func_dirname_result="${1%/*}${2}" ;;
++      *  ) func_dirname_result="${3}" ;;
++    esac])
++
++  _LT_PROG_FUNCTION_REPLACE([func_basename], [dnl
++    func_basename_result="${1##*/}"])
++
++  _LT_PROG_FUNCTION_REPLACE([func_dirname_and_basename], [dnl
++    case ${1} in
++      */*) func_dirname_result="${1%/*}${2}" ;;
++      *  ) func_dirname_result="${3}" ;;
++    esac
++    func_basename_result="${1##*/}"])
++
++  _LT_PROG_FUNCTION_REPLACE([func_stripname], [dnl
++    # pdksh 5.2.14 does not do ${X%$Y} correctly if both X and Y are
++    # positional parameters, so assign one to ordinary parameter first.
++    func_stripname_result=${3}
++    func_stripname_result=${func_stripname_result#"${1}"}
++    func_stripname_result=${func_stripname_result%"${2}"}])
++
++  _LT_PROG_FUNCTION_REPLACE([func_split_long_opt], [dnl
++    func_split_long_opt_name=${1%%=*}
++    func_split_long_opt_arg=${1#*=}])
++
++  _LT_PROG_FUNCTION_REPLACE([func_split_short_opt], [dnl
++    func_split_short_opt_arg=${1#??}
++    func_split_short_opt_name=${1%"$func_split_short_opt_arg"}])
++
++  _LT_PROG_FUNCTION_REPLACE([func_lo2o], [dnl
++    case ${1} in
++      *.lo) func_lo2o_result=${1%.lo}.${objext} ;;
++      *)    func_lo2o_result=${1} ;;
++    esac])
++
++  _LT_PROG_FUNCTION_REPLACE([func_xform], [    func_xform_result=${1%.*}.lo])
++
++  _LT_PROG_FUNCTION_REPLACE([func_arith], [    func_arith_result=$(( $[*] ))])
++
++  _LT_PROG_FUNCTION_REPLACE([func_len], [    func_len_result=${#1}])
++fi
++
++if test x"$lt_shell_append" = xyes; then
++  _LT_PROG_FUNCTION_REPLACE([func_append], [    eval "${1}+=\\${2}"])
++
++  _LT_PROG_FUNCTION_REPLACE([func_append_quoted], [dnl
++    func_quote_for_eval "${2}"
++dnl m4 expansion turns \\\\ into \\, and then the shell eval turns that into \
++    eval "${1}+=\\\\ \\$func_quote_for_eval_result"])
++
++  # Save a `func_append' function call where possible by direct use of '+='
++  sed -e 's%func_append \([[a-zA-Z_]]\{1,\}\) "%\1+="%g' $cfgfile > $cfgfile.tmp \
++    && mv -f "$cfgfile.tmp" "$cfgfile" \
++      || (rm -f "$cfgfile" && cp "$cfgfile.tmp" "$cfgfile" && rm -f "$cfgfile.tmp")
++  test 0 -eq $? || _lt_function_replace_fail=:
++else
++  # Save a `func_append' function call even when '+=' is not available
++  sed -e 's%func_append \([[a-zA-Z_]]\{1,\}\) "%\1="$\1%g' $cfgfile > $cfgfile.tmp \
++    && mv -f "$cfgfile.tmp" "$cfgfile" \
++      || (rm -f "$cfgfile" && cp "$cfgfile.tmp" "$cfgfile" && rm -f "$cfgfile.tmp")
++  test 0 -eq $? || _lt_function_replace_fail=:
++fi
++
++if test x"$_lt_function_replace_fail" = x":"; then
++  AC_MSG_WARN([Unable to substitute extended shell functions in $ofile])
++fi
++])
++
++# _LT_PATH_CONVERSION_FUNCTIONS
++# -----------------------------
++# Determine which file name conversion functions should be used by
++# func_to_host_file (and, implicitly, by func_to_host_path).  These are needed
++# for certain cross-compile configurations and native mingw.
++m4_defun([_LT_PATH_CONVERSION_FUNCTIONS],
++[AC_REQUIRE([AC_CANONICAL_HOST])dnl
++AC_REQUIRE([AC_CANONICAL_BUILD])dnl
++AC_MSG_CHECKING([how to convert $build file names to $host format])
++AC_CACHE_VAL(lt_cv_to_host_file_cmd,
++[case $host in
++  *-*-mingw* )
++    case $build in
++      *-*-mingw* ) # actually msys
++        lt_cv_to_host_file_cmd=func_convert_file_msys_to_w32
++        ;;
++      *-*-cygwin* )
++        lt_cv_to_host_file_cmd=func_convert_file_cygwin_to_w32
++        ;;
++      * ) # otherwise, assume *nix
++        lt_cv_to_host_file_cmd=func_convert_file_nix_to_w32
++        ;;
++    esac
++    ;;
++  *-*-cygwin* )
++    case $build in
++      *-*-mingw* ) # actually msys
++        lt_cv_to_host_file_cmd=func_convert_file_msys_to_cygwin
++        ;;
++      *-*-cygwin* )
++        lt_cv_to_host_file_cmd=func_convert_file_noop
++        ;;
++      * ) # otherwise, assume *nix
++        lt_cv_to_host_file_cmd=func_convert_file_nix_to_cygwin
++        ;;
++    esac
++    ;;
++  * ) # unhandled hosts (and "normal" native builds)
++    lt_cv_to_host_file_cmd=func_convert_file_noop
++    ;;
++esac
++])
++to_host_file_cmd=$lt_cv_to_host_file_cmd
++AC_MSG_RESULT([$lt_cv_to_host_file_cmd])
++_LT_DECL([to_host_file_cmd], [lt_cv_to_host_file_cmd],
++         [0], [convert $build file names to $host format])dnl
++
++AC_MSG_CHECKING([how to convert $build file names to toolchain format])
++AC_CACHE_VAL(lt_cv_to_tool_file_cmd,
++[#assume ordinary cross tools, or native build.
++lt_cv_to_tool_file_cmd=func_convert_file_noop
++case $host in
++  *-*-mingw* )
++    case $build in
++      *-*-mingw* ) # actually msys
++        lt_cv_to_tool_file_cmd=func_convert_file_msys_to_w32
++        ;;
++    esac
++    ;;
++esac
++])
++to_tool_file_cmd=$lt_cv_to_tool_file_cmd
++AC_MSG_RESULT([$lt_cv_to_tool_file_cmd])
++_LT_DECL([to_tool_file_cmd], [lt_cv_to_tool_file_cmd],
++         [0], [convert $build files to toolchain format])dnl
++])# _LT_PATH_CONVERSION_FUNCTIONS
++
++# Helper functions for option handling.                    -*- Autoconf -*-
++#
++#   Copyright (C) 2004, 2005, 2007, 2008, 2009 Free Software Foundation,
++#   Inc.
++#   Written by Gary V. Vaughan, 2004
++#
++# This file is free software; the Free Software Foundation gives
++# unlimited permission to copy and/or distribute it, with or without
++# modifications, as long as this notice is preserved.
++
++# serial 7 ltoptions.m4
++
++# This is to help aclocal find these macros, as it can't see m4_define.
++AC_DEFUN([LTOPTIONS_VERSION], [m4_if([1])])
++
++
++# _LT_MANGLE_OPTION(MACRO-NAME, OPTION-NAME)
++# ------------------------------------------
++m4_define([_LT_MANGLE_OPTION],
++[[_LT_OPTION_]m4_bpatsubst($1__$2, [[^a-zA-Z0-9_]], [_])])
++
++
++# _LT_SET_OPTION(MACRO-NAME, OPTION-NAME)
++# ---------------------------------------
++# Set option OPTION-NAME for macro MACRO-NAME, and if there is a
++# matching handler defined, dispatch to it.  Other OPTION-NAMEs are
++# saved as a flag.
++m4_define([_LT_SET_OPTION],
++[m4_define(_LT_MANGLE_OPTION([$1], [$2]))dnl
++m4_ifdef(_LT_MANGLE_DEFUN([$1], [$2]),
++        _LT_MANGLE_DEFUN([$1], [$2]),
++    [m4_warning([Unknown $1 option `$2'])])[]dnl
++])
++
++
++# _LT_IF_OPTION(MACRO-NAME, OPTION-NAME, IF-SET, [IF-NOT-SET])
++# ------------------------------------------------------------
++# Execute IF-SET if OPTION is set, IF-NOT-SET otherwise.
++m4_define([_LT_IF_OPTION],
++[m4_ifdef(_LT_MANGLE_OPTION([$1], [$2]), [$3], [$4])])
++
++
++# _LT_UNLESS_OPTIONS(MACRO-NAME, OPTION-LIST, IF-NOT-SET)
++# -------------------------------------------------------
++# Execute IF-NOT-SET unless all options in OPTION-LIST for MACRO-NAME
++# are set.
++m4_define([_LT_UNLESS_OPTIONS],
++[m4_foreach([_LT_Option], m4_split(m4_normalize([$2])),
++	    [m4_ifdef(_LT_MANGLE_OPTION([$1], _LT_Option),
++		      [m4_define([$0_found])])])[]dnl
++m4_ifdef([$0_found], [m4_undefine([$0_found])], [$3
++])[]dnl
++])
++
++
++# _LT_SET_OPTIONS(MACRO-NAME, OPTION-LIST)
++# ----------------------------------------
++# OPTION-LIST is a space-separated list of Libtool options associated
++# with MACRO-NAME.  If any OPTION has a matching handler declared with
++# LT_OPTION_DEFINE, dispatch to that macro; otherwise complain about
++# the unknown option and exit.
++m4_defun([_LT_SET_OPTIONS],
++[# Set options
++m4_foreach([_LT_Option], m4_split(m4_normalize([$2])),
++    [_LT_SET_OPTION([$1], _LT_Option)])
++
++m4_if([$1],[LT_INIT],[
++  dnl
++  dnl Simply set some default values (i.e off) if boolean options were not
++  dnl specified:
++  _LT_UNLESS_OPTIONS([LT_INIT], [dlopen], [enable_dlopen=no
++  ])
++  _LT_UNLESS_OPTIONS([LT_INIT], [win32-dll], [enable_win32_dll=no
++  ])
++  dnl
++  dnl If no reference was made to various pairs of opposing options, then
++  dnl we run the default mode handler for the pair.  For example, if neither
++  dnl `shared' nor `disable-shared' was passed, we enable building of shared
++  dnl archives by default:
++  _LT_UNLESS_OPTIONS([LT_INIT], [shared disable-shared], [_LT_ENABLE_SHARED])
++  _LT_UNLESS_OPTIONS([LT_INIT], [static disable-static], [_LT_ENABLE_STATIC])
++  _LT_UNLESS_OPTIONS([LT_INIT], [pic-only no-pic], [_LT_WITH_PIC])
++  _LT_UNLESS_OPTIONS([LT_INIT], [fast-install disable-fast-install],
++  		   [_LT_ENABLE_FAST_INSTALL])
++  ])
++])# _LT_SET_OPTIONS
++
++
++
++# _LT_MANGLE_DEFUN(MACRO-NAME, OPTION-NAME)
++# -----------------------------------------
++m4_define([_LT_MANGLE_DEFUN],
++[[_LT_OPTION_DEFUN_]m4_bpatsubst(m4_toupper([$1__$2]), [[^A-Z0-9_]], [_])])
++
++
++# LT_OPTION_DEFINE(MACRO-NAME, OPTION-NAME, CODE)
++# -----------------------------------------------
++m4_define([LT_OPTION_DEFINE],
++[m4_define(_LT_MANGLE_DEFUN([$1], [$2]), [$3])[]dnl
++])# LT_OPTION_DEFINE
++
++
++# dlopen
++# ------
++LT_OPTION_DEFINE([LT_INIT], [dlopen], [enable_dlopen=yes
++])
++
++AU_DEFUN([AC_LIBTOOL_DLOPEN],
++[_LT_SET_OPTION([LT_INIT], [dlopen])
++AC_DIAGNOSE([obsolete],
++[$0: Remove this warning and the call to _LT_SET_OPTION when you
++put the `dlopen' option into LT_INIT's first parameter.])
++])
++
++dnl aclocal-1.4 backwards compatibility:
++dnl AC_DEFUN([AC_LIBTOOL_DLOPEN], [])
++
++
++# win32-dll
++# ---------
++# Declare package support for building win32 dll's.
++LT_OPTION_DEFINE([LT_INIT], [win32-dll],
++[enable_win32_dll=yes
++
++case $host in
++*-*-cygwin* | *-*-mingw* | *-*-pw32* | *-*-cegcc*)
++  AC_CHECK_TOOL(AS, as, false)
++  AC_CHECK_TOOL(DLLTOOL, dlltool, false)
++  AC_CHECK_TOOL(OBJDUMP, objdump, false)
++  ;;
++esac
++
++test -z "$AS" && AS=as
++_LT_DECL([], [AS],      [1], [Assembler program])dnl
++
++test -z "$DLLTOOL" && DLLTOOL=dlltool
++_LT_DECL([], [DLLTOOL], [1], [DLL creation program])dnl
++
++test -z "$OBJDUMP" && OBJDUMP=objdump
++_LT_DECL([], [OBJDUMP], [1], [Object dumper program])dnl
++])# win32-dll
++
++AU_DEFUN([AC_LIBTOOL_WIN32_DLL],
++[AC_REQUIRE([AC_CANONICAL_HOST])dnl
++_LT_SET_OPTION([LT_INIT], [win32-dll])
++AC_DIAGNOSE([obsolete],
++[$0: Remove this warning and the call to _LT_SET_OPTION when you
++put the `win32-dll' option into LT_INIT's first parameter.])
++])
++
++dnl aclocal-1.4 backwards compatibility:
++dnl AC_DEFUN([AC_LIBTOOL_WIN32_DLL], [])
++
++
++# _LT_ENABLE_SHARED([DEFAULT])
++# ----------------------------
++# implement the --enable-shared flag, and supports the `shared' and
++# `disable-shared' LT_INIT options.
++# DEFAULT is either `yes' or `no'.  If omitted, it defaults to `yes'.
++m4_define([_LT_ENABLE_SHARED],
++[m4_define([_LT_ENABLE_SHARED_DEFAULT], [m4_if($1, no, no, yes)])dnl
++AC_ARG_ENABLE([shared],
++    [AS_HELP_STRING([--enable-shared@<:@=PKGS@:>@],
++	[build shared libraries @<:@default=]_LT_ENABLE_SHARED_DEFAULT[@:>@])],
++    [p=${PACKAGE-default}
++    case $enableval in
++    yes) enable_shared=yes ;;
++    no) enable_shared=no ;;
++    *)
++      enable_shared=no
++      # Look at the argument we got.  We use all the common list separators.
++      lt_save_ifs="$IFS"; IFS="${IFS}$PATH_SEPARATOR,"
++      for pkg in $enableval; do
++	IFS="$lt_save_ifs"
++	if test "X$pkg" = "X$p"; then
++	  enable_shared=yes
++	fi
++      done
++      IFS="$lt_save_ifs"
++      ;;
++    esac],
++    [enable_shared=]_LT_ENABLE_SHARED_DEFAULT)
++
++    _LT_DECL([build_libtool_libs], [enable_shared], [0],
++	[Whether or not to build shared libraries])
++])# _LT_ENABLE_SHARED
++
++LT_OPTION_DEFINE([LT_INIT], [shared], [_LT_ENABLE_SHARED([yes])])
++LT_OPTION_DEFINE([LT_INIT], [disable-shared], [_LT_ENABLE_SHARED([no])])
++
++# Old names:
++AC_DEFUN([AC_ENABLE_SHARED],
++[_LT_SET_OPTION([LT_INIT], m4_if([$1], [no], [disable-])[shared])
++])
++
++AC_DEFUN([AC_DISABLE_SHARED],
++[_LT_SET_OPTION([LT_INIT], [disable-shared])
++])
++
++AU_DEFUN([AM_ENABLE_SHARED], [AC_ENABLE_SHARED($@)])
++AU_DEFUN([AM_DISABLE_SHARED], [AC_DISABLE_SHARED($@)])
++
++dnl aclocal-1.4 backwards compatibility:
++dnl AC_DEFUN([AM_ENABLE_SHARED], [])
++dnl AC_DEFUN([AM_DISABLE_SHARED], [])
++
++
++
++# _LT_ENABLE_STATIC([DEFAULT])
++# ----------------------------
++# implement the --enable-static flag, and support the `static' and
++# `disable-static' LT_INIT options.
++# DEFAULT is either `yes' or `no'.  If omitted, it defaults to `yes'.
++m4_define([_LT_ENABLE_STATIC],
++[m4_define([_LT_ENABLE_STATIC_DEFAULT], [m4_if($1, no, no, yes)])dnl
++AC_ARG_ENABLE([static],
++    [AS_HELP_STRING([--enable-static@<:@=PKGS@:>@],
++	[build static libraries @<:@default=]_LT_ENABLE_STATIC_DEFAULT[@:>@])],
++    [p=${PACKAGE-default}
++    case $enableval in
++    yes) enable_static=yes ;;
++    no) enable_static=no ;;
++    *)
++     enable_static=no
++      # Look at the argument we got.  We use all the common list separators.
++      lt_save_ifs="$IFS"; IFS="${IFS}$PATH_SEPARATOR,"
++      for pkg in $enableval; do
++	IFS="$lt_save_ifs"
++	if test "X$pkg" = "X$p"; then
++	  enable_static=yes
++	fi
++      done
++      IFS="$lt_save_ifs"
++      ;;
++    esac],
++    [enable_static=]_LT_ENABLE_STATIC_DEFAULT)
++
++    _LT_DECL([build_old_libs], [enable_static], [0],
++	[Whether or not to build static libraries])
++])# _LT_ENABLE_STATIC
++
++LT_OPTION_DEFINE([LT_INIT], [static], [_LT_ENABLE_STATIC([yes])])
++LT_OPTION_DEFINE([LT_INIT], [disable-static], [_LT_ENABLE_STATIC([no])])
++
++# Old names:
++AC_DEFUN([AC_ENABLE_STATIC],
++[_LT_SET_OPTION([LT_INIT], m4_if([$1], [no], [disable-])[static])
++])
++
++AC_DEFUN([AC_DISABLE_STATIC],
++[_LT_SET_OPTION([LT_INIT], [disable-static])
++])
++
++AU_DEFUN([AM_ENABLE_STATIC], [AC_ENABLE_STATIC($@)])
++AU_DEFUN([AM_DISABLE_STATIC], [AC_DISABLE_STATIC($@)])
++
++dnl aclocal-1.4 backwards compatibility:
++dnl AC_DEFUN([AM_ENABLE_STATIC], [])
++dnl AC_DEFUN([AM_DISABLE_STATIC], [])
++
++
++
++# _LT_ENABLE_FAST_INSTALL([DEFAULT])
++# ----------------------------------
++# implement the --enable-fast-install flag, and support the `fast-install'
++# and `disable-fast-install' LT_INIT options.
++# DEFAULT is either `yes' or `no'.  If omitted, it defaults to `yes'.
++m4_define([_LT_ENABLE_FAST_INSTALL],
++[m4_define([_LT_ENABLE_FAST_INSTALL_DEFAULT], [m4_if($1, no, no, yes)])dnl
++AC_ARG_ENABLE([fast-install],
++    [AS_HELP_STRING([--enable-fast-install@<:@=PKGS@:>@],
++    [optimize for fast installation @<:@default=]_LT_ENABLE_FAST_INSTALL_DEFAULT[@:>@])],
++    [p=${PACKAGE-default}
++    case $enableval in
++    yes) enable_fast_install=yes ;;
++    no) enable_fast_install=no ;;
++    *)
++      enable_fast_install=no
++      # Look at the argument we got.  We use all the common list separators.
++      lt_save_ifs="$IFS"; IFS="${IFS}$PATH_SEPARATOR,"
++      for pkg in $enableval; do
++	IFS="$lt_save_ifs"
++	if test "X$pkg" = "X$p"; then
++	  enable_fast_install=yes
++	fi
++      done
++      IFS="$lt_save_ifs"
++      ;;
++    esac],
++    [enable_fast_install=]_LT_ENABLE_FAST_INSTALL_DEFAULT)
++
++_LT_DECL([fast_install], [enable_fast_install], [0],
++	 [Whether or not to optimize for fast installation])dnl
++])# _LT_ENABLE_FAST_INSTALL
++
++LT_OPTION_DEFINE([LT_INIT], [fast-install], [_LT_ENABLE_FAST_INSTALL([yes])])
++LT_OPTION_DEFINE([LT_INIT], [disable-fast-install], [_LT_ENABLE_FAST_INSTALL([no])])
++
++# Old names:
++AU_DEFUN([AC_ENABLE_FAST_INSTALL],
++[_LT_SET_OPTION([LT_INIT], m4_if([$1], [no], [disable-])[fast-install])
++AC_DIAGNOSE([obsolete],
++[$0: Remove this warning and the call to _LT_SET_OPTION when you put
++the `fast-install' option into LT_INIT's first parameter.])
++])
++
++AU_DEFUN([AC_DISABLE_FAST_INSTALL],
++[_LT_SET_OPTION([LT_INIT], [disable-fast-install])
++AC_DIAGNOSE([obsolete],
++[$0: Remove this warning and the call to _LT_SET_OPTION when you put
++the `disable-fast-install' option into LT_INIT's first parameter.])
++])
++
++dnl aclocal-1.4 backwards compatibility:
++dnl AC_DEFUN([AC_ENABLE_FAST_INSTALL], [])
++dnl AC_DEFUN([AM_DISABLE_FAST_INSTALL], [])
++
++
++# _LT_WITH_PIC([MODE])
++# --------------------
++# implement the --with-pic flag, and support the `pic-only' and `no-pic'
++# LT_INIT options.
++# MODE is either `yes' or `no'.  If omitted, it defaults to `both'.
++m4_define([_LT_WITH_PIC],
++[AC_ARG_WITH([pic],
++    [AS_HELP_STRING([--with-pic@<:@=PKGS@:>@],
++	[try to use only PIC/non-PIC objects @<:@default=use both@:>@])],
++    [lt_p=${PACKAGE-default}
++    case $withval in
++    yes|no) pic_mode=$withval ;;
++    *)
++      pic_mode=default
++      # Look at the argument we got.  We use all the common list separators.
++      lt_save_ifs="$IFS"; IFS="${IFS}$PATH_SEPARATOR,"
++      for lt_pkg in $withval; do
++	IFS="$lt_save_ifs"
++	if test "X$lt_pkg" = "X$lt_p"; then
++	  pic_mode=yes
++	fi
++      done
++      IFS="$lt_save_ifs"
++      ;;
++    esac],
++    [pic_mode=default])
++
++test -z "$pic_mode" && pic_mode=m4_default([$1], [default])
++
++_LT_DECL([], [pic_mode], [0], [What type of objects to build])dnl
++])# _LT_WITH_PIC
++
++LT_OPTION_DEFINE([LT_INIT], [pic-only], [_LT_WITH_PIC([yes])])
++LT_OPTION_DEFINE([LT_INIT], [no-pic], [_LT_WITH_PIC([no])])
++
++# Old name:
++AU_DEFUN([AC_LIBTOOL_PICMODE],
++[_LT_SET_OPTION([LT_INIT], [pic-only])
++AC_DIAGNOSE([obsolete],
++[$0: Remove this warning and the call to _LT_SET_OPTION when you
++put the `pic-only' option into LT_INIT's first parameter.])
++])
++
++dnl aclocal-1.4 backwards compatibility:
++dnl AC_DEFUN([AC_LIBTOOL_PICMODE], [])
++
++
++m4_define([_LTDL_MODE], [])
++LT_OPTION_DEFINE([LTDL_INIT], [nonrecursive],
++		 [m4_define([_LTDL_MODE], [nonrecursive])])
++LT_OPTION_DEFINE([LTDL_INIT], [recursive],
++		 [m4_define([_LTDL_MODE], [recursive])])
++LT_OPTION_DEFINE([LTDL_INIT], [subproject],
++		 [m4_define([_LTDL_MODE], [subproject])])
++
++m4_define([_LTDL_TYPE], [])
++LT_OPTION_DEFINE([LTDL_INIT], [installable],
++		 [m4_define([_LTDL_TYPE], [installable])])
++LT_OPTION_DEFINE([LTDL_INIT], [convenience],
++		 [m4_define([_LTDL_TYPE], [convenience])])
++
++# ltsugar.m4 -- libtool m4 base layer.                         -*-Autoconf-*-
++#
++# Copyright (C) 2004, 2005, 2007, 2008 Free Software Foundation, Inc.
++# Written by Gary V. Vaughan, 2004
++#
++# This file is free software; the Free Software Foundation gives
++# unlimited permission to copy and/or distribute it, with or without
++# modifications, as long as this notice is preserved.
++
++# serial 6 ltsugar.m4
++
++# This is to help aclocal find these macros, as it can't see m4_define.
++AC_DEFUN([LTSUGAR_VERSION], [m4_if([0.1])])
++
++
++# lt_join(SEP, ARG1, [ARG2...])
++# -----------------------------
++# Produce ARG1SEPARG2...SEPARGn, omitting [] arguments and their
++# associated separator.
++# Needed until we can rely on m4_join from Autoconf 2.62, since all earlier
++# versions in m4sugar had bugs.
++m4_define([lt_join],
++[m4_if([$#], [1], [],
++       [$#], [2], [[$2]],
++       [m4_if([$2], [], [], [[$2]_])$0([$1], m4_shift(m4_shift($@)))])])
++m4_define([_lt_join],
++[m4_if([$#$2], [2], [],
++       [m4_if([$2], [], [], [[$1$2]])$0([$1], m4_shift(m4_shift($@)))])])
++
++
++# lt_car(LIST)
++# lt_cdr(LIST)
++# ------------
++# Manipulate m4 lists.
++# These macros are necessary as long as will still need to support
++# Autoconf-2.59 which quotes differently.
++m4_define([lt_car], [[$1]])
++m4_define([lt_cdr],
++[m4_if([$#], 0, [m4_fatal([$0: cannot be called without arguments])],
++       [$#], 1, [],
++       [m4_dquote(m4_shift($@))])])
++m4_define([lt_unquote], $1)
++
++
++# lt_append(MACRO-NAME, STRING, [SEPARATOR])
++# ------------------------------------------
++# Redefine MACRO-NAME to hold its former content plus `SEPARATOR'`STRING'.
++# Note that neither SEPARATOR nor STRING are expanded; they are appended
++# to MACRO-NAME as is (leaving the expansion for when MACRO-NAME is invoked).
++# No SEPARATOR is output if MACRO-NAME was previously undefined (different
++# than defined and empty).
++#
++# This macro is needed until we can rely on Autoconf 2.62, since earlier
++# versions of m4sugar mistakenly expanded SEPARATOR but not STRING.
++m4_define([lt_append],
++[m4_define([$1],
++	   m4_ifdef([$1], [m4_defn([$1])[$3]])[$2])])
++
++
++
++# lt_combine(SEP, PREFIX-LIST, INFIX, SUFFIX1, [SUFFIX2...])
++# ----------------------------------------------------------
++# Produce a SEP delimited list of all paired combinations of elements of
++# PREFIX-LIST with SUFFIX1 through SUFFIXn.  Each element of the list
++# has the form PREFIXmINFIXSUFFIXn.
++# Needed until we can rely on m4_combine added in Autoconf 2.62.
++m4_define([lt_combine],
++[m4_if(m4_eval([$# > 3]), [1],
++       [m4_pushdef([_Lt_sep], [m4_define([_Lt_sep], m4_defn([lt_car]))])]]dnl
++[[m4_foreach([_Lt_prefix], [$2],
++	     [m4_foreach([_Lt_suffix],
++		]m4_dquote(m4_dquote(m4_shift(m4_shift(m4_shift($@)))))[,
++	[_Lt_sep([$1])[]m4_defn([_Lt_prefix])[$3]m4_defn([_Lt_suffix])])])])])
++
++
++# lt_if_append_uniq(MACRO-NAME, VARNAME, [SEPARATOR], [UNIQ], [NOT-UNIQ])
++# -----------------------------------------------------------------------
++# Iff MACRO-NAME does not yet contain VARNAME, then append it (delimited
++# by SEPARATOR if supplied) and expand UNIQ, else NOT-UNIQ.
++m4_define([lt_if_append_uniq],
++[m4_ifdef([$1],
++	  [m4_if(m4_index([$3]m4_defn([$1])[$3], [$3$2$3]), [-1],
++		 [lt_append([$1], [$2], [$3])$4],
++		 [$5])],
++	  [lt_append([$1], [$2], [$3])$4])])
++
++
++# lt_dict_add(DICT, KEY, VALUE)
++# -----------------------------
++m4_define([lt_dict_add],
++[m4_define([$1($2)], [$3])])
++
++
++# lt_dict_add_subkey(DICT, KEY, SUBKEY, VALUE)
++# --------------------------------------------
++m4_define([lt_dict_add_subkey],
++[m4_define([$1($2:$3)], [$4])])
++
++
++# lt_dict_fetch(DICT, KEY, [SUBKEY])
++# ----------------------------------
++m4_define([lt_dict_fetch],
++[m4_ifval([$3],
++	m4_ifdef([$1($2:$3)], [m4_defn([$1($2:$3)])]),
++    m4_ifdef([$1($2)], [m4_defn([$1($2)])]))])
++
++
++# lt_if_dict_fetch(DICT, KEY, [SUBKEY], VALUE, IF-TRUE, [IF-FALSE])
++# -----------------------------------------------------------------
++m4_define([lt_if_dict_fetch],
++[m4_if(lt_dict_fetch([$1], [$2], [$3]), [$4],
++	[$5],
++    [$6])])
++
++
++# lt_dict_filter(DICT, [SUBKEY], VALUE, [SEPARATOR], KEY, [...])
++# --------------------------------------------------------------
++m4_define([lt_dict_filter],
++[m4_if([$5], [], [],
++  [lt_join(m4_quote(m4_default([$4], [[, ]])),
++           lt_unquote(m4_split(m4_normalize(m4_foreach(_Lt_key, lt_car([m4_shiftn(4, $@)]),
++		      [lt_if_dict_fetch([$1], _Lt_key, [$2], [$3], [_Lt_key ])])))))])[]dnl
++])
++
++# ltversion.m4 -- version numbers			-*- Autoconf -*-
++#
++#   Copyright (C) 2004 Free Software Foundation, Inc.
++#   Written by Scott James Remnant, 2004
++#
++# This file is free software; the Free Software Foundation gives
++# unlimited permission to copy and/or distribute it, with or without
++# modifications, as long as this notice is preserved.
++
++# @configure_input@
++
++# serial 3337 ltversion.m4
++# This file is part of GNU Libtool
++
++m4_define([LT_PACKAGE_VERSION], [2.4.2])
++m4_define([LT_PACKAGE_REVISION], [1.3337])
++
++AC_DEFUN([LTVERSION_VERSION],
++[macro_version='2.4.2'
++macro_revision='1.3337'
++_LT_DECL(, macro_version, 0, [Which release of libtool.m4 was used?])
++_LT_DECL(, macro_revision, 0)
++])
++
++# lt~obsolete.m4 -- aclocal satisfying obsolete definitions.    -*-Autoconf-*-
++#
++#   Copyright (C) 2004, 2005, 2007, 2009 Free Software Foundation, Inc.
++#   Written by Scott James Remnant, 2004.
++#
++# This file is free software; the Free Software Foundation gives
++# unlimited permission to copy and/or distribute it, with or without
++# modifications, as long as this notice is preserved.
++
++# serial 5 lt~obsolete.m4
++
++# These exist entirely to fool aclocal when bootstrapping libtool.
++#
++# In the past libtool.m4 has provided macros via AC_DEFUN (or AU_DEFUN)
++# which have later been changed to m4_define as they aren't part of the
++# exported API, or moved to Autoconf or Automake where they belong.
++#
++# The trouble is, aclocal is a bit thick.  It'll see the old AC_DEFUN
++# in /usr/share/aclocal/libtool.m4 and remember it, then when it sees us
++# using a macro with the same name in our local m4/libtool.m4 it'll
++# pull the old libtool.m4 in (it doesn't see our shiny new m4_define
++# and doesn't know about Autoconf macros at all.)
++#
++# So we provide this file, which has a silly filename so it's always
++# included after everything else.  This provides aclocal with the
++# AC_DEFUNs it wants, but when m4 processes it, it doesn't do anything
++# because those macros already exist, or will be overwritten later.
++# We use AC_DEFUN over AU_DEFUN for compatibility with aclocal-1.6. 
++#
++# Anytime we withdraw an AC_DEFUN or AU_DEFUN, remember to add it here.
++# Yes, that means every name once taken will need to remain here until
++# we give up compatibility with versions before 1.7, at which point
++# we need to keep only those names which we still refer to.
++
++# This is to help aclocal find these macros, as it can't see m4_define.
++AC_DEFUN([LTOBSOLETE_VERSION], [m4_if([1])])
++
++m4_ifndef([AC_LIBTOOL_LINKER_OPTION],	[AC_DEFUN([AC_LIBTOOL_LINKER_OPTION])])
++m4_ifndef([AC_PROG_EGREP],		[AC_DEFUN([AC_PROG_EGREP])])
++m4_ifndef([_LT_AC_PROG_ECHO_BACKSLASH],	[AC_DEFUN([_LT_AC_PROG_ECHO_BACKSLASH])])
++m4_ifndef([_LT_AC_SHELL_INIT],		[AC_DEFUN([_LT_AC_SHELL_INIT])])
++m4_ifndef([_LT_AC_SYS_LIBPATH_AIX],	[AC_DEFUN([_LT_AC_SYS_LIBPATH_AIX])])
++m4_ifndef([_LT_PROG_LTMAIN],		[AC_DEFUN([_LT_PROG_LTMAIN])])
++m4_ifndef([_LT_AC_TAGVAR],		[AC_DEFUN([_LT_AC_TAGVAR])])
++m4_ifndef([AC_LTDL_ENABLE_INSTALL],	[AC_DEFUN([AC_LTDL_ENABLE_INSTALL])])
++m4_ifndef([AC_LTDL_PREOPEN],		[AC_DEFUN([AC_LTDL_PREOPEN])])
++m4_ifndef([_LT_AC_SYS_COMPILER],	[AC_DEFUN([_LT_AC_SYS_COMPILER])])
++m4_ifndef([_LT_AC_LOCK],		[AC_DEFUN([_LT_AC_LOCK])])
++m4_ifndef([AC_LIBTOOL_SYS_OLD_ARCHIVE],	[AC_DEFUN([AC_LIBTOOL_SYS_OLD_ARCHIVE])])
++m4_ifndef([_LT_AC_TRY_DLOPEN_SELF],	[AC_DEFUN([_LT_AC_TRY_DLOPEN_SELF])])
++m4_ifndef([AC_LIBTOOL_PROG_CC_C_O],	[AC_DEFUN([AC_LIBTOOL_PROG_CC_C_O])])
++m4_ifndef([AC_LIBTOOL_SYS_HARD_LINK_LOCKS], [AC_DEFUN([AC_LIBTOOL_SYS_HARD_LINK_LOCKS])])
++m4_ifndef([AC_LIBTOOL_OBJDIR],		[AC_DEFUN([AC_LIBTOOL_OBJDIR])])
++m4_ifndef([AC_LTDL_OBJDIR],		[AC_DEFUN([AC_LTDL_OBJDIR])])
++m4_ifndef([AC_LIBTOOL_PROG_LD_HARDCODE_LIBPATH], [AC_DEFUN([AC_LIBTOOL_PROG_LD_HARDCODE_LIBPATH])])
++m4_ifndef([AC_LIBTOOL_SYS_LIB_STRIP],	[AC_DEFUN([AC_LIBTOOL_SYS_LIB_STRIP])])
++m4_ifndef([AC_PATH_MAGIC],		[AC_DEFUN([AC_PATH_MAGIC])])
++m4_ifndef([AC_PROG_LD_GNU],		[AC_DEFUN([AC_PROG_LD_GNU])])
++m4_ifndef([AC_PROG_LD_RELOAD_FLAG],	[AC_DEFUN([AC_PROG_LD_RELOAD_FLAG])])
++m4_ifndef([AC_DEPLIBS_CHECK_METHOD],	[AC_DEFUN([AC_DEPLIBS_CHECK_METHOD])])
++m4_ifndef([AC_LIBTOOL_PROG_COMPILER_NO_RTTI], [AC_DEFUN([AC_LIBTOOL_PROG_COMPILER_NO_RTTI])])
++m4_ifndef([AC_LIBTOOL_SYS_GLOBAL_SYMBOL_PIPE], [AC_DEFUN([AC_LIBTOOL_SYS_GLOBAL_SYMBOL_PIPE])])
++m4_ifndef([AC_LIBTOOL_PROG_COMPILER_PIC], [AC_DEFUN([AC_LIBTOOL_PROG_COMPILER_PIC])])
++m4_ifndef([AC_LIBTOOL_PROG_LD_SHLIBS],	[AC_DEFUN([AC_LIBTOOL_PROG_LD_SHLIBS])])
++m4_ifndef([AC_LIBTOOL_POSTDEP_PREDEP],	[AC_DEFUN([AC_LIBTOOL_POSTDEP_PREDEP])])
++m4_ifndef([LT_AC_PROG_EGREP],		[AC_DEFUN([LT_AC_PROG_EGREP])])
++m4_ifndef([LT_AC_PROG_SED],		[AC_DEFUN([LT_AC_PROG_SED])])
++m4_ifndef([_LT_CC_BASENAME],		[AC_DEFUN([_LT_CC_BASENAME])])
++m4_ifndef([_LT_COMPILER_BOILERPLATE],	[AC_DEFUN([_LT_COMPILER_BOILERPLATE])])
++m4_ifndef([_LT_LINKER_BOILERPLATE],	[AC_DEFUN([_LT_LINKER_BOILERPLATE])])
++m4_ifndef([_AC_PROG_LIBTOOL],		[AC_DEFUN([_AC_PROG_LIBTOOL])])
++m4_ifndef([AC_LIBTOOL_SETUP],		[AC_DEFUN([AC_LIBTOOL_SETUP])])
++m4_ifndef([_LT_AC_CHECK_DLFCN],		[AC_DEFUN([_LT_AC_CHECK_DLFCN])])
++m4_ifndef([AC_LIBTOOL_SYS_DYNAMIC_LINKER],	[AC_DEFUN([AC_LIBTOOL_SYS_DYNAMIC_LINKER])])
++m4_ifndef([_LT_AC_TAGCONFIG],		[AC_DEFUN([_LT_AC_TAGCONFIG])])
++m4_ifndef([AC_DISABLE_FAST_INSTALL],	[AC_DEFUN([AC_DISABLE_FAST_INSTALL])])
++m4_ifndef([_LT_AC_LANG_CXX],		[AC_DEFUN([_LT_AC_LANG_CXX])])
++m4_ifndef([_LT_AC_LANG_F77],		[AC_DEFUN([_LT_AC_LANG_F77])])
++m4_ifndef([_LT_AC_LANG_GCJ],		[AC_DEFUN([_LT_AC_LANG_GCJ])])
++m4_ifndef([AC_LIBTOOL_LANG_C_CONFIG],	[AC_DEFUN([AC_LIBTOOL_LANG_C_CONFIG])])
++m4_ifndef([_LT_AC_LANG_C_CONFIG],	[AC_DEFUN([_LT_AC_LANG_C_CONFIG])])
++m4_ifndef([AC_LIBTOOL_LANG_CXX_CONFIG],	[AC_DEFUN([AC_LIBTOOL_LANG_CXX_CONFIG])])
++m4_ifndef([_LT_AC_LANG_CXX_CONFIG],	[AC_DEFUN([_LT_AC_LANG_CXX_CONFIG])])
++m4_ifndef([AC_LIBTOOL_LANG_F77_CONFIG],	[AC_DEFUN([AC_LIBTOOL_LANG_F77_CONFIG])])
++m4_ifndef([_LT_AC_LANG_F77_CONFIG],	[AC_DEFUN([_LT_AC_LANG_F77_CONFIG])])
++m4_ifndef([AC_LIBTOOL_LANG_GCJ_CONFIG],	[AC_DEFUN([AC_LIBTOOL_LANG_GCJ_CONFIG])])
++m4_ifndef([_LT_AC_LANG_GCJ_CONFIG],	[AC_DEFUN([_LT_AC_LANG_GCJ_CONFIG])])
++m4_ifndef([AC_LIBTOOL_LANG_RC_CONFIG],	[AC_DEFUN([AC_LIBTOOL_LANG_RC_CONFIG])])
++m4_ifndef([_LT_AC_LANG_RC_CONFIG],	[AC_DEFUN([_LT_AC_LANG_RC_CONFIG])])
++m4_ifndef([AC_LIBTOOL_CONFIG],		[AC_DEFUN([AC_LIBTOOL_CONFIG])])
++m4_ifndef([_LT_AC_FILE_LTDLL_C],	[AC_DEFUN([_LT_AC_FILE_LTDLL_C])])
++m4_ifndef([_LT_REQUIRED_DARWIN_CHECKS],	[AC_DEFUN([_LT_REQUIRED_DARWIN_CHECKS])])
++m4_ifndef([_LT_AC_PROG_CXXCPP],		[AC_DEFUN([_LT_AC_PROG_CXXCPP])])
++m4_ifndef([_LT_PREPARE_SED_QUOTE_VARS],	[AC_DEFUN([_LT_PREPARE_SED_QUOTE_VARS])])
++m4_ifndef([_LT_PROG_ECHO_BACKSLASH],	[AC_DEFUN([_LT_PROG_ECHO_BACKSLASH])])
++m4_ifndef([_LT_PROG_F77],		[AC_DEFUN([_LT_PROG_F77])])
++m4_ifndef([_LT_PROG_FC],		[AC_DEFUN([_LT_PROG_FC])])
++m4_ifndef([_LT_PROG_CXX],		[AC_DEFUN([_LT_PROG_CXX])])
++
+ # Copyright (C) 2002-2013 Free Software Foundation, Inc.
+ #
+ # This file is free software; the Free Software Foundation
+@@ -995,8 +9597,3 @@ AC_SUBST([am__untar])
+ ]) # _AM_PROG_TAR
+ 
+ m4_include([m4/depend.m4])
+-m4_include([m4/libtool.m4])
+-m4_include([m4/ltoptions.m4])
+-m4_include([m4/ltsugar.m4])
+-m4_include([m4/ltversion.m4])
+-m4_include([m4/lt~obsolete.m4])
+diff --git a/config.h b/config.h
+index 06e129d..8abf834 100644
+--- a/config.h
++++ b/config.h
+@@ -37,6 +37,9 @@
+ /* Define to 1 if the compiler supports dynamic arrays */
+ #define HAVE_DYNAMIC_ARRAYS 1
+ 
++/* Define to 1 if the compiler supports dynamic arrays with classes */
++#define HAVE_DYNAMIC_ARRAYS_NOPOD 1
++
+ /* Define to 1 if you have the <execinfo.h> header file. */
+ #define HAVE_EXECINFO_H 1
+ 
+diff --git a/config.h.in b/config.h.in
+index 91dcfec..950b844 100644
+--- a/config.h.in
++++ b/config.h.in
+@@ -36,6 +36,9 @@
+ /* Define to 1 if the compiler supports dynamic arrays */
+ #undef HAVE_DYNAMIC_ARRAYS
+ 
++/* Define to 1 if the compiler supports dynamic arrays with classes */
++#undef HAVE_DYNAMIC_ARRAYS_NOPOD
++
+ /* Define to 1 if you have the <execinfo.h> header file. */
+ #undef HAVE_EXECINFO_H
+ 
+diff --git a/configure b/configure
+index 53c7ff1..5900358 100755
+--- a/configure
++++ b/configure
+@@ -9077,10 +9077,6 @@ _lt_linker_boilerplate=`cat conftest.err`
+ $RM -r conftest*
+ 
+ 
+-## CAVEAT EMPTOR:
+-## There is no encapsulation within the following macros, do not change
+-## the running order or otherwise move them around unless you know exactly
+-## what you are doing...
+ if test -n "$compiler"; then
+ 
+ lt_prog_compiler_no_builtin_flag=
+@@ -18306,18 +18302,17 @@ $as_echo "$HAVE_SOLARIS_ATOMIC" >&6; }
+ 
+ # see if the compiler supports dynamic arrays
+ #
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking if compiler supports dynamic arrays" >&5
+-$as_echo_n "checking if compiler supports dynamic arrays... " >&6; }
++{ $as_echo "$as_me:${as_lineno-$LINENO}: checking if compiler supports dynamic arrays of PODs" >&5
++$as_echo_n "checking if compiler supports dynamic arrays of PODs... " >&6; }
+ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+  extern int foo();
+-           class A { public: A() {} };
+ 
+ int
+ main ()
+ {
+  int len = foo();
+-          A array[len];
++          int array[len];
+           for (int l = 1; l < len; ++l) array[l] = array[l - 1];
+ 
+   ;
+@@ -18340,6 +18335,42 @@ _ACEOF
+ 
+ fi
+ 
++# see if the compiler supports dynamic arrays with classes
++#
++{ $as_echo "$as_me:${as_lineno-$LINENO}: checking if compiler supports dynamic arrays with classes" >&5
++$as_echo_n "checking if compiler supports dynamic arrays with classes... " >&6; }
++cat confdefs.h - <<_ACEOF >conftest.$ac_ext
++/* end confdefs.h.  */
++ extern int foo();
++           class A { public: A() {} };
++
++int
++main ()
++{
++ int len = foo();
++          A array[len];
++          for (int l = 1; l < len; ++l) array[l] = array[l - 1];
++
++  ;
++  return 0;
++}
++_ACEOF
++if ac_fn_cxx_try_compile "$LINENO"; then :
++  DynArrays_noPOD=yes
++else
++  DynArrays_noPOD=no
++fi
++rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $DynArrays_noPOD" >&5
++$as_echo "$DynArrays_noPOD" >&6; }
++if test "x$DynArrays_noPOD" = "xyes"; then
++
++cat >>confdefs.h <<_ACEOF
++#define HAVE_DYNAMIC_ARRAYS_NOPOD 1
++_ACEOF
++
++fi
++
+ # check if the user compiles for ANDROID
+ #
+ { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we are compiling for Android" >&5
+@@ -18615,6 +18646,7 @@ else
+ fi
+ 
+ 
++echo
+ cat >confcache <<\_ACEOF
+ # This file is a shell script that caches the results of configure
+ # tests run on this system so they can be shared between configure
+@@ -21316,6 +21348,16 @@ $as_echo "$as_me: WARNING: unrecognized options: $ac_unrecognized_opts" >&2;}
+ fi
+ 
+ 
++# create src/buildtag.hh
++echo
++echo "configure: creating src/buildtag.hh"
++. src/buildtag > src/buildtag.hh
++
++# remember how ./configure was called
++echo "configure: creating src/configure_args.cc"
++echo "extern const char * configure_args;" > src/configure_args.cc
++echo "const char * configure_args = \"$0 $ac_configure_args\";" >> src/configure_args.cc
++
+ # summary
+   echo " "
+ if test "x$USABLE_PostgreSQL" != "xyes"; then
+@@ -21330,7 +21372,3 @@ fi
+   echo " "
+ fi
+ 
+-# remember how ./configure was called
+-echo "extern const char * configure_args;" > src/configure_args.cc
+-echo "const char * configure_args = \"$0 $ac_configure_args\";" >> src/configure_args.cc
+-
+diff --git a/configure.ac b/configure.ac
+index fe40410..942f12b 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -221,14 +221,13 @@ AC_MSG_RESULT([$HAVE_SOLARIS_ATOMIC])
+ 
+ # see if the compiler supports dynamic arrays
+ #
+-AC_MSG_CHECKING([if compiler supports dynamic arrays])
++AC_MSG_CHECKING([if compiler supports dynamic arrays of PODs])
+ AC_COMPILE_IFELSE(
+     [AC_LANG_PROGRAM(
+         [ [extern int foo();]
+-          [ class A { public: A() {} }; ]
+         ],
+         [ [int len = foo();]
+-          [A array[len];]
++          [int array[len];]
+           [for (int l = 1; l < len; ++l) array[l] = array[l - 1];]
+         ]           )],
+     [DynArrays=yes], [DynArrays=no])
+@@ -238,6 +237,25 @@ if test "x$DynArrays" = "xyes"; then
+                       [Define to 1 if the compiler supports dynamic arrays])
+ fi
+ 
++# see if the compiler supports dynamic arrays with classes
++#
++AC_MSG_CHECKING([if compiler supports dynamic arrays with classes])
++AC_COMPILE_IFELSE(
++    [AC_LANG_PROGRAM(
++        [ [extern int foo();]
++          [ class A { public: A() {} }; ]
++        ],
++        [ [int len = foo();]
++          [A array[len];]
++          [for (int l = 1; l < len; ++l) array[l] = array[l - 1];]
++        ]           )],
++    [DynArrays_noPOD=yes], [DynArrays_noPOD=no])
++AC_MSG_RESULT([$DynArrays_noPOD])
++if test "x$DynArrays_noPOD" = "xyes"; then
++   AC_DEFINE_UNQUOTED([HAVE_DYNAMIC_ARRAYS_NOPOD], [1],
++      [Define to 1 if the compiler supports dynamic arrays with classes])
++fi
++
+ # check if the user compiles for ANDROID
+ #
+ AC_MSG_CHECKING([if we are compiling for Android])
+@@ -456,8 +474,19 @@ AM_CONDITIONAL([DEVELOP],  [test x$DEVELOP_WANTED    = xyes])
+ AM_CONDITIONAL([SQLITE3],  [test x$found_sqlite      = xyes])
+ AM_CONDITIONAL([POSTGRES], [test x$USABLE_PostgreSQL = xyes])
+ 
++echo
+ AC_OUTPUT
+ 
++# create src/buildtag.hh
++echo
++echo "configure: creating src/buildtag.hh"
++. src/buildtag > src/buildtag.hh
++
++# remember how ./configure was called
++echo "configure: creating src/configure_args.cc"
++echo "extern const char * configure_args;" > src/configure_args.cc
++echo "const char * configure_args = \"$0 $ac_configure_args\";" >> src/configure_args.cc
++
+ # summary
+   echo " "
+ if test "x$USABLE_PostgreSQL" != "xyes"; then
+@@ -472,7 +501,3 @@ fi
+   echo " "
+ fi
+ 
+-# remember how ./configure was called
+-echo "extern const char * configure_args;" > src/configure_args.cc
+-echo "const char * configure_args = \"$0 $ac_configure_args\";" >> src/configure_args.cc
+-
+diff --git a/debian/Makefile.in b/debian/Makefile.in
+index 86032c7..e906b9a 100644
+--- a/debian/Makefile.in
++++ b/debian/Makefile.in
+@@ -81,9 +81,6 @@ subdir = debian
+ DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/m4/depend.m4 \
+-	$(top_srcdir)/m4/libtool.m4 $(top_srcdir)/m4/ltoptions.m4 \
+-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
+-	$(top_srcdir)/m4/lt~obsolete.m4 \
+ 	$(top_srcdir)/m4/ax_lib_sqlite3.m4 \
+ 	$(top_srcdir)/m4/ax_lib_postgresql.m4 \
+ 	$(top_srcdir)/configure.ac
+diff --git a/debian/source/Makefile.in b/debian/source/Makefile.in
+index f13a83a..ec52e99 100644
+--- a/debian/source/Makefile.in
++++ b/debian/source/Makefile.in
+@@ -81,9 +81,6 @@ subdir = debian/source
+ DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/m4/depend.m4 \
+-	$(top_srcdir)/m4/libtool.m4 $(top_srcdir)/m4/ltoptions.m4 \
+-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
+-	$(top_srcdir)/m4/lt~obsolete.m4 \
+ 	$(top_srcdir)/m4/ax_lib_sqlite3.m4 \
+ 	$(top_srcdir)/m4/ax_lib_postgresql.m4 \
+ 	$(top_srcdir)/configure.ac
+diff --git a/doc/Makefile.in b/doc/Makefile.in
+index 7c6d9ef..2bd89d3 100644
+--- a/doc/Makefile.in
++++ b/doc/Makefile.in
+@@ -83,9 +83,6 @@ DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
+ 	$(top_srcdir)/texinfo.tex $(dist_doc_DATA) texinfo.tex
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/m4/depend.m4 \
+-	$(top_srcdir)/m4/libtool.m4 $(top_srcdir)/m4/ltoptions.m4 \
+-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
+-	$(top_srcdir)/m4/lt~obsolete.m4 \
+ 	$(top_srcdir)/m4/ax_lib_sqlite3.m4 \
+ 	$(top_srcdir)/m4/ax_lib_postgresql.m4 \
+ 	$(top_srcdir)/configure.ac
+diff --git a/gnu-apl.d/Makefile.in b/gnu-apl.d/Makefile.in
+index d72a395..a29aa6d 100644
+--- a/gnu-apl.d/Makefile.in
++++ b/gnu-apl.d/Makefile.in
+@@ -83,9 +83,6 @@ DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
+ 	$(dist_noinst_DATA)
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/m4/depend.m4 \
+-	$(top_srcdir)/m4/libtool.m4 $(top_srcdir)/m4/ltoptions.m4 \
+-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
+-	$(top_srcdir)/m4/lt~obsolete.m4 \
+ 	$(top_srcdir)/m4/ax_lib_sqlite3.m4 \
+ 	$(top_srcdir)/m4/ax_lib_postgresql.m4 \
+ 	$(top_srcdir)/configure.ac
+diff --git a/rpm/Makefile.in b/rpm/Makefile.in
+index 1c79cef..5a4aea6 100644
+--- a/rpm/Makefile.in
++++ b/rpm/Makefile.in
+@@ -82,9 +82,6 @@ DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
+ 	$(srcdir)/apl.spec.in
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/m4/depend.m4 \
+-	$(top_srcdir)/m4/libtool.m4 $(top_srcdir)/m4/ltoptions.m4 \
+-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
+-	$(top_srcdir)/m4/lt~obsolete.m4 \
+ 	$(top_srcdir)/m4/ax_lib_sqlite3.m4 \
+ 	$(top_srcdir)/m4/ax_lib_postgresql.m4 \
+ 	$(top_srcdir)/configure.ac
+diff --git a/src/APL_types.hh b/src/APL_types.hh
+index 5f08552..d743dde 100644
+--- a/src/APL_types.hh
++++ b/src/APL_types.hh
+@@ -484,10 +484,18 @@ struct Function_PC2
+            ~__DynArray()
+               { delete[] data; }
+ 
++           const Type * get_data()   { return data; }
++
+         protected:
+            Type * data;
+       };
+ 
++   size_t strlen(const __DynArray<char> & da)
++      { return strlen(da.get_data()); }
++
++   size_t strrchr(const __DynArray<char> & da, int ch)
++      { return strrchr(da.get_data(), ch); }
++
+ # define DynArray(Type, Name, Size) __DynArray<Type> Name(Size);
+ 
+ #endif // HAVE_DYNAMIC_ARRAYS
+diff --git a/src/APs/Makefile.in b/src/APs/Makefile.in
+index ceda5e5..a63afe2 100644
+--- a/src/APs/Makefile.in
++++ b/src/APs/Makefile.in
+@@ -87,9 +87,6 @@ DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
+ 	$(top_srcdir)/depcomp
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/m4/depend.m4 \
+-	$(top_srcdir)/m4/libtool.m4 $(top_srcdir)/m4/ltoptions.m4 \
+-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
+-	$(top_srcdir)/m4/lt~obsolete.m4 \
+ 	$(top_srcdir)/m4/ax_lib_sqlite3.m4 \
+ 	$(top_srcdir)/m4/ax_lib_postgresql.m4 \
+ 	$(top_srcdir)/configure.ac
+diff --git a/src/Makefile.in b/src/Makefile.in
+index cfc9f9d..5db3a41 100644
+--- a/src/Makefile.in
++++ b/src/Makefile.in
+@@ -87,13 +87,9 @@ host_triplet = @host@
+ @DEVELOP_TRUE@am__append_4 = -Werror -Wall -Wno-strict-aliasing
+ subdir = src
+ DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
+-	$(top_srcdir)/depcomp $(am__pkginclude_HEADERS_DIST) \
+-	texinfo.tex
++	$(top_srcdir)/depcomp $(am__pkginclude_HEADERS_DIST)
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/m4/depend.m4 \
+-	$(top_srcdir)/m4/libtool.m4 $(top_srcdir)/m4/ltoptions.m4 \
+-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
+-	$(top_srcdir)/m4/lt~obsolete.m4 \
+ 	$(top_srcdir)/m4/ax_lib_sqlite3.m4 \
+ 	$(top_srcdir)/m4/ax_lib_postgresql.m4 \
+ 	$(top_srcdir)/configure.ac
+diff --git a/src/PrintBuffer.cc b/src/PrintBuffer.cc
+index a820550..a2dcc63 100644
+--- a/src/PrintBuffer.cc
++++ b/src/PrintBuffer.cc
+@@ -121,7 +121,9 @@ const ShapeItem ec = value.element_count();
+ 
+    // non-trivial PrintBuffer
+    //
+-   const ShapeItem cols = value.get_last_shape_item();
++const ShapeItem cols = value.get_last_shape_item();
++
++#if HAVE_DYNAMIC_ARRAYS_NOPOD
+    if (cols <= PB_MAX_COLS)   // few columns
+       {
+         DynArray(bool, scaling, cols);
+@@ -160,6 +162,18 @@ const ShapeItem ec = value.element_count();
+         delete [] pcols;
+         delete [] scaling;
+       }
++#else // e.g. clang
++      {
++        bool * scaling = new bool[cols];
++        PrintBuffer * pcols = new PrintBuffer[cols];
++        PrintBuffer * item_matrix = new PrintBuffer[ec];
++        do_PrintBuffer(value, pctx, out, outer_style,
++                       scaling, pcols, item_matrix);
++        delete [] item_matrix;
++        delete [] pcols;
++        delete [] scaling;
++      }
++#endif
+ 
+    PERFORMANCE_END(fs_PrintBuffer_B, start_0, ec)
+ }
+diff --git a/src/Workspace.cc b/src/Workspace.cc
+index 997167d..4bd731b 100644
+--- a/src/Workspace.cc
++++ b/src/Workspace.cc
+@@ -943,7 +943,12 @@ XML_Loading_Archive in(filename.c_str(), dump_fd);
+         const char * wsid_start = strrchr(filename.c_str(), '/');
+         if (wsid_start == 0)   wsid_start = filename.c_str();
+         else                   ++wsid_start;   // skip /
+-        const char * wsid_end = filename.c_str() + filename.size() - 4;
++        const char * wsid_end = filename.c_str() + filename.size();
++        if (wsid_end > (wsid_start - 4) &&
++           wsid_end[-4] == '.' &&
++           wsid_end[-3] == 'a' &&
++           wsid_end[-2] == 'p' &&
++           wsid_end[-1] == 'l')   wsid_end -= 4;   // skip .apl extension
+         const UTF8_string wsid_utf8((const UTF8 *)wsid_start,
+                                     wsid_end - wsid_start);
+         const UCS_string wsid_ucs(wsid_utf8);
+diff --git a/src/buildtag b/src/buildtag
+index ea6f328..e156bdf 100644
+--- a/src/buildtag
++++ b/src/buildtag
+@@ -7,19 +7,23 @@ PACKAGE_VERSION=$2
+ 
+ SVNINFO=`svnversion`
+ 
+-ARCHIVE_SVNINFO=`svn info Archive.cc | grep "Last Changed Rev" \
+-                                     | awk -F : '{print $2;}'`
+-if [ $? != "0" ]
++ARCHIVE_SVNINFO=`svn info src/Archive.cc | grep "Last Changed Rev" \
++                                         | awk -F : '{print $2;}'`
++if [ x$ARCHIVE_SVNINFO = "x" ]
+ then
+-    ARCHIVE_SVNINFO=0
++    ARCHIVE_SVNINFO="0"
+ fi
+ 
+-CONFIGURE_OPTS=`../config.status -V | grep "with options" | sed 's/[^"]*//'`
++CONFIGURE_OPTS="unknown"
++if [ -x ./config.status ]
++then
++    CONFIGURE_OPTS=`./config.status -V | grep "with options" | sed 's/[^"]*//'`
++fi
+ BUILD_DATE=`date -u "+%F %R:%S %Z"`
+ BUILD_OS=`uname -s -r -m`
+ BUILD_TAG="\" / $SVNINFO\", \"$BUILD_DATE\", \"$BUILD_OS\", $CONFIGURE_OPTS"
+ 
+-echo "#include \"Common.hh\""                                    > buildtag.hh
+-echo "#define BUILDTAG PACKAGE_NAME, PACKAGE_VERSION $BUILD_TAG" >> buildtag.hh
+-echo "#define ARCHIVE_SVN $ARCHIVE_SVNINFO" >> buildtag.hh
++echo "#include \"Common.hh\""
++echo "#define BUILDTAG PACKAGE_NAME, PACKAGE_VERSION $BUILD_TAG"
++echo "#define ARCHIVE_SVN $ARCHIVE_SVNINFO"
+ 
+diff --git a/src/buildtag.hh b/src/buildtag.hh
+new file mode 100644
+index 0000000..159c444
+--- /dev/null
++++ b/src/buildtag.hh
+@@ -0,0 +1,3 @@
++#include "Common.hh"
++#define BUILDTAG PACKAGE_NAME, PACKAGE_VERSION " / 9585M", "2015-04-01 12:11:00 UTC", "Linux 3.13.0-37-generic i686", "'--host=i686-pc-linux-gnu' '--build=i686-pc-linux-gnu' '--program-prefix=' '--disable-dependency-tracking' '--prefix=/usr' '--exec-prefix=/usr' '--bindir=/usr/bin' '--sbindir=/usr/sbin' '--sysconfdir=/etc' '--datadir=/usr/share' '--includedir=/usr/include' '--libdir=/usr/lib' '--libexecdir=/usr/lib/i386-linux-gnu' '--localstatedir=/var' '--sharedstatedir=/usr/com' '--mandir=/usr/share/man' '--infodir=/usr/share/info' 'build_alias=i686-pc-linux-gnu' 'host_alias=i686-pc-linux-gnu' 'CFLAGS=-O2 -g -march=i486' 'CXXFLAGS=-O2 -g -march=i486'"
++#define ARCHIVE_SVN  9553
+diff --git a/src/emacs_mode/Makefile.in b/src/emacs_mode/Makefile.in
+index c1cfe7e..e1ef963 100644
+--- a/src/emacs_mode/Makefile.in
++++ b/src/emacs_mode/Makefile.in
+@@ -81,12 +81,9 @@ build_triplet = @build@
+ host_triplet = @host@
+ subdir = src/emacs_mode
+ DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
+-	$(top_srcdir)/depcomp $(dist_noinst_DATA) AUTHORS
++	$(top_srcdir)/depcomp $(dist_noinst_DATA) AUTHORS COPYING
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/m4/depend.m4 \
+-	$(top_srcdir)/m4/libtool.m4 $(top_srcdir)/m4/ltoptions.m4 \
+-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
+-	$(top_srcdir)/m4/lt~obsolete.m4 \
+ 	$(top_srcdir)/m4/ax_lib_sqlite3.m4 \
+ 	$(top_srcdir)/m4/ax_lib_postgresql.m4 \
+ 	$(top_srcdir)/configure.ac
+diff --git a/src/emacs_mode/TempFileWrapper.cc b/src/emacs_mode/TempFileWrapper.cc
+index 93b867a..b86005c 100644
+--- a/src/emacs_mode/TempFileWrapper.cc
++++ b/src/emacs_mode/TempFileWrapper.cc
+@@ -21,7 +21,7 @@
+ #include "TempFileWrapper.hh"
+ 
+ #include <stdlib.h>
+-#include <fcntl.h>
++#include <unistd.h>
+ #include <string.h>
+ 
+ #include "emacs.hh"
+@@ -41,14 +41,18 @@ FileWrapper::~FileWrapper()
+ 
+ TempFileWrapper::TempFileWrapper( const std::string &prefix )
+ {
+-char filename[APL_PATH_MAX + 1];
+-   snprintf(filename, APL_PATH_MAX, "%sXXXXXX", prefix.c_str());
+-   mktemp(filename);
+-   if (!*filename)   abort();   // mktemp() failed
+-   fd = open(filename, O_RDWR);
+-   if( fd == -1 ) abort();      // open() failed
++    stringstream name_buf;
++    name_buf << prefix << "XXXXXX";
++    const char *name_cstr = name_buf.str().c_str();
++    DynArray( char, tmp_name, strlen( name_cstr ) + 1 );
++    strcpy( tmp_name, name_cstr );
+ 
+-    name = std::string(filename);
++    fd = mkstemp( tmp_name );
++    if( fd == -1 ) {
++        abort();
++    }
++
++    name = tmp_name;
+     closed = false;
+ }
+ 
+diff --git a/src/native/Makefile.in b/src/native/Makefile.in
+index 4936043..299a632 100644
+--- a/src/native/Makefile.in
++++ b/src/native/Makefile.in
+@@ -84,9 +84,6 @@ DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
+ 	$(top_srcdir)/depcomp
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/m4/depend.m4 \
+-	$(top_srcdir)/m4/libtool.m4 $(top_srcdir)/m4/ltoptions.m4 \
+-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
+-	$(top_srcdir)/m4/lt~obsolete.m4 \
+ 	$(top_srcdir)/m4/ax_lib_sqlite3.m4 \
+ 	$(top_srcdir)/m4/ax_lib_postgresql.m4 \
+ 	$(top_srcdir)/configure.ac
+diff --git a/src/sql/Makefile.in b/src/sql/Makefile.in
+index 5c91116..4f29170 100644
+--- a/src/sql/Makefile.in
++++ b/src/sql/Makefile.in
+@@ -98,9 +98,6 @@ DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
+ 	AUTHORS
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/m4/depend.m4 \
+-	$(top_srcdir)/m4/libtool.m4 $(top_srcdir)/m4/ltoptions.m4 \
+-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
+-	$(top_srcdir)/m4/lt~obsolete.m4 \
+ 	$(top_srcdir)/m4/ax_lib_sqlite3.m4 \
+ 	$(top_srcdir)/m4/ax_lib_postgresql.m4 \
+ 	$(top_srcdir)/configure.ac
+diff --git a/src/testcases/Makefile.in b/src/testcases/Makefile.in
+index 1055971..260c751 100644
+--- a/src/testcases/Makefile.in
++++ b/src/testcases/Makefile.in
+@@ -85,9 +85,6 @@ DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
+ 	$(dist_noinst_DATA)
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/m4/depend.m4 \
+-	$(top_srcdir)/m4/libtool.m4 $(top_srcdir)/m4/ltoptions.m4 \
+-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
+-	$(top_srcdir)/m4/lt~obsolete.m4 \
+ 	$(top_srcdir)/m4/ax_lib_sqlite3.m4 \
+ 	$(top_srcdir)/m4/ax_lib_postgresql.m4 \
+ 	$(top_srcdir)/configure.ac
+diff --git a/src/workspaces/Makefile.in b/src/workspaces/Makefile.in
+index f88e864..148a1f9 100644
+--- a/src/workspaces/Makefile.in
++++ b/src/workspaces/Makefile.in
+@@ -85,9 +85,6 @@ DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
+ 	$(dist_noinst_DATA)
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/m4/depend.m4 \
+-	$(top_srcdir)/m4/libtool.m4 $(top_srcdir)/m4/ltoptions.m4 \
+-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
+-	$(top_srcdir)/m4/lt~obsolete.m4 \
+ 	$(top_srcdir)/m4/ax_lib_sqlite3.m4 \
+ 	$(top_srcdir)/m4/ax_lib_postgresql.m4 \
+ 	$(top_srcdir)/configure.ac
+diff --git a/support-files/Dirk/Makefile.in b/support-files/Dirk/Makefile.in
+index fd0bbe0..65d2276 100644
+--- a/support-files/Dirk/Makefile.in
++++ b/support-files/Dirk/Makefile.in
+@@ -83,9 +83,6 @@ DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
+ 	$(dist_noinst_DATA)
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/m4/depend.m4 \
+-	$(top_srcdir)/m4/libtool.m4 $(top_srcdir)/m4/ltoptions.m4 \
+-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
+-	$(top_srcdir)/m4/lt~obsolete.m4 \
+ 	$(top_srcdir)/m4/ax_lib_sqlite3.m4 \
+ 	$(top_srcdir)/m4/ax_lib_postgresql.m4 \
+ 	$(top_srcdir)/configure.ac
+diff --git a/support-files/Dyalog-Keyboard/Makefile.in b/support-files/Dyalog-Keyboard/Makefile.in
+index 293e9c3..9f3c125 100644
+--- a/support-files/Dyalog-Keyboard/Makefile.in
++++ b/support-files/Dyalog-Keyboard/Makefile.in
+@@ -83,9 +83,6 @@ DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
+ 	$(dist_noinst_DATA)
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/m4/depend.m4 \
+-	$(top_srcdir)/m4/libtool.m4 $(top_srcdir)/m4/ltoptions.m4 \
+-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
+-	$(top_srcdir)/m4/lt~obsolete.m4 \
+ 	$(top_srcdir)/m4/ax_lib_sqlite3.m4 \
+ 	$(top_srcdir)/m4/ax_lib_postgresql.m4 \
+ 	$(top_srcdir)/configure.ac
+diff --git a/support-files/Makefile.in b/support-files/Makefile.in
+index 5c6bd08..a322f1c 100644
+--- a/support-files/Makefile.in
++++ b/support-files/Makefile.in
+@@ -83,9 +83,6 @@ DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
+ 	$(dist_noinst_DATA)
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/m4/depend.m4 \
+-	$(top_srcdir)/m4/libtool.m4 $(top_srcdir)/m4/ltoptions.m4 \
+-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
+-	$(top_srcdir)/m4/lt~obsolete.m4 \
+ 	$(top_srcdir)/m4/ax_lib_sqlite3.m4 \
+ 	$(top_srcdir)/m4/ax_lib_postgresql.m4 \
+ 	$(top_srcdir)/configure.ac
+diff --git a/support-files/OS-X-Keyboard/Makefile.in b/support-files/OS-X-Keyboard/Makefile.in
+index bb75e22..cd71ae0 100644
+--- a/support-files/OS-X-Keyboard/Makefile.in
++++ b/support-files/OS-X-Keyboard/Makefile.in
+@@ -83,9 +83,6 @@ DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
+ 	$(dist_noinst_DATA)
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/m4/depend.m4 \
+-	$(top_srcdir)/m4/libtool.m4 $(top_srcdir)/m4/ltoptions.m4 \
+-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
+-	$(top_srcdir)/m4/lt~obsolete.m4 \
+ 	$(top_srcdir)/m4/ax_lib_sqlite3.m4 \
+ 	$(top_srcdir)/m4/ax_lib_postgresql.m4 \
+ 	$(top_srcdir)/configure.ac
+diff --git a/support-files/Unicomp-Keyboard/Makefile.in b/support-files/Unicomp-Keyboard/Makefile.in
+index 0345c92..8b35113 100644
+--- a/support-files/Unicomp-Keyboard/Makefile.in
++++ b/support-files/Unicomp-Keyboard/Makefile.in
+@@ -83,9 +83,6 @@ DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
+ 	$(dist_noinst_DATA)
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/m4/depend.m4 \
+-	$(top_srcdir)/m4/libtool.m4 $(top_srcdir)/m4/ltoptions.m4 \
+-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
+-	$(top_srcdir)/m4/lt~obsolete.m4 \
+ 	$(top_srcdir)/m4/ax_lib_sqlite3.m4 \
+ 	$(top_srcdir)/m4/ax_lib_postgresql.m4 \
+ 	$(top_srcdir)/configure.ac
+diff --git a/support-files/WASD-Keyboard/Makefile.in b/support-files/WASD-Keyboard/Makefile.in
+index bbe34e2..725bf6e 100644
+--- a/support-files/WASD-Keyboard/Makefile.in
++++ b/support-files/WASD-Keyboard/Makefile.in
+@@ -83,9 +83,6 @@ DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
+ 	$(dist_noinst_DATA)
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/m4/depend.m4 \
+-	$(top_srcdir)/m4/libtool.m4 $(top_srcdir)/m4/ltoptions.m4 \
+-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
+-	$(top_srcdir)/m4/lt~obsolete.m4 \
+ 	$(top_srcdir)/m4/ax_lib_sqlite3.m4 \
+ 	$(top_srcdir)/m4/ax_lib_postgresql.m4 \
+ 	$(top_srcdir)/configure.ac
+diff --git a/support-files/old-Keyboard/Makefile.in b/support-files/old-Keyboard/Makefile.in
+index 4e6c081..7127038 100644
+--- a/support-files/old-Keyboard/Makefile.in
++++ b/support-files/old-Keyboard/Makefile.in
+@@ -83,9 +83,6 @@ DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
+ 	$(dist_noinst_DATA)
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/m4/depend.m4 \
+-	$(top_srcdir)/m4/libtool.m4 $(top_srcdir)/m4/ltoptions.m4 \
+-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
+-	$(top_srcdir)/m4/lt~obsolete.m4 \
+ 	$(top_srcdir)/m4/ax_lib_sqlite3.m4 \
+ 	$(top_srcdir)/m4/ax_lib_postgresql.m4 \
+ 	$(top_srcdir)/configure.ac
+diff --git a/tools/Makefile.in b/tools/Makefile.in
+index 2a2b32b..6aefd53 100644
+--- a/tools/Makefile.in
++++ b/tools/Makefile.in
+@@ -87,9 +87,6 @@ DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
+ 	$(dist_noinst_SCRIPTS) $(top_srcdir)/depcomp
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/m4/depend.m4 \
+-	$(top_srcdir)/m4/libtool.m4 $(top_srcdir)/m4/ltoptions.m4 \
+-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
+-	$(top_srcdir)/m4/lt~obsolete.m4 \
+ 	$(top_srcdir)/m4/ax_lib_sqlite3.m4 \
+ 	$(top_srcdir)/m4/ax_lib_postgresql.m4 \
+ 	$(top_srcdir)/configure.ac
+diff --git a/workspaces/Makefile.in b/workspaces/Makefile.in
+index ee5bbf4..6726b42 100644
+--- a/workspaces/Makefile.in
++++ b/workspaces/Makefile.in
+@@ -83,9 +83,6 @@ DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
+ 	$(dist_doc_DATA)
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/m4/depend.m4 \
+-	$(top_srcdir)/m4/libtool.m4 $(top_srcdir)/m4/ltoptions.m4 \
+-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
+-	$(top_srcdir)/m4/lt~obsolete.m4 \
+ 	$(top_srcdir)/m4/ax_lib_sqlite3.m4 \
+ 	$(top_srcdir)/m4/ax_lib_postgresql.m4 \
+ 	$(top_srcdir)/configure.ac
+diff --git a/wslib3/Makefile.in b/wslib3/Makefile.in
+index 50ed46b..3e4ca5f 100644
+--- a/wslib3/Makefile.in
++++ b/wslib3/Makefile.in
+@@ -83,9 +83,6 @@ DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
+ 	$(dist_apl3_DATA)
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/m4/depend.m4 \
+-	$(top_srcdir)/m4/libtool.m4 $(top_srcdir)/m4/ltoptions.m4 \
+-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
+-	$(top_srcdir)/m4/lt~obsolete.m4 \
+ 	$(top_srcdir)/m4/ax_lib_sqlite3.m4 \
+ 	$(top_srcdir)/m4/ax_lib_postgresql.m4 \
+ 	$(top_srcdir)/configure.ac
+diff --git a/wslib4/Makefile.in b/wslib4/Makefile.in
+index 31aea70..ebf5fbd 100644
+--- a/wslib4/Makefile.in
++++ b/wslib4/Makefile.in
+@@ -83,9 +83,6 @@ DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
+ 	$(dist_apl4_DATA)
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/m4/depend.m4 \
+-	$(top_srcdir)/m4/libtool.m4 $(top_srcdir)/m4/ltoptions.m4 \
+-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
+-	$(top_srcdir)/m4/lt~obsolete.m4 \
+ 	$(top_srcdir)/m4/ax_lib_sqlite3.m4 \
+ 	$(top_srcdir)/m4/ax_lib_postgresql.m4 \
+ 	$(top_srcdir)/configure.ac
+diff --git a/wslib5/APLComponentFiles/Makefile.in b/wslib5/APLComponentFiles/Makefile.in
+index 879bbb5..04fd9d3 100644
+--- a/wslib5/APLComponentFiles/Makefile.in
++++ b/wslib5/APLComponentFiles/Makefile.in
+@@ -83,9 +83,6 @@ DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
+ 	$(dist_apl5ACF_DATA) AUTHORS
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/m4/depend.m4 \
+-	$(top_srcdir)/m4/libtool.m4 $(top_srcdir)/m4/ltoptions.m4 \
+-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
+-	$(top_srcdir)/m4/lt~obsolete.m4 \
+ 	$(top_srcdir)/m4/ax_lib_sqlite3.m4 \
+ 	$(top_srcdir)/m4/ax_lib_postgresql.m4 \
+ 	$(top_srcdir)/configure.ac
+diff --git a/wslib5/Makefile.in b/wslib5/Makefile.in
+index cb6e83a..f7f2ba3 100644
+--- a/wslib5/Makefile.in
++++ b/wslib5/Makefile.in
+@@ -83,9 +83,6 @@ DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
+ 	$(dist_apl5_DATA)
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/m4/depend.m4 \
+-	$(top_srcdir)/m4/libtool.m4 $(top_srcdir)/m4/ltoptions.m4 \
+-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
+-	$(top_srcdir)/m4/lt~obsolete.m4 \
+ 	$(top_srcdir)/m4/ax_lib_sqlite3.m4 \
+ 	$(top_srcdir)/m4/ax_lib_postgresql.m4 \
+ 	$(top_srcdir)/configure.ac
+diff --git a/wslib5/iso-apl-cf/Makefile.in b/wslib5/iso-apl-cf/Makefile.in
+index bb9850c..1891512 100644
+--- a/wslib5/iso-apl-cf/Makefile.in
++++ b/wslib5/iso-apl-cf/Makefile.in
+@@ -83,9 +83,6 @@ DIST_COMMON = $(srcdir)/Makefile.in $(srcdir)/Makefile.am \
+ 	$(dist_apl5iac_DATA) AUTHORS
+ ACLOCAL_M4 = $(top_srcdir)/aclocal.m4
+ am__aclocal_m4_deps = $(top_srcdir)/m4/depend.m4 \
+-	$(top_srcdir)/m4/libtool.m4 $(top_srcdir)/m4/ltoptions.m4 \
+-	$(top_srcdir)/m4/ltsugar.m4 $(top_srcdir)/m4/ltversion.m4 \
+-	$(top_srcdir)/m4/lt~obsolete.m4 \
+ 	$(top_srcdir)/m4/ax_lib_sqlite3.m4 \
+ 	$(top_srcdir)/m4/ax_lib_postgresql.m4 \
+ 	$(top_srcdir)/configure.ac


### PR DESCRIPTION
Goes together with https://github.com/Homebrew/homebrew-core/pull/2114.

Includes the following svn revisions:

r580 j_sauermann 2015-03-30 06:27:11 -0700 (Mon, 30 Mar 2015)
fixed dyadic ⊃ problem

r581 j_sauermann 2015-03-30 08:07:27 -0700 (Mon, 30 Mar 2015)
removed auto-generated files

r582 j_sauermann 2015-03-31 07:08:27 -0700 (Tue, 31 Mar 2015)
fixed clang compile issues

r583 j_sauermann 2015-03-31 08:17:20 -0700 (Tue, 31 Mar 2015)
fixed more clang issues

r584 j_sauermann 2015-03-31 09:49:51 -0700 (Tue, 31 Mar 2015)
replaced mkstemps() by tmpname()

r585 j_sauermann 2015-03-31 09:53:20 -0700 (Tue, 31 Mar 2015)
removed auto-generated file

r586 j_sauermann 2015-04-01 05:11:41 -0700 (Wed, 01 Apr 2015)
fixed some clang and build issues