### PR TITLE
wxmac: patches

### DIFF
--- a/wxmac/patch-quicktime-removal.diff
+++ b/wxmac/patch-quicktime-removal.diff
@@ -1,0 +1,30 @@
+diff --git a/src/osx/carbon/dataobj.cpp b/src/osx/carbon/dataobj.cpp
+index 758e3a7..5445aa6 100644
+--- a/src/osx/carbon/dataobj.cpp
++++ b/src/osx/carbon/dataobj.cpp
+@@ -29,10 +29,6 @@
+ 
+ #include "wx/osx/private.h"
+ 
+-#if wxOSX_USE_COCOA_OR_CARBON
+-    #include <QuickTime/QuickTime.h>
+-#endif
+-
+ // ----------------------------------------------------------------------------
+ // wxDataFormat
+ // ----------------------------------------------------------------------------
+diff --git a/src/osx/core/bitmap.cpp b/src/osx/core/bitmap.cpp
+index 3c61c17..3322b60 100644
+--- a/src/osx/core/bitmap.cpp
++++ b/src/osx/core/bitmap.cpp
+@@ -35,10 +35,6 @@ IMPLEMENT_DYNAMIC_CLASS(wxMask, wxObject)
+ #include "wx/osx/private.h"
+ #endif
+ 
+-#ifndef __WXOSX_IPHONE__
+-#include <QuickTime/QuickTime.h>
+-#endif
+-
+ CGColorSpaceRef wxMacGetGenericRGBColorSpace();
+ CGDataProviderRef wxMacCGDataProviderCreateWithMemoryBuffer( const wxMemoryBuffer& buf );
+ 

--- a/wxmac/patch-yosemite.diff
+++ b/wxmac/patch-yosemite.diff
@@ -1,0 +1,59 @@
+diff --git a/include/wx/defs.h b/include/wx/defs.h
+index 397ddd7..d128083 100644
+--- a/include/wx/defs.h
++++ b/include/wx/defs.h
+@@ -3169,12 +3169,20 @@ DECLARE_WXCOCOA_OBJC_CLASS(UIImage);
+ DECLARE_WXCOCOA_OBJC_CLASS(UIEvent);
+ DECLARE_WXCOCOA_OBJC_CLASS(NSSet);
+ DECLARE_WXCOCOA_OBJC_CLASS(EAGLContext);
++DECLARE_WXCOCOA_OBJC_CLASS(UIWebView);
+ 
+ typedef WX_UIWindow WXWindow;
+ typedef WX_UIView WXWidget;
+ typedef WX_EAGLContext WXGLContext;
+ typedef WX_NSString* WXGLPixelFormat;
+ 
++typedef WX_UIWebView OSXWebViewPtr;
++
++#endif
++
++#if wxOSX_USE_COCOA_OR_CARBON
++DECLARE_WXCOCOA_OBJC_CLASS(WebView);
++typedef WX_WebView OSXWebViewPtr;
+ #endif
+ 
+ #endif /* __WXMAC__ */
+diff --git a/include/wx/html/webkit.h b/include/wx/html/webkit.h
+index 8700367..f805099 100644
+--- a/include/wx/html/webkit.h
++++ b/include/wx/html/webkit.h
+@@ -18,7 +18,6 @@
+ #endif
+ 
+ #include "wx/control.h"
+-DECLARE_WXCOCOA_OBJC_CLASS(WebView); 
+ 
+ // ----------------------------------------------------------------------------
+ // Web Kit Control
+@@ -107,7 +106,7 @@ private:
+     wxString m_currentURL;
+     wxString m_pageTitle;
+ 
+-    WX_WebView m_webView;
++    OSXWebViewPtr m_webView;
+ 
+     // we may use this later to setup our own mouse events,
+     // so leave it in for now.
+diff --git a/include/wx/osx/webview_webkit.h b/include/wx/osx/webview_webkit.h
+index 803f8b0..438e532 100644
+--- a/include/wx/osx/webview_webkit.h
++++ b/include/wx/osx/webview_webkit.h
+@@ -158,7 +158,7 @@ private:
+     wxWindowID m_windowID;
+     wxString m_pageTitle;
+ 
+-    wxObjCID m_webView;
++    OSXWebViewPtr m_webView;
+ 
+     // we may use this later to setup our own mouse events,
+     // so leave it in for now.


### PR DESCRIPTION
- `patch-yosemite.diff`: Old patch, pulled out from `__END__` in the formula;

- `patch-quicktime-removal.diff`: Required for building against Xcode 8 (with macOS 10.12 SDK, where `<QuickTime/QuickTime.h>` has been removed).

  Ref http://trac.wxwidgets.org/changeset/f6a2d1caef5c6d412c84aa900cb0d3990b350938/git-wxWidgets