### PR TITLE
unbound: fix IPv6 make test build failure

### DIFF
--- a/unbound/unbound-1.7.0-fix-v6-make-test.diff
+++ b/unbound/unbound-1.7.0-fix-v6-make-test.diff
@@ -1,0 +1,51 @@
+Index: doc/Changelog
+===================================================================
+--- doc/Changelog
++++ doc/Changelog
+@@ -1,3 +1,6 @@
++3 April 2018: Wouter
++	- Fix #4043: make test fails due to v6 presentation issue in macOS.
++
+ 12 March 2018: Wouter
+ 	- Added documentation for aggressive-nsec: yes.
+ 	- tag 1.7.0rc3.
+Index: testdata/auth_xfr_ixfr.rpl
+===================================================================
+--- testdata/auth_xfr_ixfr.rpl	(revision 4598)
++++ testdata/auth_xfr_ixfr.rpl	(revision 4599)
+@@ -38,7 +38,7 @@
+ mail.example.com.	3600	IN	A	1.2.3.7
+ zup.example.com.	3600	IN	A	1.2.3.4
+ yyy.example.com.	3600	IN	A	1.2.3.4
+-yyy.example.com.	3600	IN	AAAA	::5
++yyy.example.com.	3600	IN	AAAA	2001:db8::5
+ r1.example.com.	3600	IN	A	1.2.3.4
+ r1.example.com.	3600	IN	RRSIG	A 8 3 10200 20170612005010 20170515005010 42393 nlnetlabs.nl. NhEDrHkuIgHkjWhDRVsGOIJWZpSs+QdduilWFe5d+/ZhOheLJbaTYD5w6+ZZ3yPh1tNud+jlg+GyiOSVapLEO31swDCIarL1UfRjRSpxxDCHGag5Zu+S4hF+KURxO3cJk8jLBELMQyRuMRHoKrw/wsiLGVu1YpAyAPPMcjFBNbk=
+ r2.example.com.	3600	IN	A	1.2.3.4
+@@ -195,7 +195,7 @@
+ www.example.com. IN A	1.2.3.4
+ mail.example.com.	3600	IN	A	1.2.3.6
+ zup.example.com.	3600	IN	A	1.2.3.4
+-yyy.example.com.	3600	IN	AAAA	::5
++yyy.example.com.	3600	IN	AAAA	2001:db8::5
+ r1.example.com.	3600	IN	A	1.2.3.4
+ r2.example.com.	3600	IN	A	1.2.3.4
+ r3.example.com.	3600	IN	RRSIG A 8 3 10200 20170612005010 20170515005010 12345 nlnetlabs.nl. NhEDrHkuIgHkjWhDRVsGOIJWZpSs+QdduilWFe5d+/ZhOheLJbaTYD5w6+ZZ3yPh1tNud+jlg+GyiOSVapLEO31swDCIarL1UfRjRSpxxDCHGag5Zu+S4hF+KURxO3cJk8jLBELMQyRuMRHoKrw/wsiLGVu1YpAyAPPMcjFBNbk=
+@@ -207,7 +207,7 @@
+ SECTION ANSWER
+ www.example.com. IN A	1.2.3.5
+ mail.example.com.	3600	IN	A	1.2.3.8
+-mail.example.com. IN AAAA	::5
++mail.example.com. IN AAAA	2001:db8::5
+ add2.example.com.	3600	IN	A	1.2.3.4
+ example.com. IN SOA ns.example.com. hostmaster.example.com. 2 3600 900 86400 3600
+ ENTRY_END
+@@ -263,7 +263,7 @@
+ mail.example.com.	3600	IN	A	1.2.3.5
+ mail.example.com.	3600	IN	A	1.2.3.7
+ mail.example.com.	3600	IN	A	1.2.3.8
+-mail.example.com.	3600	IN	AAAA	::5
++mail.example.com.	3600	IN	AAAA	2001:db8::5
+ r1.example.com.	3600	IN	RRSIG	A 8 3 10200 20170612005010 20170515005010 42393 nlnetlabs.nl. NhEDrHkuIgHkjWhDRVsGOIJWZpSs+QdduilWFe5d+/ZhOheLJbaTYD5w6+ZZ3yPh1tNud+jlg+GyiOSVapLEO31swDCIarL1UfRjRSpxxDCHGag5Zu+S4hF+KURxO3cJk8jLBELMQyRuMRHoKrw/wsiLGVu1YpAyAPPMcjFBNbk=
+ r2.example.com.	3600	IN	RRSIG	AAAA 8 3 10200 20170612005010 20170515005010 42393 nlnetlabs.nl. NhEDrHkuIgHkjWhDRVsGOIJWZpSs+QdduilWFe5d+/ZhOheLJbaTYD5w6+ZZ3yPh1tNud+jlg+GyiOSVapLEO31swDCIarL1UfRjRSpxxDCHGag5Zu+S4hF+KURxO3cJk8jLBELMQyRuMRHoKrw/wsiLGVu1YpAyAPPMcjFBNbk=
+ r2.example.com.	3600	IN	RRSIG	A 8 3 10200 20170612005010 20170515005010 42393 nlnetlabs.nl. NhEDrHkuIgHkjWhDRVsGOIJWZpSs+QdduilWFe5d+/ZhOheLJbaTYD5w6+ZZ3yPh1tNud+jlg+GyiOSVapLEO31swDCIarL1UfRjRSpxxDCHGag5Zu+S4hF+KURxO3cJk8jLBELMQyRuMRHoKrw/wsiLGVu1YpAyAPPMcjFBNbk=


### PR DESCRIPTION
only needed for unbound v1.7.0, merged upstream