### PR TITLE
erlang@19 and erlang@18: patches for BoringSSL on 10.13

### DIFF
--- a/erlang@18/boring-ssl-high-sierra.patch
+++ b/erlang@18/boring-ssl-high-sierra.patch
@@ -1,0 +1,22 @@
+From 44b3792923c96cac2191ff4f95c42c8fdb1d8633 Mon Sep 17 00:00:00 2001
+From: Mark Madsen <mm@idyll.io>
+Date: Wed, 5 Jul 2017 00:49:46 -0600
+Subject: [PATCH] Backport fix of ERL-439 for maint-18
+
+---
+ erts/configure.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/erts/configure.in b/erts/configure.in
+index 4ade3b30860eebce3da358236c0fd7321223327f..6467c50289c8590742b77640b964a6d26b4601dd 100644
+--- a/erts/configure.in
++++ b/erts/configure.in
+@@ -3821,7 +3821,7 @@ case $host_os in
+ 	darwin*)
+ 		# Mach-O linker: a shared lib and a loadable
+ 		# object file is not the same thing.
+-		DED_LDFLAGS="-bundle -flat_namespace -undefined suppress"
++		DED_LDFLAGS="-bundle -bundle_loader ${ERL_TOP}/bin/$host/beam.smp"
+ 		case $ARCH in
+ 			amd64)
+ 				DED_LDFLAGS="-m64 $DED_LDFLAGS"

--- a/erlang@19/boring-ssl-high-sierra.patch
+++ b/erlang@19/boring-ssl-high-sierra.patch
@@ -1,0 +1,22 @@
+From a9367aa77ca5579d92c7e47af37f3373f541f1da Mon Sep 17 00:00:00 2001
+From: Mark Madsen <mm@idyll.io>
+Date: Tue, 4 Jul 2017 23:53:42 -0600
+Subject: [PATCH] Backport fix of ERL-439 for maint-19
+
+---
+ erts/configure.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/erts/configure.in b/erts/configure.in
+index ad9a66126f68896043656ee0f50e8ddee25b269f..22f4bc630755e3f9c5a40313159fdd853b3746ad 100644
+--- a/erts/configure.in
++++ b/erts/configure.in
+@@ -3752,7 +3752,7 @@ case $host_os in
+ 	darwin*)
+ 		# Mach-O linker: a shared lib and a loadable
+ 		# object file is not the same thing.
+-		DED_LDFLAGS="-bundle -flat_namespace -undefined suppress"
++		DED_LDFLAGS="-bundle -bundle_loader ${ERL_TOP}/bin/$host/beam.smp"
+ 		case $ARCH in
+ 			amd64)
+ 				DED_LDFLAGS="-m64 $DED_LDFLAGS"


### PR DESCRIPTION
Backports of https://github.com/erlang/otp/pull/1501 to maint-18 and maint-19.