### PR TITLE
swift: fix build with newer pod2mans

### DIFF
--- a/swift/swift-2.2.1-pod2man.patch
+++ b/swift/swift-2.2.1-pod2man.patch
@@ -1,0 +1,25 @@
+Upstream source: https://github.com/apple/swift/commit/4e291f0b09d8bb86c91d608c1f52d741fd971527
+
+From 4e291f0b09d8bb86c91d608c1f52d741fd971527 Mon Sep 17 00:00:00 2001
+From: Lukas Stabe <lukas@stabe.de>
+Date: Sat, 23 Jul 2016 05:30:32 +0000
+Subject: [PATCH] Add release version to manpage
+
+This also fixes compatibility with newer versions of pod2man.
+---
+ cmake/modules/SwiftManpage.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cmake/modules/SwiftManpage.cmake b/cmake/modules/SwiftManpage.cmake
+index 480b100..1b0978c 100644
+--- a/cmake/modules/SwiftManpage.cmake
++++ b/cmake/modules/SwiftManpage.cmake
+@@ -30,7 +30,7 @@ function(manpage)
+       unused_var
+       COMMAND
+         "${POD2MAN}" "--section" "${MP_MAN_SECTION}"
+-        "--center" "${MP_PAGE_HEADER}" "--release"
++        "--center" "${MP_PAGE_HEADER}" "--release=\"swift ${SWIFT_VERSION}\""
+         "--name" "${MP_MAN_FILE_BASENAME}"
+         "--stderr"
+         "${MP_SOURCE}" > "${output_file_name}"


### PR DESCRIPTION
Patch picked from `swift` upstream at https://github.com/apple/swift/commit/4e291f0b09d8bb86c91d608c1f52d741fd971527.

Needed to fix build errors in swift 2.2.1 against some versions of `pod2man`; see https://github.com/Homebrew/homebrew-core/issues/5306.