### PR TITLE
libmwaw: add patch for 10.11 and below

### DIFF
--- a/libmwaw/ctor.patch
+++ b/libmwaw/ctor.patch
@@ -1,0 +1,25 @@
+From 4bc8ec0481f89b989b0c34236c9d5d9b8038d4a9 Mon Sep 17 00:00:00 2001
+From: David Tardon <dtardon@redhat.com>
+Date: Wed, 15 Nov 2017 13:15:44 +0100
+Subject: [PATCH] fix call of explicit ctor
+
+---
+ src/lib/libmwaw_internal.hxx | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/lib/libmwaw_internal.hxx b/src/lib/libmwaw_internal.hxx
+index 2875a0f..b844a9d 100644
+--- a/src/lib/libmwaw_internal.hxx
++++ b/src/lib/libmwaw_internal.hxx
+@@ -1027,7 +1027,7 @@ public:
+   }
+   //! generic constructor
+   template <class U> explicit MWAWBox2(MWAWBox2<U> const &p)
+-    : m_data(p.min(), p.max())
++    : m_data(MWAWVec2<T>(p.min()), MWAWVec2<T>(p.max()))
+   {
+   }
+ 
+-- 
+2.10.1 (Apple Git-78)
+


### PR DESCRIPTION
fix call of explicit ctor

https://sourceforge.net/p/libmwaw/libmwaw/ci/4bc8ec0481f89b989b0c34236c9d5d9b8038d4a9/