### PR TITLE
idris: patch for GHC 8

### DIFF
--- a/idris/idris-ghc8.diff
+++ b/idris/idris-ghc8.diff
@@ -1,0 +1,80 @@
+diff --git a/idris.cabal b/idris.cabal
+index 3464817..945be8b 100644
+--- a/idris.cabal
++++ b/idris.cabal
+@@ -1027,7 +1027,7 @@ Library
+                 , ansi-terminal < 0.7
+                 , ansi-wl-pprint < 0.7
+                 , base64-bytestring < 1.1
+-                , binary >= 0.7 && < 0.8
++                , binary >= 0.7 && < 0.9
+                 , blaze-html >= 0.6.1.3 && < 0.9
+                 , blaze-markup >= 0.5.2.1 && < 0.8
+                 , bytestring < 0.11
+@@ -1044,12 +1044,12 @@ Library
+                 , optparse-applicative >= 0.11 && < 0.13
+                 , parsers >= 0.9 && < 0.13
+                 , pretty < 1.2
+-                , process < 1.3
++                , process < 1.5
+                 , split < 0.3
+                 , terminal-size < 0.4
+                 , text >=1.2.1.0 && < 1.3
+-                , time >= 1.4 && < 1.6
+-                , transformers < 0.5
++                , time >= 1.4 && < 1.7
++                , transformers < 0.6
+                 , transformers-compat >= 0.3
+                 , trifecta >= 1.1 && < 1.6
+                 , uniplate >=1.6 && < 1.7
+diff --git a/src/Idris/Parser/Helpers.hs b/src/Idris/Parser/Helpers.hs
+index 80e66cd..13a7d17 100644
+--- a/src/Idris/Parser/Helpers.hs
++++ b/src/Idris/Parser/Helpers.hs
+@@ -58,6 +58,21 @@ newtype IdrisInnerParser a = IdrisInnerParser { runInnerParser :: Parser a }
+ 
+ deriving instance Parsing IdrisInnerParser
+ 
++#if MIN_VERSION_base(4,9,0)
++instance {-# OVERLAPPING #-} DeltaParsing IdrisParser where
++  line = lift line
++  {-# INLINE line #-}
++  position = lift position
++  {-# INLINE position #-}
++  slicedWith f (StateT m) = StateT $ \s -> slicedWith (\(a,s') b -> (f a b, s')) $ m s
++  {-# INLINE slicedWith #-}
++  rend = lift rend
++  {-# INLINE rend #-}
++  restOfLine = lift restOfLine
++  {-# INLINE restOfLine #-}
++
++#endif
++
+ #if MIN_VERSION_base(4,8,0)
+ instance {-# OVERLAPPING #-} TokenParsing IdrisParser where
+ #else
+diff --git a/src/Pkg/PParser.hs b/src/Pkg/PParser.hs
+index 26e60dc..f68db14 100644
+--- a/src/Pkg/PParser.hs
++++ b/src/Pkg/PParser.hs
+@@ -59,6 +59,20 @@ defaultPkg = PkgDesc "" Nothing Nothing Nothing Nothing
+ instance HasLastTokenSpan PParser where
+   getLastTokenSpan = return Nothing
+ 
++#if MIN_VERSION_base(4,9,0)
++instance {-# OVERLAPPING #-} DeltaParsing PParser where
++  line = lift line
++  {-# INLINE line #-}
++  position = lift position
++  {-# INLINE position #-}
++  slicedWith f (StateT m) = StateT $ \s -> slicedWith (\(a,s') b -> (f a b, s')) $ m s
++  {-# INLINE slicedWith #-}
++  rend = lift rend
++  {-# INLINE rend #-}
++  restOfLine = lift restOfLine
++  {-# INLINE restOfLine #-}
++#endif
++
+ #if MIN_VERSION_base(4,8,0)
+ instance {-# OVERLAPPING #-} TokenParsing PParser where
+ #else


### PR DESCRIPTION
This is adapted from the patch in idris-lang/Idris-dev#3226 with the
only difference being that it works with the released version of the
trifecta dependency (1.5.2) rather than ekmett/trifecta@53f76115.