### PR TITLE
add sane-backends/1.0.25-missing-types.patch

### DIFF
--- a/sane-backends/1.0.25-missing-types.patch
+++ b/sane-backends/1.0.25-missing-types.patch
@@ -1,0 +1,66 @@
+diff --git a/backend/pieusb_buffer.c b/backend/pieusb_buffer.c
+index 53bd867..23fc645 100644
+--- a/backend/pieusb_buffer.c
++++ b/backend/pieusb_buffer.c
+@@ -100,7 +100,13 @@
+ #include <stdio.h>
+ #include <fcntl.h>
+ #include <sys/mman.h>
++
++#ifdef __APPLE__
++#include <machine/endian.h>
++#elif
+ #include <endian.h>
++#endif
++
+ 
+ /* When creating the release backend, make complains about unresolved external
+  * le16toh, although it finds the include <endian.h> */
+diff --git a/include/sane/sane.h b/include/sane/sane.h
+index 5320b4a..736a9cd 100644
+--- a/include/sane/sane.h
++++ b/include/sane/sane.h
+@@ -20,6 +20,11 @@
+ extern "C" {
+ #endif
+ 
++#ifdef __APPLE__
++// Fixes u_long missing error
++#include <sys/types.h>
++#endif
++
+ /*
+  * SANE types and defines
+  */
+diff --git a/include/sane/sanei_backend.h b/include/sane/sanei_backend.h
+index 1b5afe2..982dedc 100644
+--- a/include/sane/sanei_backend.h
++++ b/include/sane/sanei_backend.h
+@@ -96,7 +96,9 @@
+ #  undef SIG_SETMASK
+ # endif
+ 
++# ifndef __APPLE__
+ # define sigset_t               int
++# endif
+ # define sigemptyset(set)       do { *(set) = 0; } while (0)
+ # define sigfillset(set)        do { *(set) = ~0; } while (0)
+ # define sigaddset(set,signal)  do { *(set) |= sigmask (signal); } while (0)
+diff --git a/sanei/sanei_ir.c b/sanei/sanei_ir.c
+index 42e82ba..0db2c29 100644
+--- a/sanei/sanei_ir.c
++++ b/sanei/sanei_ir.c
+@@ -29,7 +29,13 @@
+ 
+ #include <stdlib.h>
+ #include <string.h>
++#ifdef __APPLE__ //OSX
++#include <sys/types.h>
++#include <limits.h>
++#include <float.h>
++#elif // not OSX
+ #include <values.h>
++#endif
+ #include <math.h>
+ 
+ #define BACKEND_NAME sanei_ir  /* name of this module for debugging */


### PR DESCRIPTION
from https://github.com/Homebrew/homebrew-core/pull/2467