### PR TITLE
gst-plugins-bad: new patch adding the gstglwindow_cocoa.h file

### DIFF
--- a/gst-plugins-bad/gstglwindow_cocoa.patch
+++ b/gst-plugins-bad/gstglwindow_cocoa.patch
@@ -1,0 +1,71 @@
+diff -urN gst-plugins-bad-1.12.1.orig/gst-libs/gst/gl/cocoa/gstglwindow_cocoa.h gst-plugins-bad-1.12.1/gst-libs/gst/gl/cocoa/gstglwindow_cocoa.h
+--- gst-plugins-bad-1.12.1.orig/gst-libs/gst/gl/cocoa/gstglwindow_cocoa.h	1970-01-01 01:00:00.000000000 +0100
++++ gst-plugins-bad-1.12.1/gst-libs/gst/gl/cocoa/gstglwindow_cocoa.h	2017-06-28 14:41:45.000000000 +0100
+@@ -0,0 +1,67 @@
++/*
++ * GStreamer
++ * Copyright (C) 2012 Matthew Waters <ystreet00@gmail.com>
++ *
++ * This library is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Library General Public
++ * License as published by the Free Software Foundation; either
++ * version 2 of the License, or (at your option) any later version.
++ *
++ * This library is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Library General Public License for more details.
++ *
++ * You should have received a copy of the GNU Library General Public
++ * License along with this library; if not, write to the
++ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
++ * Boston, MA 02110-1301, USA.
++ */
++
++#ifndef __GST_GL_WINDOW_COCOA_H__
++#define __GST_GL_WINDOW_COCOA_H__
++
++#include <gst/gst.h>
++
++#include <gst/gl/gl.h>
++
++G_BEGIN_DECLS
++
++#define GST_TYPE_GL_WINDOW_COCOA         (gst_gl_window_cocoa_get_type())
++#define GST_GL_WINDOW_COCOA(o)           (G_TYPE_CHECK_INSTANCE_CAST((o), GST_TYPE_GL_WINDOW_COCOA, GstGLWindowCocoa))
++#define GST_GL_WINDOW_COCOA_CLASS(k)     (G_TYPE_CHECK_CLASS((k), GST_TYPE_GL_WINDOW_COCOA, GstGLWindowCocoaClass))
++#define GST_IS_GL_WINDOW_COCOA(o)        (G_TYPE_CHECK_INSTANCE_TYPE((o), GST_TYPE_GL_WINDOW_COCOA))
++#define GST_IS_GL_WINDOW_COCOA_CLASS(k)  (G_TYPE_CHECK_CLASS_TYPE((k), GST_TYPE_GL_WINDOW_COCOA))
++#define GST_GL_WINDOW_COCOA_GET_CLASS(o) (G_TYPE_INSTANCE_GET_CLASS((o), GST_TYPE_GL_WINDOW_COCOA, GstGLWindowCocoaClass))
++
++typedef struct _GstGLWindowCocoa        GstGLWindowCocoa;
++typedef struct _GstGLWindowCocoaPrivate GstGLWindowCocoaPrivate;
++typedef struct _GstGLWindowCocoaClass   GstGLWindowCocoaClass;
++
++struct _GstGLWindowCocoa {
++  /*< private >*/
++  GstGLWindow parent;
++
++  /*< private >*/
++  GstGLWindowCocoaPrivate *priv;
++  
++  gpointer _reserved[GST_PADDING];
++};
++
++struct _GstGLWindowCocoaClass {
++  /*< private >*/
++  GstGLWindowClass parent_class;
++
++  /*< private >*/
++  gpointer _reserved[GST_PADDING_LARGE];
++};
++
++GType gst_gl_window_cocoa_get_type     (void);
++
++GstGLWindowCocoa * gst_gl_window_cocoa_new (GstGLDisplay * display);
++
++void gst_gl_window_cocoa_draw_thread (GstGLWindowCocoa *window_cocoa);
++
++G_END_DECLS
++
++#endif /* __GST_GL_WINDOW_COCOA_H__ */


### PR DESCRIPTION
This header was not shipped in the 1.12.1 release. The issue was fixed
upstream already with this commit:
https://cgit.freedesktop.org/gstreamer/gst-plugins-bad/patch/?id=450b1c92abe2ae8f84e557f61c9512a1f4006bab