### PR TITLE
xqilla: Use new Xerces 3.2.0 containing node introspection

### DIFF
--- a/xqilla/xerces-containing-node.patch
+++ b/xqilla/xerces-containing-node.patch
@@ -1,0 +1,55 @@
+--- a/src/dom-api/impl/XPathDocumentImpl.cpp	2017-09-03 19:24:35 UTC
++++ b/src/dom-api/impl/XPathDocumentImpl.cpp
+@@ -62,7 +62,11 @@ DOMNode *XPathDocumentImpl::insertBefore
+     if (thisNodeImpl->isReadOnly())
+         throw DOMException(DOMException::NO_MODIFICATION_ALLOWED_ERR, 0, getMemoryManager());
+ 
++#if _XERCES_VERSION >= 30200
++    DOMNode* thisNode = fParent.fContainingNode;
++#else
+     DOMNode* thisNode = castToNode(&fParent);
++#endif
+     if (newChild->getOwnerDocument() != thisNode)
+         throw DOMException(DOMException::WRONG_DOCUMENT_ERR, 0, getMemoryManager());
+ 
+--- a/src/dom-api/impl/XPathNamespaceImpl.cpp	2017-09-03 20:26:37 UTC
++++ b/src/dom-api/impl/XPathNamespaceImpl.cpp
+@@ -33,7 +33,11 @@ XERCES_CPP_NAMESPACE_USE;
+ 
+ XPathNamespaceImpl::XPathNamespaceImpl(const XMLCh* const nsPrefix, 
+ 		const XMLCh* const nsUri, DOMElement *owner, DOMDocument *docOwner) 
++#if _XERCES_VERSION >= 30200 
++	: fNode(this, docOwner)
++#else
+ 	: fNode(docOwner)
++#endif
+ {
+     DOMNodeImpl *argImpl = castToNodeImpl(this);
+ 
+@@ -54,7 +58,13 @@ XPathNamespaceImpl::XPathNamespaceImpl(c
+ }
+ 
+ XPathNamespaceImpl::XPathNamespaceImpl(const XPathNamespaceImpl &other) 
+-	: fNode(other.fNode), uri(other.uri), prefix(other.prefix)
++#if _XERCES_VERSION >= 30200 
++	: fNode(this, other.fNode),
++#else
++	: fNode(other.fNode), 
++
++#endif
++	  uri(other.uri), prefix(other.prefix)
+ {
+ }
+ 
+@@ -196,7 +206,11 @@ short            XPathNamespaceImpl::com
+ 
+     //if it is a custom node and bigger than us we must ask it for the order
+     if(otherType > DOMXPathNamespace::XPATH_NAMESPACE_NODE) {
++#if _XERCES_VERSION >= 30200 
++        DOMNodeImpl tmp(const_cast<XPathNamespaceImpl *>(this), 0);
++#else
+         DOMNodeImpl tmp(0);
++#endif
+ #if _XERCES_VERSION >= 30000
+         return tmp.reverseTreeOrderBitPattern(other->compareDocumentPosition(this));
+ #else


### PR DESCRIPTION
Xerces-C 3.1 provided non-portable and unsafe casts which were replaced with a safe alternative in 3.2.0.  This patch is required to build with Xerces-C 3.2.0.

See https://sourceforge.net/p/xqilla/bugs/48/