### PR TITLE
gnumeric: add patch to avoid textdomain as a Gnumeric variable

### DIFF
--- a/gnumeric/textdomain.patch
+++ b/gnumeric/textdomain.patch
@@ -1,0 +1,286 @@
+diff --git a/src/dialogs/dialog-function-select.c b/src/dialogs/dialog-function-select.c
+index dc654fe..d1d0cbe 100644
+--- a/src/dialogs/dialog-function-select.c
++++ b/src/dialogs/dialog-function-select.c
+@@ -46,7 +46,7 @@
+ #include <gtk/gtk.h>
+ #include <string.h>
+ 
+-#define F2(func,s) dgettext ((func)->textdomain->str, (s))
++#define F2(func,s) dgettext ((func)->tdomain->str, (s))
+ 
+ #define FUNCTION_SELECT_KEY "function-selector-dialog"
+ #define FUNCTION_SELECT_HELP_KEY "function-selector-dialog-help-mode"
+diff --git a/src/func-builtin.c b/src/func-builtin.c
+index 51e7701..985432c 100644
+--- a/src/func-builtin.c
++++ b/src/func-builtin.c
+@@ -453,7 +453,7 @@ void
+ func_builtin_init (void)
+ {
+ 	const char *gname;
+-	const char *textdomain = GETTEXT_PACKAGE;
++	const char *tdomain = GETTEXT_PACKAGE;
+ 	int i = 0;
+ 
+ 	static GnmFuncDescriptor const builtins [] = {
+@@ -502,20 +502,20 @@ func_builtin_init (void)
+ 
+ 	gname = N_("Mathematics");
+ 	math_group = gnm_func_group_fetch (gname, _(gname));
+-	gnm_func_add (math_group, builtins + i++, textdomain);
+-	gnm_func_add (math_group, builtins + i++, textdomain);
++	gnm_func_add (math_group, builtins + i++, tdomain);
++	gnm_func_add (math_group, builtins + i++, tdomain);
+ 
+ 	gname = N_("Gnumeric");
+ 	gnumeric_group = gnm_func_group_fetch (gname, _(gname));
+-	gnm_func_add (gnumeric_group, builtins + i++, textdomain);
+-	gnm_func_add (gnumeric_group, builtins + i++, textdomain);
++	gnm_func_add (gnumeric_group, builtins + i++, tdomain);
++	gnm_func_add (gnumeric_group, builtins + i++, tdomain);
+ 	if (gnm_debug_flag ("testsuite"))
+-		gnm_func_add (gnumeric_group, builtins + i, textdomain);
++		gnm_func_add (gnumeric_group, builtins + i, tdomain);
+ 	i++;
+ 
+ 	gname = N_("Logic");
+ 	logic_group = gnm_func_group_fetch (gname, _(gname));
+-	gnm_func_add (logic_group, builtins + i++, textdomain);
++	gnm_func_add (logic_group, builtins + i++, tdomain);
+ 
+ 	gnm_expr_deriv_install_handler (gnm_func_lookup ("sum", NULL),
+ 					gnumeric_sum_deriv,
+diff --git a/src/func.c b/src/func.c
+index 6a82392..53ba25a 100644
+--- a/src/func.c
++++ b/src/func.c
+@@ -35,7 +35,7 @@
+ #include <string.h>
+ #include <stdlib.h>
+ 
+-#define F2(func,s) dgettext ((func)->textdomain->str, (s))
++#define F2(func,s) dgettext ((func)->tdomain->str, (s))
+ 
+ static GList	    *categories;
+ static GnmFuncGroup *unknown_cat;
+@@ -370,8 +370,8 @@ gnm_func_free (GnmFunc *func)
+ 
+ 	g_free ((char *)func->name);
+ 
+-	if (func->textdomain)
+-		go_string_unref (func->textdomain);
++	if (func->tdomain)
++		go_string_unref (func->tdomain);
+ 
+ 	gnm_func_clear_arg_names (func);
+ 
+@@ -483,7 +483,7 @@ gnm_func_lookup_prefix (char const *prefix, Workbook *scope, gboolean trans)
+ GnmFunc *
+ gnm_func_add (GnmFuncGroup *fn_group,
+ 	      GnmFuncDescriptor const *desc,
+-	      const char *textdomain)
++	      const char *tdomain)
+ {
+ 	static char const valid_tokens[] = "fsbraAES?|";
+ 	GnmFunc *func;
+@@ -494,12 +494,12 @@ gnm_func_add (GnmFuncGroup *fn_group,
+ 
+ 	func = g_new (GnmFunc, 1);
+ 
+-	if (!textdomain)
+-		textdomain = GETTEXT_PACKAGE;
++	if (!tdomain)
++		tdomain = GETTEXT_PACKAGE;
+ 
+ 	func->name		= g_strdup (desc->name);
+ 	func->help		= desc->help ? desc->help : NULL;
+-	func->textdomain        = go_string_new (textdomain);
++	func->tdomain        = go_string_new (tdomain);
+ 	func->linker		= desc->linker;
+ 	func->usage_notify	= desc->usage_notify;
+ 	func->flags		= desc->flags;
+@@ -560,14 +560,14 @@ unknownFunctionHandler (GnmFuncEvalInfo *ei,
+  * gnm_func_upgrade_placeholder:
+  * @fd:
+  * @fn_group:
+- * @textdomain:
++ * @tdomain:
+  * @load_desc: (scope async):
+  * @opt_usage_notify: (scope async):
+  **/
+ void
+ gnm_func_upgrade_placeholder (GnmFunc *fd,
+ 			      GnmFuncGroup *fn_group,
+-			      const char *textdomain,
++			      const char *tdomain,
+ 			      GnmFuncLoadDesc load_desc,
+ 			      GnmFuncUsageNotify opt_usage_notify)
+ {
+@@ -575,8 +575,8 @@ gnm_func_upgrade_placeholder (GnmFunc *fd,
+ 	g_return_if_fail (fd->flags & GNM_FUNC_IS_PLACEHOLDER);
+ 	g_return_if_fail (fn_group != NULL);
+ 
+-	if (!textdomain)
+-		textdomain = GETTEXT_PACKAGE;
++	if (!tdomain)
++		tdomain = GETTEXT_PACKAGE;
+ 
+ 	/* Remove from unknown_cat */
+ 	gnm_func_group_remove_func (fd->fn_group, fd);
+@@ -585,8 +585,8 @@ gnm_func_upgrade_placeholder (GnmFunc *fd,
+ 	fd->fn.load_desc = load_desc;
+ 	fd->usage_notify = opt_usage_notify;
+ 
+-	go_string_unref (fd->textdomain);
+-	fd->textdomain = go_string_new (textdomain);
++	go_string_unref (fd->tdomain);
++	fd->tdomain = go_string_new (tdomain);
+ 
+ 	/* Clear localized_name so we can deduce the proper name.  */
+ 	gnm_func_set_localized_name (fd, NULL);
+diff --git a/src/func.h b/src/func.h
+index a6bcd56..85fccc0 100644
+--- a/src/func.h
++++ b/src/func.h
+@@ -190,7 +190,7 @@ struct _GnmFunc {
+ 	char const *name;
+ 	GPtrArray  *arg_names_p;
+ 	GnmFuncHelp const *help;
+-	GOString *textdomain;
++	GOString *tdomain;
+ 	char *localized_name;
+ 	GnmFuncType fn_type;
+ 	union {
+@@ -236,7 +236,7 @@ GSList	   *gnm_func_lookup_prefix   (char const *prefix, Workbook *scope,
+ 				      gboolean trans);
+ GnmFunc    *gnm_func_add	     (GnmFuncGroup *group,
+ 				      GnmFuncDescriptor const *descriptor,
+-				      const char *textdomain);
++				      const char *tdomain);
+ GnmFunc    *gnm_func_add_placeholder (Workbook *optional_scope,
+ 				      char const *name,
+ 				      char const *type);
+@@ -245,7 +245,7 @@ GnmFunc	   *gnm_func_lookup_or_add_placeholder (char const *name);
+ void        gnm_func_upgrade_placeholder
+ 				      (GnmFunc *fd,
+ 				       GnmFuncGroup *fn_group,
+-				       const char *textdomain,
++				       const char *tdomain,
+ 				       GnmFuncLoadDesc load_desc,
+ 				       GnmFuncUsageNotify opt_usage_notify);
+ 
+diff --git a/src/gnm-plugin.c b/src/gnm-plugin.c
+index d3c6a05..127795b 100644
+--- a/src/gnm-plugin.c
++++ b/src/gnm-plugin.c
+@@ -41,7 +41,7 @@ struct GnmPluginServiceFunctionGroup_ {
+ 
+ 	GnmFuncGroup *func_group;
+ 	GnmPluginServiceFunctionGroupCallbacks cbs;
+-	char *textdomain;
++	char *tdomain;
+ };
+ 
+ static void
+@@ -59,8 +59,8 @@ plugin_service_function_group_finalize (GObject *obj)
+ 	g_slist_free_full (sfg->function_name_list, g_free);
+ 	sfg->function_name_list = NULL;
+ 
+-	g_free (sfg->textdomain);
+-	sfg->textdomain = NULL;
++	g_free (sfg->tdomain);
++	sfg->tdomain = NULL;
+ 
+ 	parent_class = g_type_class_peek (GO_TYPE_PLUGIN_SERVICE);
+ 	parent_class->finalize (obj);
+@@ -72,7 +72,7 @@ plugin_service_function_group_read_xml (GOPluginService *service, xmlNode *tree,
+ 	xmlNode *category_node, *translated_category_node, *functions_node;
+ 	gchar *category_name, *translated_category_name;
+ 	GSList *function_name_list = NULL;
+-	gchar *textdomain = NULL;
++	gchar *tdomain = NULL;
+ 
+ 	GO_INIT_RET_ERROR_INFO (ret_error);
+ 	category_node = go_xml_get_child_by_name_no_lang (tree, "category");
+@@ -99,7 +99,7 @@ plugin_service_function_group_read_xml (GOPluginService *service, xmlNode *tree,
+ 	if (functions_node != NULL) {
+ 		xmlNode *node;
+ 
+-		textdomain = xml2c (go_xml_node_get_cstr (functions_node, "textdomain"));
++		tdomain = xml2c (go_xml_node_get_cstr (functions_node, "textdomain"));
+ 
+ 		for (node = functions_node->xmlChildrenNode; node != NULL; node = node->next) {
+ 			gchar *func_name;
+@@ -121,7 +121,7 @@ plugin_service_function_group_read_xml (GOPluginService *service, xmlNode *tree,
+ 		sfg->category_name = category_name;
+ 		sfg->translated_category_name = translated_category_name;
+ 		sfg->function_name_list = function_name_list;
+-		sfg->textdomain = textdomain;
++		sfg->tdomain = tdomain;
+ 	} else {
+ 		GSList *error_list = NULL;
+ 
+@@ -140,7 +140,7 @@ plugin_service_function_group_read_xml (GOPluginService *service, xmlNode *tree,
+ 		g_free (translated_category_name);
+ 		g_slist_free_full (function_name_list, g_free);
+ 
+-		g_free (textdomain);
++		g_free (tdomain);
+ 	}
+ }
+ 
+@@ -223,7 +223,7 @@ plugin_service_function_group_activate (GOPluginService *service, GOErrorInfo **
+ 			 gnm_func_set_user_data (fd, service);
+ 			 gnm_func_upgrade_placeholder
+ 				 (fd, sfg->func_group,
+-				  sfg->textdomain,
++				  sfg->tdomain,
+ 				  plugin_service_function_group_func_desc_load,
+ 				  plugin_service_function_group_func_ref_notify);
+ 			 if (fd->usage_count > 0)
+@@ -280,7 +280,7 @@ plugin_service_function_group_init (GnmPluginServiceFunctionGroup *s)
+ 	s->translated_category_name = NULL;
+ 	s->function_name_list = NULL;
+ 	s->func_group = NULL;
+-	s->textdomain = NULL;
++	s->tdomain = NULL;
+ }
+ 
+ static void
+@@ -433,7 +433,7 @@ plugin_service_ui_activate (GOPluginService *service, GOErrorInfo **ret_error)
+ 	PluginServiceUI *service_ui = GNM_PLUGIN_SERVICE_UI (service);
+ 	const char *uifile = service_ui->file_name;
+ 	char *xml_ui, *group_name;
+-	char const *textdomain;
++	char const *tdomain;
+ 	GError *error = NULL;
+ 	GsfInput *src;
+ 	size_t len;
+@@ -468,11 +468,11 @@ plugin_service_ui_activate (GOPluginService *service, GOErrorInfo **ret_error)
+ 	if (!xml_ui)
+ 		goto err;
+ 
+-	textdomain = go_plugin_get_textdomain (service->plugin);
++	tdomain = go_plugin_get_textdomain (service->plugin);
+ 	group_name = g_strconcat (go_plugin_get_id (service->plugin), service->id, NULL);
+ 	service_ui->layout_id = gnm_app_add_extra_ui (group_name,
+ 		service_ui->actions,
+-		xml_ui, textdomain, service);
++		xml_ui, tdomain, service);
+ 	g_free (group_name);
+ 	g_free (xml_ui);
+ 	g_object_unref (src);
+diff --git a/src/sstest.c b/src/sstest.c
+index 3b8a4d3..acda80e 100644
+--- a/src/sstest.c
++++ b/src/sstest.c
+@@ -91,7 +91,7 @@ static GOptionEntry const sstest_options [] = {
+ /* ------------------------------------------------------------------------- */
+ 
+ #define UNICODE_ELLIPSIS "\xe2\x80\xa6"
+-#define F2(func,s) dgettext ((func)->textdomain->str, (s))
++#define F2(func,s) dgettext ((func)->tdomain->str, (s))
+ 
+ static char *
+ split_at_colon (char const *s, char **rest)


### PR DESCRIPTION
Cherry-picks
https://github.com/GNOME/gnumeric/commit/7017a7ee2
https://github.com/GNOME/gnumeric/commit/64f1410b7

See https://bugzilla.gnome.org/show_bug.cgi?id=791951