### PR TITLE
cocoapods: patch for avoiding activesupport 5

### DIFF
--- a/cocoapods/patch-activesupport-4.x.diff
+++ b/cocoapods/patch-activesupport-4.x.diff
@@ -1,0 +1,27 @@
+diff --git a/Gemfile.lock b/Gemfile.lock
+index e57c432..c8a4cb6 100644
+--- a/Gemfile.lock
++++ b/Gemfile.lock
+@@ -9,7 +9,7 @@ PATH
+   remote: .
+   specs:
+     cocoapods (1.0.1)
+-      activesupport (>= 4.0.2)
++      activesupport (>= 4.0.2, < 5)
+       claide (>= 1.0.0, < 2.0)
+       cocoapods-core (= 1.0.1)
+       cocoapods-deintegrate (>= 1.0.0, < 2.0)
+diff --git a/cocoapods.gemspec b/cocoapods.gemspec
+index 1486745..f37ee5d 100644
+--- a/cocoapods.gemspec
++++ b/cocoapods.gemspec
+@@ -40,7 +40,8 @@ Gem::Specification.new do |s|
+   s.add_runtime_dependency 'molinillo',             '~> 0.4.5'
+   s.add_runtime_dependency 'xcodeproj',             '>= 1.1.0', '< 2.0'
+ 
+-  s.add_runtime_dependency 'activesupport', '>= 4.0.2'
++  ## Version 5 needs Ruby 2.2, so we specify an upper bound to stay compatible with system ruby
++  s.add_runtime_dependency 'activesupport', '>= 4.0.2', '< 5'
+   s.add_runtime_dependency 'colored',       '~> 1.2'
+   s.add_runtime_dependency 'escape',        '~> 0.0.4'
+   s.add_runtime_dependency 'fourflusher',   '~> 0.3.0'


### PR DESCRIPTION
Avoids use of activesupport version 5 (which requires Ruby >= 2.2.2).

https://github.com/CocoaPods/CocoaPods/pull/5602
https://github.com/CocoaPods/CocoaPods/commit/c6e557b