### PR TITLE
Patch to compile 2.1.14

### DIFF
--- a/gnupg21/missing_libintl_in_2_1_14
+++ b/gnupg21/missing_libintl_in_2_1_14
@@ -1,0 +1,13 @@
+diff --git a/tests/gpgscm/Makefile.am b/tests/gpgscm/Makefile.am
+index e57a4bb..dad30ed 100644
+--- a/tests/gpgscm/Makefile.am
++++ b/tests/gpgscm/Makefile.am
+@@ -45,7 +45,7 @@ gpgscm_CFLAGS = -imacros scheme-config.h \
+ gpgscm_SOURCES = main.c private.h ffi.c ffi.h ffi-private.h \
+        scheme-config.h opdefines.h scheme.c scheme.h scheme-private.h
+ gpgscm_LDADD = $(LDADD) $(common_libs) \
+-       $(NETLIBS) $(LIBICONV) $(LIBREADLINE) \
++       $(NETLIBS) $(LIBICONV) $(LIBREADLINE) $(LIBINTL) \
+        $(LIBGCRYPT_LIBS) $(GPG_ERROR_LIBS)
+
+ t_child_SOURCES = t-child.c

--- a/gnupg21/missing_libintl_in_2_1_14
+++ b/gnupg21/missing_libintl_in_2_1_14
@@ -4,10 +4,10 @@ index e57a4bb..dad30ed 100644
 +++ b/tests/gpgscm/Makefile.am
 @@ -45,7 +45,7 @@ gpgscm_CFLAGS = -imacros scheme-config.h \
  gpgscm_SOURCES = main.c private.h ffi.c ffi.h ffi-private.h \
-        scheme-config.h opdefines.h scheme.c scheme.h scheme-private.h
+ 	scheme-config.h opdefines.h scheme.c scheme.h scheme-private.h
  gpgscm_LDADD = $(LDADD) $(common_libs) \
--       $(NETLIBS) $(LIBICONV) $(LIBREADLINE) \
-+       $(NETLIBS) $(LIBICONV) $(LIBREADLINE) $(LIBINTL) \
-        $(LIBGCRYPT_LIBS) $(GPG_ERROR_LIBS)
-
+-	$(NETLIBS) $(LIBICONV) $(LIBREADLINE) \
++	$(NETLIBS) $(LIBICONV) $(LIBREADLINE) $(LIBINTL) \
+ 	$(LIBGCRYPT_LIBS) $(GPG_ERROR_LIBS)
+ 
  t_child_SOURCES = t-child.c

--- a/gnupg21/missing_libintl_in_2_1_14
+++ b/gnupg21/missing_libintl_in_2_1_14
@@ -1,3 +1,15 @@
+From c49c43d7e4229fd9f1bc55e17fa32fdc334dbef6 Mon Sep 17 00:00:00 2001
+From: Justus Winter <justus@g10code.com>
+Date: Fri, 15 Jul 2016 12:28:46 +0200
+Subject: [PATCH] gpgscm: Fix linking.
+
+* tests/gpgscm/Makefile.am: Add -lintl.
+
+Signed-off-by: Justus Winter <justus@g10code.com>
+---
+ tests/gpgscm/Makefile.am | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
 diff --git a/tests/gpgscm/Makefile.am b/tests/gpgscm/Makefile.am
 index e57a4bb..dad30ed 100644
 --- a/tests/gpgscm/Makefile.am
@@ -11,3 +23,6 @@ index e57a4bb..dad30ed 100644
  	$(LIBGCRYPT_LIBS) $(GPG_ERROR_LIBS)
  
  t_child_SOURCES = t-child.c
+-- 
+2.6.4 (Apple Git-63)
+


### PR DESCRIPTION
commit c49c43d7e4229fd9f1bc55e17fa32fdc334dbef6
Author: Justus Winter <justus@g10code.com>
Date:   Fri Jul 15 12:28:46 2016

    gpgscm: Fix linking.

    * tests/gpgscm/Makefile.am: Add -lintl.

    Signed-off-by: Justus Winter <justus@g10code.com>