### PR TITLE
gnupg: add patch for using tools from the build directory

### DIFF
--- a/gnupg/fix-using-tools-from-build-dir.patch
+++ b/gnupg/fix-using-tools-from-build-dir.patch
@@ -1,0 +1,62 @@
+From a98459d3f4ec3d196fb0adb0e90dadf40abc8c81 Mon Sep 17 00:00:00 2001
+From: Justus Winter <justus@g10code.com>
+Date: Wed, 15 Mar 2017 14:36:27 +0100
+Subject: [PATCH] tests: Fix using tools from the build directory.
+
+* tests/openpgp/defs.scm (gpg-conf'): Explicitly pass the build prefix
+to gpgconf here...
+(gpg-components): ... instead of only here.
+--
+
+Previously, gpgconf was not invoked with '--build-prefix' when
+changing the configuration.  This made tests using this facility fail
+(e.g. the TOFU test).  This only affected release builds, because in
+development builds gpgconf picks up the build prefix from the
+environment.
+
+GnuPG-bug-id: 2979
+Signed-off-by: Justus Winter <justus@g10code.com>
+---
+ tests/openpgp/defs.scm | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/tests/openpgp/defs.scm b/tests/openpgp/defs.scm
+index 568ffab..7c8e10a 100644
+--- a/tests/openpgp/defs.scm
++++ b/tests/openpgp/defs.scm
+@@ -140,10 +140,16 @@
+ (define valgrind
+   '("/usr/bin/valgrind" --leak-check=full --error-exitcode=154))
+ 
++(unless installed?
++	(setenv "GNUPG_BUILDDIR" (getenv "objdir") #t))
++
+ (define (gpg-conf . args)
+   (gpg-conf' "" args))
+ (define (gpg-conf' input args)
+-  (let ((s (call-popen `(,(tool-hardcoded 'gpgconf) ,@args) input)))
++  (let ((s (call-popen `(,(tool-hardcoded 'gpgconf)
++			 ,@(if installed? '()
++			       (list '--build-prefix (getenv "objdir")))
++			 ,@args) input)))
+     (map (lambda (line) (map percent-decode (string-split line #\:)))
+ 	 (string-split-newlines s))))
+ (define :gc:c:name car)
+@@ -180,13 +186,7 @@
+      (gpg-conf' (string-append key ":16:")
+ 		`(--change-options ,component)))))
+ 
+-
+-(unless installed?
+-	(setenv "GNUPG_BUILDDIR" (getenv "objdir") #t))
+-(define gpg-components (apply gpg-conf
+-			`(,@(if installed? '()
+-				(list '--build-prefix (getenv "objdir")))
+-			  --list-components)))
++(define gpg-components (apply gpg-conf '(--list-components)))
+ 
+ (define (tool which)
+   (case which
+-- 
+2.8.0.rc3
+


### PR DESCRIPTION
Lets us run "make check" before "make install".

upstream commit "tests: Fix using tools from the build directory."
https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=patch;h=a98459d3f4ec3d196fb0adb0e90dadf40abc8c81

See https://bugs.gnupg.org/gnupg/issue2979