### PR TITLE
maq: add patch for compilation

### DIFF
--- a/maq/maq-0.7.1-compilation-fix.patch
+++ b/maq/maq-0.7.1-compilation-fix.patch
@@ -1,0 +1,44 @@
+diff --git a/get_pos.c b/get_pos.c
+index d1a1b72..3b4a837 100644
+--- a/get_pos.c
++++ b/get_pos.c
+@@ -5,7 +5,7 @@
+ #include "assemble.h"
+
+ /** fill the rolling buffer */
+-inline void assemble_fill_buffer(gzFile fpin, rolling_buf_t *ab)
++void assemble_fill_buffer(gzFile fpin, rolling_buf_t *ab)
+ {
+	if (gzeof(fpin) || (ab->is_rounded == 1 && ab->head == ab->tail)) return; // the buffer is full
+	int n_records, n_bytes;
+diff --git a/stdhash.hh b/stdhash.hh
+index eaf98af..16cd1a3 100644
+--- a/stdhash.hh
++++ b/stdhash.hh
+@@ -412,7 +412,7 @@ public:
+	inline bool insert(const keytype_t &key) {
+		__lh3_hash_base_class<keytype_t>::rehash();
+		hashint_t i;
+-		int ret = direct_insert_aux(key, this->n_capacity, this->keys, this->flags, &i);
++		int ret = this->direct_insert_aux(key, this->n_capacity, this->keys, this->flags, &i);
+		if (ret == 0) return true;
+		if (ret == 1) { ++(this->n_size); ++(this->n_occupied); }
+		else ++(this->n_size); // then ret == 2
+@@ -493,7 +493,7 @@ public:
+	inline bool insert(const keytype_t &key, const valtype_t &val) {
+		rehash();
+		hashint_t i;
+-		int ret = direct_insert_aux(key, this->n_capacity, this->keys, this->flags, &i);
++		int ret = this->direct_insert_aux(key, this->n_capacity, this->keys, this->flags, &i);
+		vals[i] = val;
+		if (ret == 0) return true;
+		if (ret == 1) { ++(this->n_size); ++(this->n_occupied); }
+@@ -503,7 +503,7 @@ public:
+	inline bool insert(const keytype_t &key, valtype_t **q) {
+		rehash();
+		hashint_t i;
+-		int ret = direct_insert_aux(key, this->n_capacity, this->keys, this->flags, &i);
++		int ret = this->direct_insert_aux(key, this->n_capacity, this->keys, this->flags, &i);
+		*q = vals + i;
+		if (ret == 0) return true;
+		if (ret == 1) { ++(this->n_size); ++(this->n_occupied); }


### PR DESCRIPTION
Fixes:

In file included from mapcheck.cc:11:
./stdhash.hh:415:13: error: use of undeclared identifier 'directinsertaux'
                int ret = directinsertaux(key, this->ncapacity, this->keys, this->flags, &i);
                          ^
                          this->
mapcheck.cc:24:10: note: in instantiation of member function 'hashsetmisc<unsigned long long>::insert' requested here
                        hash->insert((bit64t)seqid<<32 | (pos-1));
                              ^
./stdhash.hh:295:13: note: must qualify identifier to find this declaration in dependent base class
        inline int directinsertaux(const keytypet &key, hashintt m, keytypet K, lh3flagt F, hashintt i) {
                   ^
1 error generated.

Reported upstream: https://sourceforge.net/p/maq/bugs/33/