### PR TITLE
gnupg21: patch for "make check" on 10.10 and below

### DIFF
--- a/gnupg21/ssh-import-scm.patch
+++ b/gnupg21/ssh-import-scm.patch
@@ -1,0 +1,75 @@
+From 56aa85f88f6b35fb03a2dc1a95882d49a74290e3 Mon Sep 17 00:00:00 2001
+From: Justus Winter <justus@g10code.com>
+Date: Tue, 7 Feb 2017 18:01:44 +0100
+Subject: [PATCH] tests: Skip key types not supported by OpenSSH.
+
+* tests/openpgp/ssh-import.scm (path): New variable.
+(ssh,ssh-keygen,ssh-version,ssh-supports?): Likewise.
+--
+
+Skip algorithms not supported by the OpenSSH in the ssh import test.
+This notably fixes the test on macOS when the stock ssh version is
+used.
+
+GnuPG-bug-id: 2847
+GnuPG-bug-id: 2947
+Signed-off-by: Justus Winter <justus@g10code.com>
+---
+ tests/openpgp/ssh-import.scm | 33 +++++++++++++++++++++++++++++----
+ 1 file changed, 29 insertions(+), 4 deletions(-)
+
+diff --git a/tests/openpgp/ssh-import.scm b/tests/openpgp/ssh-import.scm
+index ad5acc5..7a4364c 100755
+--- a/tests/openpgp/ssh-import.scm
++++ b/tests/openpgp/ssh-import.scm
+@@ -24,10 +24,35 @@
+         (call-check `(,(tool 'gpgconf) --null --list-dirs agent-ssh-socket))
+         #t)
+ 
+-(define SSH-ADD #f)
++(define path (string-split (getenv "PATH") *pathsep*))
++(define ssh #f)
++(catch (skip "ssh not found") (set! ssh (path-expand "ssh" path)))
++
++(define ssh-add #f)
+ (catch (skip "ssh-add not found")
+-       (set! SSH-ADD
+-	     (path-expand "ssh-add" (string-split (getenv "PATH") *pathsep*))))
++       (set! ssh-add (path-expand "ssh-add" path)))
++
++(define ssh-keygen #f)
++(catch (skip "ssh-keygen not found")
++       (set! ssh-keygen (path-expand "ssh-keygen" path)))
++
++(define ssh-version
++  (let ((tmp (:stderr (call-with-io `(,ssh "-V") "")))
++	(prefix "OpenSSH_"))
++    (unless (string-prefix? tmp prefix)
++	    (skip "This doesn't look like OpenSSH:" tmp))
++    (string->number (substring tmp (string-length prefix)
++			       (+ 3 (string-length prefix))))))
++
++(define (ssh-supports? algorithm)
++  (cond
++   ((equal? algorithm "ed25519")
++    (>= ssh-version 6.5))
++   (else
++    (not (string-contains? (:stderr (call-with-io `(,ssh-keygen
++						    -t ,algorithm
++						    -b "1009") ""))
++			   "unknown key type")))))
+ 
+ (define keys
+   '(("dsa" "9a:e1:f1:5f:46:ea:a5:06:e1:e2:f8:38:8e:06:54:58")
+@@ -48,7 +73,7 @@
+       (pipe:spawn `(,SSH-ADD -)))
+      (unless (string-contains? (call-popen `(,SSH-ADD -l "-E" md5) "") hash)
+ 	     (fail "key not added"))))
+- car keys)
++ car (filter (lambda (x) (ssh-supports? (car x))) keys))
+ 
+ (info "Checking for issue2316...")
+ (unlink (path-join GNUPGHOME "sshcontrol"))
+-- 
+2.8.0.rc3
+


### PR DESCRIPTION
fixes the ssh-import.scm test