### PR TITLE
qt5: xcrun fix for Xcode 8

### DIFF
--- a/qt5/xcrun-xcode-8.patch
+++ b/qt5/xcrun-xcode-8.patch
@@ -1,0 +1,49 @@
+From 77a71c32c9d19b87f79b208929e71282e8d8b5d9 Mon Sep 17 00:00:00 2001
+From: Gabriel de Dietrich <gabriel.dedietrich@qt.io>
+Date: Thu, 7 Jul 2016 16:00:17 -0700
+Subject: configure and mkspecs: Don't try to find xcrun with xcrun
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Since Xcode 8 (beta 2) that tool is no longer available
+through xcrun. We resort to xcodebuild instead.
+
+Change-Id: If9d7b535c1cbac2caae0112b2003283aeff34fb9
+Reviewed-by: Jake Petroules <jake.petroules@qt.io>
+Reviewed-by: Oswald Buddenhagen <oswald.buddenhagen@theqtcompany.com>
+Reviewed-by: Morten Johan Sørvig <morten.sorvig@qt.io>
+---
+ qtbase/configure                            | 2 +-
+ qtbase/mkspecs/features/mac/default_pre.prf | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/qtbase/configure b/qtbase/configure
+index a1f0a8f..f4c7813 100755
+--- a/qtbase/configure
++++ b/qtbase/configure
+@@ -543,7 +543,7 @@ if [ "$BUILD_ON_MAC" = "yes" ]; then
+         exit 2
+     fi
+ 
+-    if ! /usr/bin/xcrun -find xcrun >/dev/null 2>&1; then
++    if ! /usr/bin/xcrun -find xcodebuild >/dev/null 2>&1; then
+         echo >&2
+         echo "   Xcode not set up properly. You may need to confirm the license" >&2
+         echo "   agreement by running /usr/bin/xcodebuild without arguments." >&2
+diff --git a/qtbase/mkspecs/features/mac/default_pre.prf b/qtbase/mkspecs/features/mac/default_pre.prf
+index 0cc8cd6..5df99d1 100644
+--- a/qtbase/mkspecs/features/mac/default_pre.prf
++++ b/qtbase/mkspecs/features/mac/default_pre.prf
+@@ -12,7 +12,7 @@ isEmpty(QMAKE_XCODE_DEVELOPER_PATH) {
+         error("Xcode is not installed in $${QMAKE_XCODE_DEVELOPER_PATH}. Please use xcode-select to choose Xcode installation path.")
+ 
+     # Make sure Xcode is set up properly
+-    isEmpty($$list($$system("/usr/bin/xcrun -find xcrun 2>/dev/null"))): \
++    isEmpty($$list($$system("/usr/bin/xcrun -find xcodebuild 2>/dev/null"))): \
+         error("Xcode not set up properly. You may need to confirm the license agreement by running /usr/bin/xcodebuild.")
+ }
+ 
+-- 
+cgit v1.0-4-g1e03
+


### PR DESCRIPTION
Upstream commit from 7 Jul 2016 "configure and mkspecs: Don't try to find xcrun with xcrun"
http://code.qt.io/cgit/qt/qtbase.git/patch/configure?id=77a71c32c9d19b87f79b208929e71282e8d8b5d9