### PR TITLE
go@1.5: patch to fix building on macOS Sierra

### DIFF
--- a/go@1.5/go@1.5-Sierra-build.patch
+++ b/go@1.5/go@1.5-Sierra-build.patch
@@ -1,0 +1,237 @@
+From c26cf5cc1a3a128d1c7e20cf5ca79547263fce38 Mon Sep 17 00:00:00 2001
+From: Josh Bleecher Snyder <josharian@gmail.com>
+Date: Thu, 7 Jul 2016 16:41:29 -0700
+Subject: [PATCH 1/3] runtime: fix nanotime for macOS Sierra
+
+This is a cherry-pick of https://go-review.googlesource.com/24812
+to the release-branch-go1.4
+
+In the beta version of the macOS Sierra (10.12) release, the
+gettimeofday system call changed on x86. Previously it always returned
+the time in the AX/DX registers. Now, if AX is returned as 0, it means
+that the system call has stored the values into the memory pointed to by
+the first argument, just as the libc gettimeofday function does. The
+libc function handles both cases, and we need to do so as well.
+
+Fixes #16272.
+
+Change-Id: I490ed0a82e251fce73becc4722cbe276feebc7b7
+Reviewed-on: https://go-review.googlesource.com/31729
+Reviewed-by: Brad Fitzpatrick <bradfitz@golang.org>
+---
+ src/runtime/sys_darwin_386.s   | 5 +++++
+ src/runtime/sys_darwin_amd64.s | 7 ++++++-
+ 2 files changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/src/runtime/sys_darwin_386.s b/src/runtime/sys_darwin_386.s
+index a961c71..469cabc 100644
+--- a/src/runtime/sys_darwin_386.s
++++ b/src/runtime/sys_darwin_386.s
+@@ -187,6 +187,11 @@ systime:
+ 	MOVL	$0, 8(SP)	// time zone pointer
+ 	MOVL	$116, AX
+ 	INT	$0x80
++	CMPL	AX, $0
++	JNE	inreg
++	MOVL	12(SP), AX
++	MOVL	16(SP), DX
++inreg:
+ 	// sec is in AX, usec in DX
+ 	// convert to DX:AX nsec
+ 	MOVL	DX, BX
+diff --git a/src/runtime/sys_darwin_amd64.s b/src/runtime/sys_darwin_amd64.s
+index bd397d7..8f845e5 100644
+--- a/src/runtime/sys_darwin_amd64.s
++++ b/src/runtime/sys_darwin_amd64.s
+@@ -141,10 +141,15 @@ timeloop:
+ 
+ systime:
+ 	// Fall back to system call (usually first call in this thread).
+-	MOVQ	SP, DI	// must be non-nil, unused
++	MOVQ	SP, DI
+ 	MOVQ	$0, SI
+ 	MOVL	$(0x2000000+116), AX
+ 	SYSCALL
++	CMPQ	AX, $0
++	JNE	inreg
++	MOVQ	0(SP), AX
++	MOVL	8(SP), DX
++inreg:
+ 	// sec is in AX, usec in DX
+ 	// return nsec in AX
+ 	IMULQ	$1000000000, AX
+
+From 524c67d0d6cd8d4b96d1272ff0a705ab80ff341a Mon Sep 17 00:00:00 2001
+From: Josh Bleecher Snyder <josharian@gmail.com>
+Date: Mon, 1 Aug 2016 21:54:40 -0700
+Subject: [PATCH 2/3] runtime: fix nanotime for macOS Sierra, again.
+
+This is a cherry-pick of https://go-review.googlesource.com/25400
+to the release-branch-go1.4
+
+macOS Sierra beta4 changed the kernel interface for getting time.
+DX now optionally points to an address for additional info.
+Set it to zero to avoid corrupting memory.
+
+Fixes #16570
+
+Change-Id: I714325a7749a145d23cf03251db38196ac9c481a
+Reviewed-on: https://go-review.googlesource.com/31750
+Reviewed-by: Brad Fitzpatrick <bradfitz@golang.org>
+---
+ src/runtime/sys_darwin_386.s   | 7 ++++---
+ src/runtime/sys_darwin_amd64.s | 1 +
+ 2 files changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/src/runtime/sys_darwin_386.s b/src/runtime/sys_darwin_386.s
+index 469cabc..3ae60eb 100644
+--- a/src/runtime/sys_darwin_386.s
++++ b/src/runtime/sys_darwin_386.s
+@@ -182,15 +182,16 @@ timeloop:
+ 
+ systime:
+ 	// Fall back to system call (usually first call in this thread)
+-	LEAL	12(SP), AX	// must be non-nil, unused
++	LEAL	16(SP), AX	// must be non-nil, unused
+ 	MOVL	AX, 4(SP)
+ 	MOVL	$0, 8(SP)	// time zone pointer
++	MOVL	$0, 12(SP)	// required as of Sierra; Issue 16570
+ 	MOVL	$116, AX
+ 	INT	$0x80
+ 	CMPL	AX, $0
+ 	JNE	inreg
+-	MOVL	12(SP), AX
+-	MOVL	16(SP), DX
++	MOVL	16(SP), AX
++	MOVL	20(SP), DX
+ inreg:
+ 	// sec is in AX, usec in DX
+ 	// convert to DX:AX nsec
+diff --git a/src/runtime/sys_darwin_amd64.s b/src/runtime/sys_darwin_amd64.s
+index 8f845e5..fe9f384 100644
+--- a/src/runtime/sys_darwin_amd64.s
++++ b/src/runtime/sys_darwin_amd64.s
+@@ -143,6 +143,7 @@ systime:
+ 	// Fall back to system call (usually first call in this thread).
+ 	MOVQ	SP, DI
+ 	MOVQ	$0, SI
++	MOVQ	$0, DX  // required as of Sierra; Issue 16570
+ 	MOVL	$(0x2000000+116), AX
+ 	SYSCALL
+ 	CMPQ	AX, $0
+
+From 02118ad0a0cacb00c1d834b3b5e7a01d8b6327d4 Mon Sep 17 00:00:00 2001
+From: Josh Bleecher Snyder <josharian@gmail.com>
+Date: Thu, 4 Aug 2016 12:21:05 -0700
+Subject: [PATCH 3/3] syscall: fix Gettimeofday on macOS Sierra
+
+This is a cherry-pick of https://go-review.googlesource.com/25495
+to the release-branch-go1.4
+
+Fixes #16606
+
+Change-Id: I7b7fc8677153065ee608eb94c4c72be0b273b28d
+Reviewed-on: https://go-review.googlesource.com/31751
+Reviewed-by: Rob Pike <r@golang.org>
+---
+ src/syscall/syscall_darwin_386.go   | 21 ++++++++++++++-------
+ src/syscall/syscall_darwin_amd64.go | 21 ++++++++++++++-------
+ src/syscall/syscall_darwin_test.go  | 23 +++++++++++++++++++++++
+ 3 files changed, 51 insertions(+), 14 deletions(-)
+ create mode 100644 src/syscall/syscall_darwin_test.go
+
+diff --git a/src/syscall/syscall_darwin_386.go b/src/syscall/syscall_darwin_386.go
+index 2074e7a..f75de00 100644
+--- a/src/syscall/syscall_darwin_386.go
++++ b/src/syscall/syscall_darwin_386.go
+@@ -26,14 +26,21 @@ func NsecToTimeval(nsec int64) (tv Timeval) {
+ }
+ 
+ //sysnb	gettimeofday(tp *Timeval) (sec int32, usec int32, err error)
+-func Gettimeofday(tv *Timeval) (err error) {
+-	// The tv passed to gettimeofday must be non-nil
+-	// but is otherwise unused.  The answers come back
+-	// in the two registers.
++func Gettimeofday(tv *Timeval) error {
++	// The tv passed to gettimeofday must be non-nil.
++	// Before macOS Sierra (10.12), tv was otherwise unused and
++	// the answers came back in the two registers.
++	// As of Sierra, gettimeofday return zeros and populates
++	// tv itself.
+ 	sec, usec, err := gettimeofday(tv)
+-	tv.Sec = int32(sec)
+-	tv.Usec = int32(usec)
+-	return err
++	if err != nil {
++		return err
++	}
++	if sec != 0 || usec != 0 {
++		tv.Sec = int32(sec)
++		tv.Usec = int32(usec)
++	}
++	return nil
+ }
+ 
+ func SetKevent(k *Kevent_t, fd, mode, flags int) {
+diff --git a/src/syscall/syscall_darwin_amd64.go b/src/syscall/syscall_darwin_amd64.go
+index 81b1fd3..711d08d 100644
+--- a/src/syscall/syscall_darwin_amd64.go
++++ b/src/syscall/syscall_darwin_amd64.go
+@@ -26,14 +26,21 @@ func NsecToTimeval(nsec int64) (tv Timeval) {
+ }
+ 
+ //sysnb	gettimeofday(tp *Timeval) (sec int64, usec int32, err error)
+-func Gettimeofday(tv *Timeval) (err error) {
+-	// The tv passed to gettimeofday must be non-nil
+-	// but is otherwise unused.  The answers come back
+-	// in the two registers.
++func Gettimeofday(tv *Timeval) error {
++	// The tv passed to gettimeofday must be non-nil.
++	// Before macOS Sierra (10.12), tv was otherwise unused and
++	// the answers came back in the two registers.
++	// As of Sierra, gettimeofday return zeros and populates
++	// tv itself.
+ 	sec, usec, err := gettimeofday(tv)
+-	tv.Sec = sec
+-	tv.Usec = usec
+-	return err
++	if err != nil {
++		return err
++	}
++	if sec != 0 || usec != 0 {
++		tv.Sec = sec
++		tv.Usec = usec
++	}
++	return nil
+ }
+ 
+ func SetKevent(k *Kevent_t, fd, mode, flags int) {
+diff --git a/src/syscall/syscall_darwin_test.go b/src/syscall/syscall_darwin_test.go
+new file mode 100644
+index 0000000..dd0e32b
+--- /dev/null
++++ b/src/syscall/syscall_darwin_test.go
+@@ -0,0 +1,23 @@
++// Copyright 2016 The Go Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style
++// license that can be found in the LICENSE file.
++
++// +build darwin
++// +build amd64 386
++
++package syscall_test
++
++import (
++	"syscall"
++	"testing"
++)
++
++func TestDarwinGettimeofday(t *testing.T) {
++	tv := &syscall.Timeval{}
++	if err := syscall.Gettimeofday(tv); err != nil {
++		t.Fatal(err)
++	}
++	if tv.Sec == 0 && tv.Usec == 0 {
++		t.Fatal("Sec and Usec both zero")
++	}
++}


### PR DESCRIPTION
primarily addresses issues regarding the changed behavior of Sierra's gettimeofday function