### PR TITLE
hashcat: add patch for VERSION_TAG in Makefile

### DIFF
--- a/hashcat/VERSION_TAG.patch
+++ b/hashcat/VERSION_TAG.patch
@@ -1,0 +1,22 @@
+From c06c5ddd4857b0a5d7862451da431c42287918ce Mon Sep 17 00:00:00 2001
+From: philsmd <philsmd@hashcat.net>
+Date: Sat, 28 Oct 2017 13:28:07 +0200
+Subject: [PATCH] fixes #1412: sed for VERSION_EXPORT fixed compilation problem
+
+---
+ src/Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/Makefile b/src/Makefile
+index 3541f7dfcfd16ac870fd7d0b2dc0da71932cde82..75e7757d928ee719588395d666a0d55ce263ad84 100644
+--- a/src/Makefile
++++ b/src/Makefile
+@@ -127,7 +127,7 @@ COMPTIME                := $(shell date +%s)
+ # the value will be something like this: "tag: vX.Y.Z, refs/pull/Y/head"
+ 
+ VERSION_EXPORT          := HEAD -> master, tag: v4.0.0
+-VERSION_TAG             := $(shell test -d .git && git describe --tags --dirty=+ || echo "$(VERSION_EXPORT)" | $(SED) 's/.*: v\([\.0-9]*\),.*/v\1/')
++VERSION_TAG             := $(shell test -d .git && git describe --tags --dirty=+ || echo "$(VERSION_EXPORT)" | $(SED) 's/.*: v\([\.0-9]*\).*/v\1/')
+ 
+ ##
+ ## General compiler and linker options


### PR DESCRIPTION
See https://github.com/hashcat/hashcat/issues/1412 and https://github.com/hashcat/hashcat/pull/1413.