### PR TITLE
allegro: patch for 10.12

### DIFF
--- a/allegro/patch-allegro-10.12.diff
+++ b/allegro/patch-allegro-10.12.diff
@@ -1,0 +1,42 @@
+diff --git a/include/allegro5/platform/alosx.h b/include/allegro5/platform/alosx.h
+index 0c36c84..c9278ec 100644
+--- a/include/allegro5/platform/alosx.h
++++ b/include/allegro5/platform/alosx.h
+@@ -40,7 +40,6 @@
+    #import <CoreAudio/CoreAudio.h>
+    #import <AudioUnit/AudioUnit.h>
+    #import <AudioToolbox/AudioToolbox.h>
+-   #import <QuickTime/QuickTime.h>
+    #import <IOKit/IOKitLib.h>
+    #import <IOKit/IOCFPlugIn.h>
+    #import <IOKit/hid/IOHIDLib.h>
+diff --git a/src/macosx/osx_app_delegate.m b/src/macosx/osx_app_delegate.m
+index 7336578..d99e11a 100644
+--- a/src/macosx/osx_app_delegate.m
++++ b/src/macosx/osx_app_delegate.m
+@@ -130,8 +130,11 @@ - (BOOL)application: (NSApplication *)theApplication openFile: (NSString *)filen
+         unsigned int len = 1 + [data length];
+         arg1 = al_malloc(len);
+         memset(arg1, 0, len);
++#if MAC_OS_X_VERSION_MIN_REQUIRED >= 1100
++        [data getBytes: arg1 length:len];
++#else
+         [data getBytes: arg1];
+-        
++#endif
+         return YES;
+     }
+     else {
+diff --git a/src/macosx/qzmouse.m b/src/macosx/qzmouse.m
+index fd88171..b70f5b5 100644
+--- a/src/macosx/qzmouse.m
++++ b/src/macosx/qzmouse.m
+@@ -162,7 +162,7 @@ void _al_osx_mouse_generate_event(NSEvent* evt, ALLEGRO_DISPLAY* dpy)
+       // Y-coordinates in OS X start from the bottom.
+       pos.y = NSHeight(frm) - pos.y;
+ #if MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
+-      scaling_factor = [[[evt window] contentView] backingScaleFactor];
++      scaling_factor = [[evt window] backingScaleFactor];
+ #endif
+    }
+    else


### PR DESCRIPTION
https://github.com/liballeg/allegro5/pull/682

(Cannot use the patch directly because `.travis.yml` is not in the release tarball.)