### PR TITLE
valgrind: patch for Xcode 8

### DIFF
--- a/valgrind/xcode-8.diff
+++ b/valgrind/xcode-8.diff
@@ -1,0 +1,13 @@
+diff --git a/configure.ac b/configure.ac
+index 8ab7f9b..c5cef85 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -154,7 +154,7 @@ AM_CONDITIONAL(COMPILER_IS_ICC, test $is_clang = icc)
+ # Note: m4 arguments are quoted with [ and ] so square brackets in shell
+ # statements have to be quoted.
+ case "${is_clang}-${gcc_version}" in
+-     applellvm-5.1|applellvm-6.*|applellvm-7.*)
++     applellvm-5.1|applellvm-6.*|applellvm-7.*|applellvm-8.*)
+ 	AC_MSG_RESULT([ok (Apple LLVM version ${gcc_version})])
+ 	;;
+      icc-1[[3-9]].*)


### PR DESCRIPTION
From svn r15949. See https://bugs.kde.org/show_bug.cgi?id=366138#c5.