### PR TITLE
med-file: Patches to enable building with Apple's clang libc++

### DIFF
--- a/med-file/libc++_and_python_bindings_fixes.diff
+++ b/med-file/libc++_and_python_bindings_fixes.diff
@@ -1,0 +1,70 @@
+diff --git a/include/H5public_extract.h.in b/include/H5public_extract.h.in
+index c38765e..0e9451c 100644
+--- a/include/H5public_extract.h.in
++++ b/include/H5public_extract.h.in
+@@ -28,10 +28,6 @@ extern "C" {
+ @HDF5_TYPEDEF_HID_T@
+ @HDF5_TYPEDEF_HSIZE_T@
+ 
+-#typedef int herr_t;
+-#typedef int hid_t;
+-#typedef unsigned long long   hsize_t;
+-
+ #ifdef __cplusplus
+ }
+ #endif
+diff --git a/python/CMakeLists.txt b/python/CMakeLists.txt
+index 4016f7c..1e45797 100644
+--- a/python/CMakeLists.txt
++++ b/python/CMakeLists.txt
+@@ -26,8 +26,12 @@ SET(_swig_files
+   medsubdomain_module.i
+ )
+ 
++IF(APPLE)
++  SET(PYTHON_LIBRARIES "-undefined dynamic_lookup")
++ENDIF(APPLE)
++
+ SET(_link_libs
+-  med
++  medC
+   ${PYTHON_LIBRARIES}
+   )
+ 
+diff --git a/python/medenum_module.i b/python/medenum_module.i
+index 91fc0d8..920c9eb 100644
+--- a/python/medenum_module.i
++++ b/python/medenum_module.i
+@@ -6,6 +6,7 @@
+ 
+ %{
+ #include "med.h"
++#include <utility>
+ %}
+ 
+ %include "H5public_extract.h"
+diff --git a/python/medenumtest_module.i b/python/medenumtest_module.i
+index 7bfc32b..efda37d 100644
+--- a/python/medenumtest_module.i
++++ b/python/medenumtest_module.i
+@@ -4,6 +4,7 @@
+ 
+ %{
+ #include "med.h"
++#include <utility>
+ %}
+ 
+ %include "H5public_extract.h"
+diff --git a/src/2.3.6/ci/MEDequivInfo.c b/src/2.3.6/ci/MEDequivInfo.c
+index 60a97e8..d157cb9 100644
+--- a/src/2.3.6/ci/MEDequivInfo.c
++++ b/src/2.3.6/ci/MEDequivInfo.c
+@@ -24,7 +24,7 @@
+ #include <stdlib.h>
+ 
+ int
+-MEDequivInfo(int fid, char *maa, int ind, char *eq, char *des)
++MEDequivInfo(med_idt fid, char *maa, int ind, char *eq, char *des)
+ {
+   med_idt eqid;
+   med_err ret;


### PR DESCRIPTION
Reference: Homebrew/homebrew-science#5138