### PR TITLE
qt5: Add patch to fix QT-58344

### DIFF
--- a/qt5/QTBUG-58344.patch
+++ b/qt5/QTBUG-58344.patch
@@ -1,0 +1,33 @@
+From 59780d132aa114f8b7edfb17a24b91d09e38236d Mon Sep 17 00:00:00 2001
+From: Oleg Yadrov <oleg.yadrov@qt.io>
+Date: Mon, 23 Jan 2017 15:25:38 -0800
+Subject: [PATCH] Cocoa: fix crash regression in qt_mac_create_nsimage()
+
+The regression was introduced in d8857f21ac264. The original change was
+meant to fix support for SVG icons, but failed to take into account
+a valid QIcon with no sizes, but which is also unable to create
+a pixmap for the requested size.
+
+Task-number: QTBUG-58344
+Change-Id: I7ac1dbfaf6e3dab8581fe4b33c814e2517fcdba8
+Reviewed-by: Andy Shaw <andy.shaw@qt.io>
+---
+ qtbase/src/gui/painting/qcoregraphics.mm | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/qtbase/src/gui/painting/qcoregraphics.mm b/src/gui/painting/qcoregraphics.mm
+index 803328c10f..3753fa4e88 100644
+--- a/qtbase/src/gui/painting/qcoregraphics.mm
++++ b/qtbase/src/gui/painting/qcoregraphics.mm
+@@ -157,6 +157,8 @@ NSImage *qt_mac_create_nsimage(const QIcon &icon, int defaultSize)
+         availableSizes << QSize(defaultSize, defaultSize);
+     foreach (QSize size, availableSizes) {
+         QPixmap pm = icon.pixmap(size);
++        if (pm.isNull())
++            continue;
+         QImage image = pm.toImage();
+         CGImageRef cgImage = qt_mac_toCGImage(image);
+         NSBitmapImageRep *imageRep = [[NSBitmapImageRep alloc] initWithCGImage:cgImage];
+-- 
+2.12.2
+


### PR DESCRIPTION
Upstream issue QTBUG-58344 "UI crash upon start" which won't be fixed in qt 5.7, 5.8.
Affected at least a formula djview4.
Patch is created with non-essential changes from the upstream patch.
See https://codereview.qt-project.org/#/c/183183/
