### PR TITLE
qt5: bluetooth fixes

### DIFF
--- a/qt5/qtconnectivity-bluetooth-fix.diff
+++ b/qt5/qtconnectivity-bluetooth-fix.diff
@@ -1,0 +1,68 @@
+From 462323dba4f963844e8c9911da27a0d21e4abf43 Mon Sep 17 00:00:00 2001
+From: Samuel Gaist <samuel.gaist@edeltech.ch>
+Date: Sun, 2 Oct 2016 21:19:39 +0200
+Subject: Fixed build with MaxOSX10.12 SDK
+
+This patch adds missing includes that allows to build the module with
+the 10.12 SDK and Xcode 8.
+
+Change-Id: Ieab48f6a0582b916ceecbbb9a01a4169d6ba53f5
+Reviewed-by: Jake Petroules <jake.petroules@qt.io>
+---
+ qtconnectivity/src/bluetooth/osx/osxbtcentralmanager_p.h | 8 ++++++++
+ qtconnectivity/src/bluetooth/osx/osxbtledeviceinquiry.mm | 5 +++++
+ qtconnectivity/src/bluetooth/osx/osxbtutility.mm         | 3 +++
+ 3 files changed, 16 insertions(+)
+
+diff --git a/qtconnectivity/src/bluetooth/osx/osxbtcentralmanager_p.h b/src/bluetooth/osx/osxbtcentralmanager_p.h
+index 1ff33c1..68b32f3 100644
+--- a/qtconnectivity/src/bluetooth/osx/osxbtcentralmanager_p.h
++++ b/qtconnectivity/src/bluetooth/osx/osxbtcentralmanager_p.h
+@@ -61,6 +61,14 @@
+ 
+ #include "corebluetoothwrapper_p.h"
+ 
++#if QT_MAC_PLATFORM_SDK_EQUAL_OR_ABOVE(__MAC_10_12, __IPHONE_NA)
++#include <CoreBluetooth/CBService.h>
++#include <CoreBluetooth/CBCharacteristic.h>
++#include <CoreBluetooth/CBDescriptor.h>
++#include <CoreBluetooth/CBCentralManager.h>
++#include <CoreBluetooth/CBPeripheral.h>
++#endif
++
+ @class QT_MANGLE_NAMESPACE(OSXBTCentralManager);
+ 
+ QT_BEGIN_NAMESPACE
+diff --git a/qtconnectivity/src/bluetooth/osx/osxbtledeviceinquiry.mm b/src/bluetooth/osx/osxbtledeviceinquiry.mm
+index 5cf9b19..5a2f2db 100644
+--- a/qtconnectivity/src/bluetooth/osx/osxbtledeviceinquiry.mm
++++ b/qtconnectivity/src/bluetooth/osx/osxbtledeviceinquiry.mm
+@@ -42,6 +42,11 @@
+ 
+ #include "corebluetoothwrapper_p.h"
+ 
++#if QT_MAC_PLATFORM_SDK_EQUAL_OR_ABOVE(__MAC_10_12, __IPHONE_NA)
++#import <CoreBluetooth/CBCentralManager.h>
++#import <CoreBluetooth/CBPeripheral.h>
++#endif
++
+ QT_BEGIN_NAMESPACE
+ 
+ namespace OSXBluetooth {
+diff --git a/qtconnectivity/src/bluetooth/osx/osxbtutility.mm b/src/bluetooth/osx/osxbtutility.mm
+index 08ff699..32f6f74 100644
+--- a/qtconnectivity/src/bluetooth/osx/osxbtutility.mm
++++ b/qtconnectivity/src/bluetooth/osx/osxbtutility.mm
+@@ -41,6 +41,9 @@
+ #ifndef QT_IOS_BLUETOOTH
+ 
+ #import <IOBluetooth/objc/IOBluetoothSDPUUID.h>
++#if QT_MAC_PLATFORM_SDK_EQUAL_OR_ABOVE(__MAC_10_12, __IPHONE_NA)
++#import <CoreBluetooth/CBUUID.h>
++#endif
+ 
+ #endif
+ 
+-- 
+cgit v1.0-4-g1e03
+

--- a/qt5/qtwebengine-bluetooth-fix.diff
+++ b/qt5/qtwebengine-bluetooth-fix.diff
@@ -1,0 +1,12 @@
+diff --git a/qtwebengine/src/3rdparty/chromium/base/mac/sdk_forward_declarations.h b/qtwebengine/src/3rdparty/chromium/base/mac/sdk_forward_declarations.h
+index e45ab43..1ba35cb 100644
+--- a/qtwebengine/src/3rdparty/chromium/base/mac/sdk_forward_declarations.h
++++ b/qtwebengine/src/3rdparty/chromium/base/mac/sdk_forward_declarations.h
+@@ -15,6 +15,7 @@
+ #import <CoreWLAN/CoreWLAN.h>
+ #import <ImageCaptureCore/ImageCaptureCore.h>
+ #import <IOBluetooth/IOBluetooth.h>
++#import <CoreBluetooth/CoreBluetooth.h>
+ 
+ #include "base/base_export.h"
+ 


### PR DESCRIPTION
CoreBluetooth headers now need to be imported.

The qtconnectivity patch is an upstream commit, while the qtwebengine
patch was contributed by Steve Yin. Both patches are basically the same
fix, just in two different modules of the Qt 5 code base.