### PR TITLE
poppler: update clang fix to use upstream patch

### DIFF
--- a/poppler/clang.diff
+++ b/poppler/clang.diff
@@ -1,12 +1,22 @@
+From dd80c182cbcb188af0dd590f222ba9bbb31e3fb7 Mon Sep 17 00:00:00 2001
+From: Albert Astals Cid <aacid@kde.org>
+Date: Mon, 4 Sep 2017 19:36:06 +0200
+Subject: Fix building with old clang
+
+
 diff --git a/poppler/StructElement.cc b/poppler/StructElement.cc
-index 0fbd336..6ddc228 100644
+index 0fbd336..451213f 100644
 --- a/poppler/StructElement.cc
 +++ b/poppler/StructElement.cc
-@@ -248,6 +248,7 @@ struct AttributeMapEntry {
+@@ -248,6 +248,8 @@ struct AttributeMapEntry {
  };
-
+ 
  struct AttributeDefaults {
-+  AttributeDefaults(){}
++  AttributeDefaults() {}; // needed to support old clang
++
    Object Inline  = Object(objName, "Inline");
    Object LrTb = Object(objName, "LrTb");
    Object Normal = Object(objName, "Normal");
+-- 
+cgit v0.10.2
+


### PR DESCRIPTION
The patch was accepted upstream in https://cgit.freedesktop.org/poppler/poppler/commit/?id=dd80c182cbcb188af0dd590f222ba9bbb31e3fb7.

See https://bugs.freedesktop.org/show_bug.cgi?id=102538.