### PR TITLE
poppler: fix build with clang

### DIFF
--- a/poppler/clang.diff
+++ b/poppler/clang.diff
@@ -1,0 +1,12 @@
+diff --git a/poppler/StructElement.cc b/poppler/StructElement.cc
+index 0fbd336..6ddc228 100644
+--- a/poppler/StructElement.cc
++++ b/poppler/StructElement.cc
+@@ -248,6 +248,7 @@ struct AttributeMapEntry {
+ };
+
+ struct AttributeDefaults {
++  AttributeDefaults(){}
+   Object Inline  = Object(objName, "Inline");
+   Object LrTb = Object(objName, "LrTb");
+   Object Normal = Object(objName, "Normal");


### PR DESCRIPTION
Add user-provided default constructor for AttributeDefaults.

Avoids the following build failure:

```
  CXX      libpoppler_la-StructElement.lo
StructElement.cc:264:32: error: default initialization of an object of const type
      'const AttributeDefaults' without a user-provided default constructor
static const AttributeDefaults attributeDefaults;
                               ^
                                                {}
1 error generated.
make[3]: *** [libpoppler_la-StructElement.lo] Error 1
make[2]: *** [all] Error 2
make[1]: *** [all-recursive] Error 1
make: *** [all] Error 2
```