### PR TITLE
qt5: fix for widget examples' missing install target

### DIFF
--- a/qt5/widget-examples.patch
+++ b/qt5/widget-examples.patch
@@ -1,0 +1,37 @@
+From 58408ffa1b9c0b42a1719d3c8a4d4c62dec4fce6 Mon Sep 17 00:00:00 2001
+From: Andy Nichols <andy.nichols@qt.io>
+Date: Tue, 31 May 2016 14:46:17 +0200
+Subject: Add install target to mac widget examples
+
+Change-Id: I524ba3fcc82a6ef015241d90f212059ae7772443
+Reviewed-by: Jake Petroules <jake.petroules@qt.io>
+Reviewed-by: Timur Pocheptsov <timur.pocheptsov@theqtcompany.com>
+Reviewed-by: Oswald Buddenhagen <oswald.buddenhagen@theqtcompany.com>
+---
+ .../widgets/mac/qmaccocoaviewcontainer/qmaccocoaviewcontainer.pro     | 3 +++
+ qtbase/examples/widgets/mac/qmacnativewidget/qmacnativewidget.pro            | 4 ++++
+ 2 files changed, 7 insertions(+)
+
+diff --git a/qtbase/examples/widgets/mac/qmaccocoaviewcontainer/qmaccocoaviewcontainer.pro b/qtbase/examples/widgets/mac/qmaccocoaviewcontainer/qmaccocoaviewcontainer.pro
+index c8c2195..183e307 100644
+--- a/qtbase/examples/widgets/mac/qmaccocoaviewcontainer/qmaccocoaviewcontainer.pro
++++ b/qtbase/examples/widgets/mac/qmaccocoaviewcontainer/qmaccocoaviewcontainer.pro
+@@ -5,3 +5,6 @@ LIBS += -framework Cocoa
+ 
+ QT += widgets
+ 
++# install
++target.path = $$[QT_INSTALL_EXAMPLES]/widgets/mac/qmaccocoaviewcontainer
++INSTALLS += target
+diff --git a/qtbase/examples/widgets/mac/qmacnativewidget/qmacnativewidget.pro b/qtbase/examples/widgets/mac/qmacnativewidget/qmacnativewidget.pro
+index cafff9f..b39792e 100644
+--- a/qtbase/examples/widgets/mac/qmacnativewidget/qmacnativewidget.pro
++++ b/qtbase/examples/widgets/mac/qmacnativewidget/qmacnativewidget.pro
+@@ -5,3 +5,7 @@ LIBS += -framework Cocoa
+ 
+ QT += widgets
+ #QT += widgets-private gui-private core-private
++
++# install
++target.path = $$[QT_INSTALL_EXAMPLES]/widgets/mac/qmacnativewidget
++INSTALLS += target


### PR DESCRIPTION
Upstream commit "Add install target to mac widget examples"
http://code.qt.io/cgit/qt/qtbase.git/commit/examples/widgets/mac/qmaccocoaviewcontainer/qmaccocoaviewcontainer.pro?h=5.7&id=58408ffa1b9c0b42a1719d3c8a4d4c62dec4fce6