### PR TITLE
cvs: fix runtime error on 10.13 caused by gnulib vasnprintf

### DIFF
--- a/cvs/vasnprintf-high-sierra-fix.diff
+++ b/cvs/vasnprintf-high-sierra-fix.diff
@@ -1,0 +1,17 @@
+--- a/lib/vasnprintf.c	2017-01-01 00:00:00.000000000 -0000
++++ b/lib/vasnprintf.c	2017-01-01 00:00:00.000000000 -0000
+@@ -558,11 +558,13 @@
+ 		  }
+ 		*p = dp->conversion;
+ #if USE_SNPRINTF
++# if ! (defined __APPLE__ && defined __MACH__)
+ 		p[1] = '%';
+ 		p[2] = 'n';
+ 		p[3] = '\0';
+-#else
++# else
+ 		p[1] = '\0';
++# endif
+ #endif
+
+ 		/* Construct the arguments for calling snprintf or sprintf.  */


### PR DESCRIPTION
Fixes error: Illegal instuction 4
%n used in a non-immutable format string