### PR TITLE
qt5: CUPS build fix for Sierra

### DIFF
--- a/qt5/cups-sierra.patch
+++ b/qt5/cups-sierra.patch
@@ -1,0 +1,12 @@
+diff --git a/qtwebengine/src/3rdparty/chromium/printing/backend/print_backend_cups.cc b/qtwebengine/src/3rdparty/chromium/printing/backend/print_backend_cups.cc
+index 2b1033e..d76e1de 100644
+--- a/qtwebengine/src/3rdparty/chromium/printing/backend/print_backend_cups.cc
++++ b/qtwebengine/src/3rdparty/chromium/printing/backend/print_backend_cups.cc
+@@ -4,6 +4,7 @@
+ 
+ #include "printing/backend/print_backend.h"
+ 
++#include <cups/ppd.h>
+ #include <dlfcn.h>
+ #include <errno.h>
+ #include <pthread.h>


### PR DESCRIPTION
Equivalent to upstream commit from 4 Oct 2016 "Fix CUPS compilation error in macOS 10.12"
http://code.qt.io/cgit/qt/qtwebengine-chromium.git/commit/chromium/printing/backend/print_backend_cups.cc?h=53-based&id=3bd01037ab73b3ffbf4abbf97c54443a91b2fc4d
https://codereview.chromium.org/2248343002