### PR TITLE
OpenSSH: fix for @PREFIX@ not expanding properly

### DIFF
--- a/openssh/patch-sandbox-darwin.c-apple-sandbox-named-external.diff
+++ b/openssh/patch-sandbox-darwin.c-apple-sandbox-named-external.diff
@@ -2,18 +2,18 @@
 +++ b/sandbox-darwin.c	2015-10-24 04:41:19.000000000 +0200
 @@ -62,8 +62,16 @@ ssh_sandbox_child(struct ssh_sandbox *bo
  	struct rlimit rl_zero;
- 
+
  	debug3("%s: starting Darwin sandbox", __func__);
 +#ifdef __APPLE_SANDBOX_NAMED_EXTERNAL__
 +#ifndef SANDBOX_NAMED_EXTERNAL
 +#define SANDBOX_NAMED_EXTERNAL (0x3)
 +#endif
-+	if (sandbox_init("@PREFIX@/share/openssh/org.openssh.sshd.sb",
++	if (sandbox_init("/System/Library/Sandbox/Profiles/org.openssh.sshd.sb",
 +		SANDBOX_NAMED_EXTERNAL, &errmsg) == -1)
 +#else
  	if (sandbox_init(kSBXProfilePureComputation, SANDBOX_NAMED,
  	    &errmsg) == -1)
 +#endif
  		fatal("%s: sandbox_init: %s", __func__, errmsg);
- 
+
  	/*


### PR DESCRIPTION
@PREFIX@ is not expanding and winding up in the binary literally.
This breaks sshd preventing all connections.

This issue was reported in https://github.com/Homebrew/homebrew-dupes/issues/697