### PR TITLE
erlang@17: add patch for BoringSSL on 10.13

### DIFF
--- a/erlang@17/boring-ssl-high-sierra.patch
+++ b/erlang@17/boring-ssl-high-sierra.patch
@@ -1,0 +1,13 @@
+diff --git a/erts/configure.in b/erts/configure.in
+index b3fe48d..337bac3 100644
+--- a/erts/configure.in
++++ b/erts/configure.in
+@@ -3820,7 +3820,7 @@ case $host_os in
+ 	darwin*)
+ 		# Mach-O linker: a shared lib and a loadable
+ 		# object file is not the same thing.
+-		DED_LDFLAGS="-bundle -flat_namespace -undefined suppress"
++		DED_LDFLAGS="-bundle -bundle_loader ${ERL_TOP}/bin/$host/beam.smp"
+ 		case $ARCH in
+ 			amd64)
+ 				DED_LDFLAGS="-m64 $DED_LDFLAGS"


### PR DESCRIPTION
Backport fix of ERL-439