### PR TITLE
enigma: Compile with a C++11 compiler

### DIFF
--- a/enigma/c++11.patch
+++ b/enigma/c++11.patch
@@ -1,0 +1,26 @@
+--- a/src/Value.cc	2017-09-03 15:39:37 UTC
++++ b/src/Value.cc
+@@ -146,10 +146,10 @@ namespace enigma {
+                 val.str[0] = 0;
+                 break;
+             case BOOL :
+-                val.dval[0] = false;
++                val.dval[0] = 0;
+                 break;
+             case OBJECT :
+-                val.dval[0] = (double) NULL;
++                val.dval[0] = 0;
+                 break;
+             case NAMEDOBJECT:
+                 ASSERT(false, XLevelRuntime, "Value: illegal type usage");
+--- a/src/lev/Proxy.cc	2017-09-03 15:54:50 UTC
++++ b/src/lev/Proxy.cc
+@@ -933,7 +933,7 @@ namespace enigma { namespace lev {
+                     } else if (haveLocalCopy) {
+                         // plain file
+                         basic_ifstream<char> ifs(absExtPath.c_str(), ios::binary | ios::in);
+-                        if (ifs != NULL)
++                        if (ifs)
+                             Readfile(ifs, extCode);
+                         else
+                             haveLocalCopy = false;


### PR DESCRIPTION
Correct broken implicit conversions which no longer work with a C++11 compiler.  Required to build with Xerces-C 3.2.0 and C++11.

See https://github.com/Enigma-Game/Enigma/pull/8