### PR TITLE
xplanet 1.3.1 patch

### DIFF
--- a/xplanet/xplanet-1.3.1-ntimes.patch
+++ b/xplanet/xplanet-1.3.1-ntimes.patch
@@ -1,0 +1,11 @@
+--- a/trunk/src/libdisplay/DisplayOutput.cpp
++++ b/trunk/src/libdisplay/DisplayOutput.cpp
+@@ -51,7 +51,7 @@
+     string outputFilename = options->OutputBase();
+     int startIndex = options->OutputStartIndex();
+     int stopIndex = options->NumTimes() + startIndex - 1;
+-    if (stopIndex > 1)
++    if (stopIndex > 0)
+     {
+         const int digits = (int) (log10((double) stopIndex) + 1);
+         char buffer[64];


### PR DESCRIPTION
to resolve `-num_times=2` bug

Per https://github.com/Homebrew/homebrew-core/pull/7372
