### PR TITLE
iozone: fix for conflicting types for mythread_create

### DIFF
--- a/iozone/mythread_create.diff
+++ b/iozone/mythread_create.diff
@@ -1,0 +1,13 @@
+diff --git a/src/current/iozone.c b/src/current/iozone.c
+index 15d72bc..52182f6 100644
+--- a/src/current/iozone.c
++++ b/src/current/iozone.c
+@@ -18960,7 +18960,7 @@ mythread_create( void *(*func)(void *),int x)
+ #else
+ #ifdef HAVE_ANSIC_C
+ long long 
+-mythread_create( void *(*func)(void *),int x)
++mythread_create( void *func,int x)
+ #else
+ long long 
+ mythread_create( func, x)


### PR DESCRIPTION
Addresses the following build failure, which affects iozone > 3.459:

```
iozone.c:18963:1: error: conflicting types for 'mythread_create'
mythread_create( void *(*func)(void *),int x)
^
iozone.c:1046:11: note: previous declaration is here
long long mythread_create( void *, int );
```