### PR TITLE
vtk: patch to prevent linking against python

### DIFF
--- a/vtk/vtk-nopythonlinking-7.1.0.patch
+++ b/vtk/vtk-nopythonlinking-7.1.0.patch
@@ -1,0 +1,470 @@
+From b61a9561d41611ba21e9eeebea759f2033925ebe Mon Sep 17 00:00:00 2001
+From: Michka Popoff <michkapopoff@gmail.com>
+Date: Wed, 18 May 2016 00:31:30 +0200
+Subject: [PATCH] ENH: Do not link against libpython when possible
+
+This is similar to what is already done in ITK and SimpleITK.
+
+The new vtkTargetLinkLibrariesWithDynamicLookup.cmake file is slightly modified copy from
+ITK/CMake/itkTargetLinkLibrariesWithDynamicLookup.cmake
+The explanation of what this patch tries to achieve is documented in this file.
+
+A new argument is introduced, called OPTIONAL_PYTHON_LINK.
+When used, the module will be optionally be linked against libpython.
+In the module.cmake files, most vtkPython dependencies were moved to COMPILE_DEPENDS, so that libpython is not added to the target_link_libraries() call.
+
+The vtkPython is explicitely linked against the python libraries, as this is a python executable.
+
+Also, the find_package calls for the PythonLibs were made optional when possible.
+
+The XDMF3 project was not updated, this will need to be done separately if weak linking is wished for that project.
+
+This fixes the following bug: http://www.vtk.org/Bug/view.php?id=16068
+---
+ CMake/vtkModuleMacros.cmake                        | 11 +++
+ CMake/vtkModuleTop.cmake                           |  1 +
+ CMake/vtkPythonWrapping.cmake                      | 13 ++-
+ .../vtkTargetLinkLibrariesWithDynamicLookup.cmake  | 99 ++++++++++++++++++++++
+ CMake/vtkWrapPython.cmake                          |  7 +-
+ Filters/Python/module.cmake                        |  3 +
+ Parallel/MPI4Py/module.cmake                       |  4 +
+ ThirdParty/AutobahnPython/module.cmake             |  1 +
+ ThirdParty/SixPython/module.cmake                  |  3 +-
+ ThirdParty/Twisted/module.cmake                    |  2 +
+ ThirdParty/ZopeInterface/module.cmake              |  3 +-
+ ThirdParty/mpi4py/vtkmpi4py/CMakeLists.txt         |  7 +-
+ .../Maintenance/VisualizeModuleDependencies.py     |  3 +-
+ Utilities/Maintenance/WhatModulesVTK.py            |  3 +-
+ Utilities/PythonInterpreter/module.cmake           |  1 +
+ Web/Core/module.cmake                              |  3 +
+ Web/Python/module.cmake                            |  2 +
+ Wrapping/Python/CMakeLists.txt                     |  5 ++
+ Wrapping/PythonCore/module.cmake                   |  3 +-
+ 19 files changed, 165 insertions(+), 9 deletions(-)
+ create mode 100644 CMake/vtkTargetLinkLibrariesWithDynamicLookup.cmake
+
+diff --git a/CMake/vtkModuleMacros.cmake b/CMake/vtkModuleMacros.cmake
+index 8c2880f343..f2a0887c9f 100644
+--- a/CMake/vtkModuleMacros.cmake
++++ b/CMake/vtkModuleMacros.cmake
+@@ -5,6 +5,7 @@ set(_VTKModuleMacros_DEFAULT_LABEL "VTKModular")
+ include(${_VTKModuleMacros_DIR}/vtkModuleAPI.cmake)
+ include(VTKGenerateExportHeader)
+ include(vtkWrapping)
++include(vtkTargetLinkLibrariesWithDynamicLookup)
+ if(VTK_MAKE_INSTANTIATORS)
+   include(vtkMakeInstantiator)
+ endif()
+@@ -22,6 +23,7 @@ endif()
+ #  DEPENDS = Modules that will be publicly linked to this module
+ #  PRIVATE_DEPENDS = Modules that will be privately linked to this module
+ #  COMPILE_DEPENDS = Modules that are needed at compile time by this module
++#  OPTIONAL_PYTHON_LINK = Optionally link the python library to this module
+ #  TEST_DEPENDS = Modules that are needed by this modules testing executables
+ #  DESCRIPTION = Free text description of the module
+ #  TCL_NAME = Alternative name for the TCL wrapping (cannot contain numbers)
+@@ -47,6 +49,7 @@ macro(vtk_module _name)
+   set(${vtk-module-test}_DECLARED 1)
+   set(${vtk-module}_DEPENDS "")
+   set(${vtk-module}_COMPILE_DEPENDS "")
++  set(${vtk-module}_OPTIONAL_PYTHON_LINK 0)
+   set(${vtk-module}_PRIVATE_DEPENDS "")
+   set(${vtk-module-test}_DEPENDS "${vtk-module}")
+   set(${vtk-module}_IMPLEMENTS "")
+@@ -79,6 +82,9 @@ macro(vtk_module _name)
+     elseif("${arg}" STREQUAL "IMPLEMENTATION_REQUIRED_BY_BACKEND")
+       set(_doing "")
+       set(${vtk-module}_IMPLEMENTATION_REQUIRED_BY_BACKEND 1)
++    elseif("${arg}" STREQUAL "OPTIONAL_PYTHON_LINK")
++      set(_doing "")
++      set(${vtk-module}_OPTIONAL_PYTHON_LINK 1)
+     elseif("${arg}" MATCHES "^[A-Z][A-Z][A-Z]$" AND
+            NOT "${arg}" MATCHES "^(ON|OFF|MPI)$")
+       set(_doing "")
+@@ -661,6 +667,11 @@ function(vtk_module_library name)
+     endif()
+   endforeach()
+
++  # Optionally link the module to the python library
++  if(NOT _vtk_build_as_kit AND ${${vtk-module}_OPTIONAL_PYTHON_LINK})
++    vtk_target_link_libraries_with_dynamic_lookup(${vtk-module} LINK_PUBLIC ${vtkPython_LIBRARIES})
++  endif()
++
+   # Handle the private dependencies, setting up link/include directories.
+   foreach(dep IN LISTS ${vtk-module}_PRIVATE_DEPENDS)
+     if(${dep}_INCLUDE_DIRS)
+diff --git a/CMake/vtkModuleTop.cmake b/CMake/vtkModuleTop.cmake
+index 150282e4cf..f2daed84a9 100644
+--- a/CMake/vtkModuleTop.cmake
++++ b/CMake/vtkModuleTop.cmake
+@@ -507,6 +507,7 @@ if (NOT VTK_INSTALL_NO_DEVELOPMENT)
+                 CMake/vtkObjectFactory.h.in
+                 CMake/vtkPythonPackages.cmake
+                 CMake/vtkPythonWrapping.cmake
++                CMake/vtkTargetLinkLibrariesWithDynamicLookup.cmake
+                 CMake/vtkTclWrapping.cmake
+                 CMake/vtkThirdParty.cmake
+                 CMake/vtkWrapHierarchy.cmake
+diff --git a/CMake/vtkPythonWrapping.cmake b/CMake/vtkPythonWrapping.cmake
+index e695a03423..4af9c47266 100644
+--- a/CMake/vtkPythonWrapping.cmake
++++ b/CMake/vtkPythonWrapping.cmake
+@@ -1,5 +1,12 @@
+-find_package(PythonLibs REQUIRED)
++if (VTK_UNDEFINED_SYMBOLS_ALLOWED)
++  set(_QUIET_LIBRARY "QUIET")
++else()
++  set(_QUIET_LIBRARY "REQUIRED")
++endif()
++find_package(PythonLibs ${_QUIET_LIBRARY})
+ include(vtkWrapPython)
++include(vtkTargetLinkLibrariesWithDynamicLookup)
++
+ if(PYTHONINTERP_FOUND AND PYTHONLIBS_FOUND)
+   set(_interp_version "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}")
+   set(_libs_version "${PYTHON_MAJOR_VERSION}.${PYTHON_MINOR_VERSION}")
+@@ -120,7 +127,9 @@ function(vtk_add_python_wrapping_library module srcs)
+       PROPERTY INCLUDE_DIRECTORIES ${_python_include_dirs})
+   endif()
+   target_link_libraries(${module}PythonD LINK_PUBLIC
+-    vtkWrappingPythonCore ${extra_links} ${VTK_PYTHON_LIBRARIES})
++    vtkWrappingPythonCore ${extra_links})
++  vtk_target_link_libraries_with_dynamic_lookup(
++    ${module}PythonD LINK_PUBLIC ${VTK_PYTHON_LIBRARIES})
+
+   if (MSVC)
+     set_target_properties(${module}PythonD
+diff --git a/CMake/vtkTargetLinkLibrariesWithDynamicLookup.cmake b/CMake/vtkTargetLinkLibrariesWithDynamicLookup.cmake
+new file mode 100644
+index 0000000000..fe7794f289
+--- /dev/null
++++ b/CMake/vtkTargetLinkLibrariesWithDynamicLookup.cmake
+@@ -0,0 +1,99 @@
++#
++# - This module provides the function
++# vtk_target_link_libraries_with_dynamic_lookup which can be used to
++# "weakly" link loadable module.
++#
++# Link a library to a target such that the symbols are resolved at
++# run-time not link-time. This should be used when compiling a
++# loadable module when the symbols should be resolve from the run-time
++# environment where the module is loaded, and not a specific system
++# library.
++#
++# Specifically, for OSX it uses undefined dynamic_lookup. This is
++# simular to using "-shared" on Linux where undefined symbols are
++# ignored.
++#
++# Additionally, the linker is checked to see if it supports undefined
++# symbols when linking a shared library. If it does then the library
++# is not linked when specified with this function.
++#
++# http://blog.tim-smith.us/2015/09/python-extension-modules-os-x/
++#
++
++# Function: _vtkCheckUndefinedSymbolsAllowed
++#
++# Check if the linker allows undefined symbols for shared libraries.
++#
++# VTK_UNDEFINED_SYMBOLS_ALLOWED - true if the linker will allow
++#   undefined symbols for shared libraries
++#
++
++function(_vtkCheckUndefinedSymbolsAllowed)
++
++  set(VARIABLE "VTK_UNDEFINED_SYMBOLS_ALLOWED")
++  set(cache_var "${VARIABLE}_hash")
++
++
++  # hash the CMAKE_FLAGS passed and check cache to know if we need to rerun
++  string(MD5 cmake_flags_hash "${CMAKE_SHARED_LINKER_FLAGS}")
++
++  if(NOT DEFINED "${cache_var}" )
++    unset("${VARIABLE}" CACHE)
++  elseif(NOT "${${cache_var}}" STREQUAL "${cmake_flags_hash}" )
++    unset("${VARIABLE}" CACHE)
++  endif()
++
++  if(NOT DEFINED "${VARIABLE}")
++    set(test_project_dir "${PROJECT_BINARY_DIR}/CMakeTmp/${VARIABLE}")
++
++    file(WRITE "${test_project_dir}/CMakeLists.txt"
++"
++project(undefined C)
++add_library(foo SHARED \"foo.c\")
++")
++
++    file(WRITE "${test_project_dir}/foo.c"
++"
++extern int bar(void);
++int foo(void) {return bar()+1;}
++")
++
++    if(APPLE AND ${CMAKE_VERSION} VERSION_GREATER 2.8.11)
++      set( _rpath_arg  "-DCMAKE_MACOSX_RPATH='${CMAKE_MACOSX_RPATH}'" )
++    else()
++      set( _rpath_arg )
++    endif()
++
++    try_compile(${VARIABLE}
++      "${test_project_dir}"
++      "${test_project_dir}"
++      undefined
++      CMAKE_FLAGS
++        "-DCMAKE_SHARED_LINKER_FLAGS='${CMAKE_SHARED_LINKER_FLAGS}'"
++        ${_rpath_arg}
++      OUTPUT_VARIABLE output)
++
++    set(${cache_var} "${cmake_flags_hash}" CACHE INTERNAL  "hashed try_compile flags")
++
++    if(${VARIABLE})
++      message(STATUS "Performing Test ${VARIABLE} - Success")
++    else()
++      message(STATUS "Performing Test ${VARIABLE} - Failed")
++      file(APPEND ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeError.log
++        "Performing Test ${VARIABLE} failed with the following output:\n"
++        "${OUTPUT}\n")
++    endif()
++  endif()
++endfunction()
++
++_vtkCheckUndefinedSymbolsAllowed()
++
++macro( vtk_target_link_libraries_with_dynamic_lookup target )
++  if ( ${CMAKE_SYSTEM_NAME} MATCHES "Darwin" )
++    set_target_properties( ${target} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup" )
++  elseif(VTK_UNDEFINED_SYMBOLS_ALLOWED)
++    # linker allows undefined symbols, let's just not link
++  else()
++    target_link_libraries ( ${target} ${ARGN}  )
++  endif()
++endmacro()
+\ No newline at end of file
+diff --git a/CMake/vtkWrapPython.cmake b/CMake/vtkWrapPython.cmake
+index eecb44c2dc..f356cbca50 100644
+--- a/CMake/vtkWrapPython.cmake
++++ b/CMake/vtkWrapPython.cmake
+@@ -179,7 +179,12 @@ endmacro()
+
+ if(VTK_WRAP_PYTHON_FIND_LIBS)
+   get_filename_component(_CURRENT_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+-  find_package(PythonLibs)
++  if (VTK_UNDEFINED_SYMBOLS_ALLOWED)
++    set(_QUIET_LIBRARY "QUIET")
++  else()
++    set(_QUIET_LIBRARY "REQUIRED")
++  endif()
++  find_package(PythonLibs ${_QUIET_LIBRARY})
+
+   # Use separate debug/optimized libraries if they are different.
+   if(PYTHON_DEBUG_LIBRARY)
+diff --git a/Filters/Python/module.cmake b/Filters/Python/module.cmake
+index fe7f9ad380..f3f4d1365d 100644
+--- a/Filters/Python/module.cmake
++++ b/Filters/Python/module.cmake
+@@ -2,6 +2,9 @@ if (VTK_WRAP_PYTHON)
+   vtk_module(vtkFiltersPython
+     GROUPS
+       StandAlone
++    COMPILE_DEPENDS
++      vtkPython
++    OPTIONAL_PYTHON_LINK
+     EXCLUDE_FROM_TCL_WRAPPING
+     EXCLUDE_FROM_JAVA_WRAPPING
+     TEST_DEPENDS
+@@ -10,9 +13,8 @@ if (VTK_WRAP_PYTHON)
+       vtkWrapping
+     DEPENDS
+       vtkCommonExecutionModel
+-      vtkPython
+     PRIVATE_DEPENDS
+       vtkCommonCore
+       vtkWrappingPythonCore
+     )
+-endif ()
+\ No newline at end of file
++endif ()
+diff --git a/Parallel/MPI4Py/module.cmake b/Parallel/MPI4Py/module.cmake
+index c4e3d350bd..b4f01ad245 100644
+--- a/Parallel/MPI4Py/module.cmake
++++ b/Parallel/MPI4Py/module.cmake
+@@ -2,8 +2,12 @@ if (VTK_WRAP_PYTHON)
+   vtk_module(vtkParallelMPI4Py
+     GROUPS
+       MPI
++    DEPENDS
++      vtkParallelMPI
+     COMPILE_DEPENDS
+       vtkmpi4py
++      vtkPython
++    OPTIONAL_PYTHON_LINK
+     EXCLUDE_FROM_TCL_WRAPPING
+     EXCLUDE_FROM_JAVA_WRAPPING
+     KIT
+diff --git a/ThirdParty/AutobahnPython/module.cmake b/ThirdParty/AutobahnPython/module.cmake
+index 74ccc20a59..532894eaf9 100644
+--- a/ThirdParty/AutobahnPython/module.cmake
++++ b/ThirdParty/AutobahnPython/module.cmake
+@@ -3,4 +3,5 @@ vtk_module(AutobahnPython
+     SixPython
+     Twisted
+     vtkPython
++  OPTIONAL_PYTHON_LINK
+   EXCLUDE_FROM_WRAPPING)
+\ No newline at end of file
+diff --git a/ThirdParty/SixPython/module.cmake b/ThirdParty/SixPython/module.cmake
+index 4853db12d2..4be9961cb6 100644
+--- a/ThirdParty/SixPython/module.cmake
++++ b/ThirdParty/SixPython/module.cmake
+@@ -1,4 +1,5 @@
+ vtk_module(SixPython
+-  DEPENDS
++  COMPILE_DEPENDS
+     vtkPython
++  OPTIONAL_PYTHON_LINK
+   EXCLUDE_FROM_WRAPPING)
+\ No newline at end of file
+diff --git a/ThirdParty/Twisted/module.cmake b/ThirdParty/Twisted/module.cmake
+index c6c33cda75..eccc94b68a 100644
+--- a/ThirdParty/Twisted/module.cmake
++++ b/ThirdParty/Twisted/module.cmake
+@@ -1,5 +1,7 @@
+ vtk_module(Twisted
+   DEPENDS
+     ZopeInterface
++  COMPILE_DEPENDS
+     vtkPython
++  OPTIONAL_PYTHON_LINK
+   EXCLUDE_FROM_WRAPPING)
+\ No newline at end of file
+diff --git a/ThirdParty/ZopeInterface/module.cmake b/ThirdParty/ZopeInterface/module.cmake
+index 736ca38c47..fdb31fe69a 100644
+--- a/ThirdParty/ZopeInterface/module.cmake
++++ b/ThirdParty/ZopeInterface/module.cmake
+@@ -1,4 +1,5 @@
+ vtk_module(ZopeInterface
+-  DEPENDS
++  COMPILE_DEPENDS
+     vtkPython
++  OPTIONAL_PYTHON_LINK
+   EXCLUDE_FROM_WRAPPING)
+\ No newline at end of file
+diff --git a/ThirdParty/mpi4py/vtkmpi4py/CMakeLists.txt b/ThirdParty/mpi4py/vtkmpi4py/CMakeLists.txt
+index 1aef093101..02b0dcb87b 100644
+--- a/ThirdParty/mpi4py/vtkmpi4py/CMakeLists.txt
++++ b/ThirdParty/mpi4py/vtkmpi4py/CMakeLists.txt
+@@ -24,7 +24,12 @@ if (NOT MPI4PY_PACKAGE_BINARY_DIR)
+ endif()
+
+ FIND_PACKAGE(PythonInterp ${VTK_PYTHON_VERSION})
+-FIND_PACKAGE(PythonLibs ${VTK_PYTHON_VERSION})
++if (VTK_UNDEFINED_SYMBOLS_ALLOWED)
++  set(_QUIET_LIBRARY "QUIET")
++else()
++  set(_QUIET_LIBRARY "${VTK_PYTHON_VERSION}")
++endif()
++FIND_PACKAGE(PythonLibs ${_QUIET_LIBRARY})
+ FIND_PACKAGE(MPI)
+
+ # -------------------------------------------------------------------------
+diff --git a/Utilities/Maintenance/VisualizeModuleDependencies.py b/Utilities/Maintenance/VisualizeModuleDependencies.py
+index c2e86b214f..fcb59855c5 100755
+--- a/Utilities/Maintenance/VisualizeModuleDependencies.py
++++ b/Utilities/Maintenance/VisualizeModuleDependencies.py
+@@ -93,7 +93,8 @@ def ParseModuleFile(fileName):
+     languages = ['PYTHON', 'TCL', 'JAVA']
+     keywords = ['BACKEND', 'COMPILE_DEPENDS', 'DEPENDS', 'EXCLUDE_FROM_ALL',
+                 'EXCLUDE_FROM_WRAPPING', 'GROUPS', 'IMPLEMENTS', 'KIT',
+-                'PRIVATE_DEPENDS', 'TEST_DEPENDS', 'IMPLEMENTATION_REQUIRED_BY_BACKEND'] + \
++                'PRIVATE_DEPENDS', 'TEST_DEPENDS', 'OPTIONAL_PYTHON_LINK'
++                'IMPLEMENTATION_REQUIRED_BY_BACKEND'] + \
+                map(lambda l: 'EXCLUDE_FROM_%s_WRAPPING' % l, languages)
+     moduleName = ""
+     depends = []
+diff --git a/Utilities/Maintenance/WhatModulesVTK.py b/Utilities/Maintenance/WhatModulesVTK.py
+index ff254d5897..f530c0b494 100755
+--- a/Utilities/Maintenance/WhatModulesVTK.py
++++ b/Utilities/Maintenance/WhatModulesVTK.py
+@@ -168,7 +168,8 @@ def ParseModuleFile(fileName, renderingBackend='OpenGL'):
+     languages = ['PYTHON', 'TCL', 'JAVA']
+     keywords = ['BACKEND', 'COMPILE_DEPENDS', 'DEPENDS', 'EXCLUDE_FROM_ALL',
+                 'EXCLUDE_FROM_WRAPPING', 'GROUPS', 'IMPLEMENTS', 'KIT',
+-                'PRIVATE_DEPENDS', 'TEST_DEPENDS', 'IMPLEMENTATION_REQUIRED_BY_BACKEND'] + \
++                'PRIVATE_DEPENDS', 'TEST_DEPENDS',
++                'IMPLEMENTATION_REQUIRED_BY_BACKEND', 'OPTIONAL_PYTHON_LINK'] + \
+                map(lambda l: 'EXCLUDE_FROM_%s_WRAPPING' % l, languages)
+     moduleName = ""
+     depends = []
+diff --git a/Utilities/PythonInterpreter/module.cmake b/Utilities/PythonInterpreter/module.cmake
+index ff92a1ef97..2f0a661d8e 100644
+--- a/Utilities/PythonInterpreter/module.cmake
++++ b/Utilities/PythonInterpreter/module.cmake
+@@ -5,4 +5,5 @@ vtk_module(vtkPythonInterpreter
+     vtkCommonCore
+     vtkPython
+     vtksys
++  OPTIONAL_PYTHON_LINK
+ )
+\ No newline at end of file
+diff --git a/Web/Core/module.cmake b/Web/Core/module.cmake
+index 7cfa667c03..f4f2fb9f44 100644
+--- a/Web/Core/module.cmake
++++ b/Web/Core/module.cmake
+@@ -20,4 +20,7 @@ vtk_module(vtkWebCore
+     vtkRenderingCore
+     vtkWebGLExporter
+     vtksys
++  COMPILE_DEPENDS
++    vtkPython
++  OPTIONAL_PYTHON_LINK
+ )
+\ No newline at end of file
+diff --git a/Web/Python/module.cmake b/Web/Python/module.cmake
+index a5c714bf34..d66f9bbf52 100644
+--- a/Web/Python/module.cmake
++++ b/Web/Python/module.cmake
+@@ -4,5 +4,7 @@ vtk_module(vtkWebPython
+   EXCLUDE_FROM_WRAPPING
+   DEPENDS
+     AutobahnPython
++  COMPILE_DEPENDS
+     vtkPython
++  OPTIONAL_PYTHON_LINK
+   EXCLUDE_FROM_ALL)
+\ No newline at end of file
+diff --git a/Wrapping/Python/CMakeLists.txt b/Wrapping/Python/CMakeLists.txt
+index 6b5c014111..d0857ccc58 100644
+--- a/Wrapping/Python/CMakeLists.txt
++++ b/Wrapping/Python/CMakeLists.txt
+@@ -240,6 +240,11 @@ if(VTK_USE_FFMPEG_ENCODER)
+   list(APPEND VTKPYTHON_LINK_LIBS ${FFMPEG_BASIC_LIBRARIES})
+ endif()
+
++# Add the libPython.dylib file and link explicitly against it.
++# This is needed because this is a new python executable, which needs it's libraries.
++find_package(PythonLibs REQUIRED)
++list(APPEND VTKPYTHON_LINK_LIBS ${vtkPython_LIBRARIES})
++
+ target_link_libraries(vtkpython ${VTKPYTHON_LINK_LIBS})
+
+ unset(PVTKPYTHON_EXECUTABLE)
+diff --git a/Wrapping/PythonCore/module.cmake b/Wrapping/PythonCore/module.cmake
+index 7169017136..b811a2d95c 100644
+--- a/Wrapping/PythonCore/module.cmake
++++ b/Wrapping/PythonCore/module.cmake
+@@ -1,10 +1,11 @@
+ vtk_module(vtkWrappingPythonCore
+   COMPILE_DEPENDS
+     vtkWrappingTools
++    vtkPython
++  OPTIONAL_PYTHON_LINK
+   EXCLUDE_FROM_ALL
+   EXCLUDE_FROM_WRAPPING
+   DEPENDS
+     vtkCommonCore
+-    vtkPython
+     vtksys
+   )
+\ No newline at end of file
+--
+2.11.0


### PR DESCRIPTION
This patch has been submitted upstream:
https://gitlab.kitware.com/vtk/vtk/merge_requests/1713

The version in this commit is a backport from
the patch, as there are some slight differences
between the current VTK master and VTK 7.1.0,
which is the latest stable version.

See https://github.com/Homebrew/homebrew-science/pull/3811 for ref.