### PR TITLE
xml-security-c: Compile with a C++11 compiler.

### DIFF
--- a/xml-security-c/c++11.patch
+++ b/xml-security-c/c++11.patch
@@ -1,0 +1,55 @@
+--- a/xsec/enc/NSS/NSSCryptoSymmetricKey.hpp	2017-09-03 18:52:39 UTC
++++ b/xsec/enc/NSS/NSSCryptoSymmetricKey.hpp
+@@ -149,7 +149,7 @@ public :
+ 							 SymmetricKeyMode mode = MODE_CBC,
+ 							 const unsigned char * iv = NULL,
+                              const unsigned char* tag = NULL,
+-                             unsigned int taglen = NULL);
++                             unsigned int taglen = 0U);
+ 
+ 	/**
+ 	 * \brief Continue an decrypt operation using this key.
+--- a/xsec/enc/OpenSSL/OpenSSLCryptoSymmetricKey.hpp	2017-09-03 18:59:26 UTC
++++ b/xsec/enc/OpenSSL/OpenSSLCryptoSymmetricKey.hpp
+@@ -151,7 +151,7 @@ public :
+ 							 SymmetricKeyMode mode = MODE_CBC,
+ 							 const unsigned char * iv = NULL,
+                              const unsigned char* tag = NULL,
+-                             unsigned int taglen = NULL);
++                             unsigned int taglen = 0U);
+ 
+ 	/**
+ 	 * \brief Continue an decrypt operation using this key.
+--- a/xsec/enc/WinCAPI/WinCAPICryptoSymmetricKey.hpp	2017-09-03 18:59:55 UTC
++++ b/xsec/enc/WinCAPI/WinCAPICryptoSymmetricKey.hpp
+@@ -158,7 +158,7 @@ public :
+ 							 SymmetricKeyMode mode = MODE_CBC,
+ 							 const unsigned char * iv = NULL,
+                              const unsigned char* tag = NULL,
+-                             unsigned int taglen = NULL);
++                             unsigned int taglen = 0U);
+ 
+ 	/**
+ 	 * \brief Continue an decrypt operation using this key.
+--- a/xsec/enc/XSECCryptoSymmetricKey.hpp	2017-09-03 18:48:32 UTC
++++ b/xsec/enc/XSECCryptoSymmetricKey.hpp
+@@ -185,7 +185,7 @@ public :
+ 							 SymmetricKeyMode mode = MODE_CBC,
+ 							 const unsigned char* iv = NULL,
+                              const unsigned char* tag = NULL,
+-                             unsigned int taglen = NULL) = 0;
++                             unsigned int taglen = 0U) = 0;
+ 
+ 	/**
+ 	 * \brief Continue a decrypt operation using this key.
+--- a/xsec/tools/checksig/InteropResolver.cpp	2017-09-03 19:03:40 UTC
++++ b/xsec/tools/checksig/InteropResolver.cpp
+@@ -645,7 +645,7 @@ XSECCryptoKey * InteropResolver::resolve
+ 
+ 	}
+ 
+-	return false;
++	return 0;
+ 
+ }
+ 


### PR DESCRIPTION
Correct broken implicit conversions which are forbidden with C++11. Required to build with Xerces-C 3.2.0 and C++11.

See https://issues.apache.org/jira/browse/SANTUARIO-471