### PR TITLE
node@0.12: fix for Xcode 8.3

### DIFF
--- a/node@0.12/v8-xcode-8.3.diff
+++ b/node@0.12/v8-xcode-8.3.diff
@@ -1,0 +1,22 @@
+diff --git a/deps/v8/include/v8.h b/deps/v8/include/v8.h
+index 222404c..3f1d239 100644
+--- a/deps/v8/include/v8.h
++++ b/deps/v8/include/v8.h
+@@ -812,14 +812,14 @@ class V8_EXPORT HandleScope {
+     return reinterpret_cast<Isolate*>(isolate_);
+   }
+ 
++  static internal::Object** CreateHandle(internal::Isolate* isolate,
++                                         internal::Object* value);
++
+  protected:
+   V8_INLINE HandleScope() {}
+ 
+   void Initialize(Isolate* isolate);
+ 
+-  static internal::Object** CreateHandle(internal::Isolate* isolate,
+-                                         internal::Object* value);
+-
+  private:
+   // Uses heap_object to obtain the current Isolate.
+   static internal::Object** CreateHandle(internal::HeapObject* heap_object,


### PR DESCRIPTION
Fixes build failure with >= Apple LLVM version 8.1.0 (clang-802.0.42).

The error is
```
../deps/v8/include/v8.h:5800:54: error: 'CreateHandle' is a protected member of 'v8::HandleScope'
```

Fix suggested by Thomas Rosenstein in https://github.com/nodejs/node-gyp/issues/1160.