### PR TITLE
git-cinnabar: backport mercurial 4.4 sshpeer patch

### DIFF
--- a/git-cinnabar/mercurial-4.4-sshpeer.patch
+++ b/git-cinnabar/mercurial-4.4-sshpeer.patch
@@ -1,0 +1,17 @@
+diff --git a/cinnabar/hg/__init__.py b/cinnabar/hg/__init__.py
+index 5d94825..c5e32fa 100644
+--- a/cinnabar/hg/__init__.py
++++ b/cinnabar/hg/__init__.py
+@@ -745,9 +745,10 @@ class Remote(object):
+ if changegroup:
+     class localpeer(sshpeer):
+         def __init__(self, ui, path):
+-            self._url = self.path = path
+-            self.ui = ui
++            self._url = self.path = self._path = path
++            self.ui = self._ui = ui
+             self.pipeo = self.pipei = self.pipee = None
++            self._pipeo = self._pipei = self._pipee = None
+ 
+             shellquote = util.shellquote
+             util.shellquote = lambda x: x


### PR DESCRIPTION
Backport of https://github.com/glandium/git-cinnabar/commit/5c59ae1baaeb1585f3c1f3a4cb63a2e03fa213a4 to git-cinnabar 0.4.0