### PR TITLE
icu4c: add patch for CVE-2017-14952

### DIFF
--- a/icu4c/CVE-2017-14952.diff
+++ b/icu4c/CVE-2017-14952.diff
@@ -1,0 +1,8 @@
+--- a/source/i18n/zonemeta.cpp	(revision 40283)
++++ b/source/i18n/zonemeta.cpp	(revision 40324)
+@@ -691,5 +691,4 @@
+                     if (U_FAILURE(status)) {
+                         delete mzMappings;
+-                        deleteOlsonToMetaMappingEntry(entry);
+                         uprv_free(entry);
+                         break;


### PR DESCRIPTION
Upstream commit from 9 Aug 2017 "Removed redundant UVector entry clean up function call"
http://bugs.icu-project.org/trac/ticket/13302
http://bugs.icu-project.org/trac/changeset/40324/trunk/icu4c/source/i18n/zonemeta.cpp