### PR TITLE
bonnie++: remove the _LARGEFILE64_SOURCE macros

### DIFF
--- a/bonnie++/remove-large-file-support-macros.diff
+++ b/bonnie++/remove-large-file-support-macros.diff
@@ -1,0 +1,47 @@
+diff --git a/bonnie++.cpp b/bonnie++.cpp
+index bad0e1d..3203c19 100644
+--- a/bonnie++.cpp
++++ b/bonnie++.cpp
+@@ -294,11 +294,7 @@ int main(int argc, char *argv[])
+       {
+         char *sbuf = _strdup(optarg);
+         char *size = strtok(sbuf, ":");
+-#ifdef _LARGEFILE64_SOURCE
+         file_size = size_from_str(size, "gt");
+-#else
+-        file_size = size_from_str(size, "g");
+-#endif
+         size = strtok(NULL, "");
+         if(size)
+         {
+@@ -384,15 +380,6 @@ int main(int argc, char *argv[])
+     if(file_size % 1024 > 512)
+       file_size = file_size + 1024 - (file_size % 1024);
+   }
+-#ifndef _LARGEFILE64_SOURCE
+-  if(file_size == 2048)
+-    file_size = 2047;
+-  if(file_size > 2048)
+-  {
+-    fprintf(stderr, "Large File Support not present, can't do %dM.\n", file_size);
+-    usage();
+-  }
+-#endif
+   globals.byte_io_size = min(file_size, globals.byte_io_size);
+   globals.byte_io_size = max(0, globals.byte_io_size);
+ 
+@@ -465,14 +452,6 @@ int main(int argc, char *argv[])
+      && (directory_max_size < directory_min_size || directory_max_size < 0
+      || directory_min_size < 0) )
+     usage();
+-#ifndef _LARGEFILE64_SOURCE
+-  if(file_size > (1 << (31 - 20 + globals.io_chunk_bits)) )
+-  {
+-    fprintf(stderr
+-   , "The small chunk size and large IO size make this test impossible in 32bit.\n");
+-    usage();
+-  }
+-#endif
+   if(file_size && globals.ram && (file_size * concurrency) < (globals.ram * 2) )
+   {
+     fprintf(stderr


### PR DESCRIPTION
The large file support part of the patch from
https://github.com/Homebrew/legacy-homebrew/pull/35764

The rest of the changes from that patch have already been upstreamed.