### PR TITLE
moc: add patches for FFmpeg 4.0

### DIFF
--- a/moc/01-codec-2.5.2.patch
+++ b/moc/01-codec-2.5.2.patch
@@ -1,0 +1,91 @@
+diff --git a/decoder_plugins/ffmpeg/ffmpeg.c b/decoder_plugins/ffmpeg/ffmpeg.c
+index 7b90493..f1db552 100644
+--- a/decoder_plugins/ffmpeg/ffmpeg.c
++++ b/decoder_plugins/ffmpeg/ffmpeg.c
+@@ -965,7 +965,20 @@ static void *ffmpeg_open (const char *file)
+ 	}
+ 
+ 	data->stream = data->ic->streams[audio_ix];
+-	data->enc = data->stream->codec;
++
++	data->enc = avcodec_alloc_context3 (NULL);
++	if (!data->enc) {
++		decoder_error (&data->error, ERROR_FATAL, 0,
++		               "Failed to allocate codec context");
++		goto end;
++	}
++
++	err = avcodec_copy_context (data->enc, data->stream->codec);
++	if (err < 0) {
++	decoder_error (&data->error, ERROR_FATAL, 0,
++	               "Failed to copy codec context");
++		goto end;
++	}
+ 
+ 	data->codec = avcodec_find_decoder (data->enc->codec_id);
+ 	if (!data->codec) {
+@@ -1019,7 +1032,6 @@ static void *ffmpeg_open (const char *file)
+ 		decoder_error (&data->error, ERROR_FATAL, 0,
+ 		               "Unsupported sample size!");
+ #endif
+-		avcodec_close (data->enc);
+ 		goto end;
+ 	}
+ 
+@@ -1034,7 +1046,6 @@ static void *ffmpeg_open (const char *file)
+ 		ffmpeg_log_repeats (NULL);
+ 		decoder_error (&data->error, ERROR_FATAL, 0,
+ 		                   "Broken WAV file; use W64!");
+-		avcodec_close (data->enc);
+ 		goto end;
+ 	}
+ 
+@@ -1056,6 +1067,12 @@ static void *ffmpeg_open (const char *file)
+ 	return data;
+ 
+ end:
++#ifdef HAVE_AVCODEC_FREE_CONTEXT
++	avcodec_free_context (&data->enc);
++#else
++	avcodec_close (data->enc);
++	av_freep (&data->enc);
++#endif
+ #ifdef HAVE_AVFORMAT_CLOSE_INPUT
+ 	avformat_close_input (&data->ic);
+ #else
+@@ -1403,7 +1420,7 @@ static bool seek_in_stream (struct ffmpeg_data *data, int sec)
+ 		return false;
+ 	}
+ 
+-	avcodec_flush_buffers (data->stream->codec);
++	avcodec_flush_buffers (data->enc);
+ 
+ 	return true;
+ }
+@@ -1526,7 +1543,12 @@ static void ffmpeg_close (void *prv_data)
+ 	struct ffmpeg_data *data = (struct ffmpeg_data *)prv_data;
+ 
+ 	if (data->okay) {
++#ifdef HAVE_AVCODEC_FREE_CONTEXT
++		avcodec_free_context (&data->enc);
++#else
+ 		avcodec_close (data->enc);
++		av_freep (&data->enc);
++#endif
+ #ifdef HAVE_AVFORMAT_CLOSE_INPUT
+ 		avformat_close_input (&data->ic);
+ #else
+diff --git a/decoder_plugins/ffmpeg/ffmpeg.m4 b/decoder_plugins/ffmpeg/ffmpeg.m4
+index 91e9360..2c60d4a 100644
+--- a/decoder_plugins/ffmpeg/ffmpeg.m4
++++ b/decoder_plugins/ffmpeg/ffmpeg.m4
+@@ -137,6 +137,9 @@ then
+ 		AC_SEARCH_LIBS(avcodec_free_frame, avcodec,
+ 			[AC_DEFINE([HAVE_AVCODEC_FREE_FRAME], 1,
+ 				[Define to 1 if you have the `avcodec_free_frame' function.])])
++		AC_SEARCH_LIBS(avcodec_free_context, avcodec,
++			[AC_DEFINE([HAVE_AVCODEC_FREE_CONTEXT], 1,
++				[Define to 1 if you have the `avcodec_free_context' function.])])
+ 		AC_CHECK_DECLS([CODEC_ID_PCM_S8], , ,
+ 		                 [#include <libavcodec/avcodec.h>])
+ 		AC_CHECK_DECLS([CODEC_ID_PCM_S8_PLANAR], , ,

--- a/moc/01-codec.patch
+++ b/moc/01-codec.patch
@@ -1,0 +1,106 @@
+Author: John Fitzgerald <mocmaint@daper.net>
+Date:   Mon May 8 17:40:27 2017 +1200
+
+    Maint: Address FFmpeg/LibAV's deprecation of AVStream.codec.
+    
+    There is no guidence in the documentation of a migration path
+    for AVStream.codec and it's obvious that the FFmpeg maintainers
+    do not have a solution either.  The most consistant narrative
+    which can be pieced together from the scattered clues is that
+    the management of the AVCodecContext struct should be brought
+    in-house and MOC should create and manage its own AVCodecContext
+    struct in all cases.
+    
+    This may break when the API goes off on yet another tangent.
+
+diff --git a/decoder_plugins/ffmpeg/ffmpeg.c b/decoder_plugins/ffmpeg/ffmpeg.c
+index ba9def4..ad4f623 100644
+--- a/decoder_plugins/ffmpeg/ffmpeg.c
++++ b/decoder_plugins/ffmpeg/ffmpeg.c
+@@ -673,7 +673,20 @@ static void *ffmpeg_open_internal (struct ffmpeg_data *data)
+ 	}
+ 
+ 	data->stream = data->ic->streams[audio_ix];
+-	data->enc = data->stream->codec;
++
++	data->enc = avcodec_alloc_context3 (NULL);
++	if (!data->enc) {
++		decoder_error (&data->error, ERROR_FATAL, 0,
++		               "Failed to allocate codec context");
++		goto end;
++	}
++
++	err = avcodec_copy_context (data->enc, data->stream->codec);
++	if (err < 0) {
++		decoder_error (&data->error, ERROR_FATAL, 0,
++		               "Failed to copy codec context");
++		goto end;
++	}
+ 
+ 	data->codec = avcodec_find_decoder (data->enc->codec_id);
+ 	if (!data->codec) {
+@@ -719,7 +732,6 @@ static void *ffmpeg_open_internal (struct ffmpeg_data *data)
+ 		decoder_error (&data->error, ERROR_FATAL, 0,
+ 		               "Cannot get sample size from unknown sample format: %s",
+ 		               av_get_sample_fmt_name (data->enc->sample_fmt));
+-		avcodec_close (data->enc);
+ 		goto end;
+ 	}
+ 
+@@ -734,7 +746,6 @@ static void *ffmpeg_open_internal (struct ffmpeg_data *data)
+ 		ffmpeg_log_repeats (NULL);
+ 		decoder_error (&data->error, ERROR_FATAL, 0,
+ 		                   "Broken WAV file; use W64!");
+-		avcodec_close (data->enc);
+ 		goto end;
+ 	}
+ 
+@@ -750,6 +761,12 @@ static void *ffmpeg_open_internal (struct ffmpeg_data *data)
+ 	return data;
+ 
+ end:
++#ifdef HAVE_AVCODEC_FREE_CONTEXT
++	avcodec_free_context (&data->enc);
++#else
++	avcodec_close (data->enc);
++	av_freep (&data->enc);
++#endif
+ 	avformat_close_input (&data->ic);
+ 	ffmpeg_log_repeats (NULL);
+ 	return data;
+@@ -1079,7 +1096,7 @@ static bool seek_in_stream (struct ffmpeg_data *data, int sec)
+ 		return false;
+ 	}
+ 
+-	avcodec_flush_buffers (data->stream->codec);
++	avcodec_flush_buffers (data->enc);
+ 
+ 	return true;
+ }
+@@ -1210,7 +1227,12 @@ static void ffmpeg_close (void *prv_data)
+ 	}
+ 
+ 	if (data->okay) {
++#ifdef HAVE_AVCODEC_FREE_CONTEXT
++		avcodec_free_context (&data->enc);
++#else
+ 		avcodec_close (data->enc);
++		av_freep (&data->enc);
++#endif
+ 		avformat_close_input (&data->ic);
+ 		free_remain_buf (data);
+ 	}
+diff --git a/decoder_plugins/ffmpeg/ffmpeg.m4 b/decoder_plugins/ffmpeg/ffmpeg.m4
+index 2e7a903..8b9210f 100644
+--- a/decoder_plugins/ffmpeg/ffmpeg.m4
++++ b/decoder_plugins/ffmpeg/ffmpeg.m4
+@@ -51,6 +51,9 @@ then
+ 		AC_SEARCH_LIBS(av_frame_alloc, avutil,
+ 			[AC_DEFINE([HAVE_AV_FRAME_FNS], 1,
+ 				[Define to 1 if you have the `av_frame_*' functions.])])
++		AC_SEARCH_LIBS(avcodec_free_context, avcodec,
++			[AC_DEFINE([HAVE_AVCODEC_FREE_CONTEXT], 1,
++				[Define to 1 if you have the `avcodec_free_context' function.])])
+         CPPFLAGS="$save_CPPFLAGS"
+         CFLAGS="$save_CFLAGS"
+         LIBS="$save_LIBS"

--- a/moc/02-codecpar-2.5.2.patch
+++ b/moc/02-codecpar-2.5.2.patch
@@ -1,0 +1,58 @@
+diff --git a/decoder_plugins/ffmpeg/ffmpeg.c b/decoder_plugins/ffmpeg/ffmpeg.c
+index f1db552..93ac7e7 100644
+--- a/decoder_plugins/ffmpeg/ffmpeg.c
++++ b/decoder_plugins/ffmpeg/ffmpeg.c
+@@ -309,11 +309,15 @@ static unsigned int find_first_audio (AVFormatContext *ic)
+ 	assert (ic);
+ 
+ 	for (result = 0; result < ic->nb_streams; result += 1) {
+-#if LIBAVUTIL_VERSION_INT < AV_VERSION_INT(50,15,1)
+-		if (ic->streams[result]->codec->codec_type == CODEC_TYPE_AUDIO)
++		enum AVMediaType codec_type;
++
++#ifdef HAVE_STRUCT_AVSTREAM_CODECPAR
++		codec_type = ic->streams[result]->codecpar->codec_type;
+ #else
+-		if (ic->streams[result]->codec->codec_type == AVMEDIA_TYPE_AUDIO)
++		codec_type = ic->streams[result]->codec->codec_type;
+ #endif
++
++		if (codec_type == AVMEDIA_TYPE_AUDIO)
+ 		{
+ 			break;
+ 		}
+@@ -973,12 +977,21 @@ static void *ffmpeg_open (const char *file)
+ 		goto end;
+ 	}
+ 
++#ifdef HAVE_STRUCT_AVSTREAM_CODECPAR
++	err = avcodec_parameters_to_context (data->enc, data->stream->codecpar);
++	if (err < 0) {
++		decoder_error (&data->error, ERROR_FATAL, 0,
++		               "Failed to copy codec parameters");
++		goto end;
++	}
++#else
+ 	err = avcodec_copy_context (data->enc, data->stream->codec);
+ 	if (err < 0) {
+ 	decoder_error (&data->error, ERROR_FATAL, 0,
+ 	               "Failed to copy codec context");
+ 		goto end;
+ 	}
++#endif
+ 
+ 	data->codec = avcodec_find_decoder (data->enc->codec_id);
+ 	if (!data->codec) {
+diff --git a/decoder_plugins/ffmpeg/ffmpeg.m4 b/decoder_plugins/ffmpeg/ffmpeg.m4
+index 2c60d4a..cf818d3 100644
+--- a/decoder_plugins/ffmpeg/ffmpeg.m4
++++ b/decoder_plugins/ffmpeg/ffmpeg.m4
+@@ -140,6 +140,8 @@ then
+ 		AC_SEARCH_LIBS(avcodec_free_context, avcodec,
+ 			[AC_DEFINE([HAVE_AVCODEC_FREE_CONTEXT], 1,
+ 				[Define to 1 if you have the `avcodec_free_context' function.])])
++		AC_CHECK_MEMBERS([struct AVStream.codecpar], [], [],
++	                     [#include <libavformat/avformat.h>])
+ 		AC_CHECK_DECLS([CODEC_ID_PCM_S8], , ,
+ 		                 [#include <libavcodec/avcodec.h>])
+ 		AC_CHECK_DECLS([CODEC_ID_PCM_S8_PLANAR], , ,

--- a/moc/02-codecpar.patch
+++ b/moc/02-codecpar.patch
@@ -1,0 +1,61 @@
+Author: John Fitzgerald <mocmaint@daper.net>
+Date:   Mon May 8 17:41:37 2017 +1200
+
+    Maint: Use new AVCodecContext.codecpar field.
+
+diff --git a/decoder_plugins/ffmpeg/ffmpeg.c b/decoder_plugins/ffmpeg/ffmpeg.c
+index ad4f623..26feaf0 100644
+--- a/decoder_plugins/ffmpeg/ffmpeg.c
++++ b/decoder_plugins/ffmpeg/ffmpeg.c
+@@ -195,7 +195,15 @@ static unsigned int find_first_audio (AVFormatContext *ic)
+ 	assert (ic);
+ 
+ 	for (result = 0; result < ic->nb_streams; result += 1) {
+-		if (ic->streams[result]->codec->codec_type == AVMEDIA_TYPE_AUDIO)
++		enum AVMediaType codec_type;
++
++#ifdef HAVE_STRUCT_AVSTREAM_CODECPAR
++		codec_type = ic->streams[result]->codecpar->codec_type;
++#else
++		codec_type = ic->streams[result]->codec->codec_type;
++#endif
++
++		if (codec_type == AVMEDIA_TYPE_AUDIO)
+ 			break;
+ 	}
+ 
+@@ -681,12 +689,21 @@ static void *ffmpeg_open_internal (struct ffmpeg_data *data)
+ 		goto end;
+ 	}
+ 
++#ifdef HAVE_STRUCT_AVSTREAM_CODECPAR
++	err = avcodec_parameters_to_context (data->enc, data->stream->codecpar);
++	if (err < 0) {
++		decoder_error (&data->error, ERROR_FATAL, 0,
++		               "Failed to copy codec parameters");
++		goto end;
++	}
++#else
+ 	err = avcodec_copy_context (data->enc, data->stream->codec);
+ 	if (err < 0) {
+ 		decoder_error (&data->error, ERROR_FATAL, 0,
+ 		               "Failed to copy codec context");
+ 		goto end;
+ 	}
++#endif
+ 
+ 	data->codec = avcodec_find_decoder (data->enc->codec_id);
+ 	if (!data->codec) {
+diff --git a/decoder_plugins/ffmpeg/ffmpeg.m4 b/decoder_plugins/ffmpeg/ffmpeg.m4
+index 8b9210f..de68d6e 100644
+--- a/decoder_plugins/ffmpeg/ffmpeg.m4
++++ b/decoder_plugins/ffmpeg/ffmpeg.m4
+@@ -54,6 +54,8 @@ then
+ 		AC_SEARCH_LIBS(avcodec_free_context, avcodec,
+ 			[AC_DEFINE([HAVE_AVCODEC_FREE_CONTEXT], 1,
+ 				[Define to 1 if you have the `avcodec_free_context' function.])])
++		AC_CHECK_MEMBERS([struct AVStream.codecpar], [], [],
++	                     [#include <libavformat/avformat.h>])
+         CPPFLAGS="$save_CPPFLAGS"
+         CFLAGS="$save_CFLAGS"
+         LIBS="$save_LIBS"

--- a/moc/03-defines-2.5.2.patch
+++ b/moc/03-defines-2.5.2.patch
@@ -1,0 +1,50 @@
+diff --git a/decoder_plugins/ffmpeg/ffmpeg.c b/decoder_plugins/ffmpeg/ffmpeg.c
+index 93ac7e7..4ea635a 100644
+--- a/decoder_plugins/ffmpeg/ffmpeg.c
++++ b/decoder_plugins/ffmpeg/ffmpeg.c
+@@ -96,6 +96,16 @@ GCC_DIAG_ON(deprecated-declarations)
+ #include "files.h"
+ #include "lists.h"
+ 
++#ifndef AV_CODEC_CAP_DELAY
++# define AV_CODEC_CAP_DELAY CODEC_CAP_DELAY
++# define AV_CODEC_CAP_EXPERIMENTAL CODEC_CAP_EXPERIMENTAL
++# define AV_CODEC_CAP_TRUNCATED CODEC_CAP_TRUNCATED
++#endif
++
++#ifndef AV_CODEC_FLAG_TRUNCATED
++# define AV_CODEC_FLAG_TRUNCATED CODEC_FLAG_TRUNCATED
++#endif
++
+ /* Set SEEK_IN_DECODER to 1 if you'd prefer seeking to be delay until
+  * the next time ffmpeg_decode() is called.  This will provide seeking
+  * in formats for which FFmpeg falsely reports seek errors, but could
+@@ -1010,7 +1020,7 @@ static void *ffmpeg_open (const char *file)
+ 	 * FFmpeg/LibAV in use.  For some versions this will be caught in
+ 	 * *_find_stream_info() above and misreported as an unfound codec
+ 	 * parameters error. */
+-	if (data->codec->capabilities & CODEC_CAP_EXPERIMENTAL) {
++	if (data->codec->capabilities & AV_CODEC_CAP_EXPERIMENTAL) {
+ 		decoder_error (&data->error, ERROR_FATAL, 0,
+ 				"The codec is experimental and may damage MOC: %s",
+ 				data->codec->name);
+@@ -1019,8 +1029,8 @@ static void *ffmpeg_open (const char *file)
+ #endif
+ 
+ 	set_downmixing (data);
+-	if (data->codec->capabilities & CODEC_CAP_TRUNCATED)
+-		data->enc->flags |= CODEC_FLAG_TRUNCATED;
++	if (data->codec->capabilities & AV_CODEC_CAP_TRUNCATED)
++		data->enc->flags |= AV_CODEC_FLAG_TRUNCATED;
+ 
+ #ifdef HAVE_AVCODEC_OPEN2
+ 	if (avcodec_open2 (data->enc, data->codec, NULL) < 0)
+@@ -1050,7 +1060,7 @@ static void *ffmpeg_open (const char *file)
+ 
+ 	data->sample_width = sfmt_Bps (data->fmt);
+ 
+-	if (data->codec->capabilities & CODEC_CAP_DELAY)
++	if (data->codec->capabilities & AV_CODEC_CAP_DELAY)
+ 		data->delay = true;
+ 	data->seek_broken = is_seek_broken (data);
+ 	data->timing_broken = is_timing_broken (data->ic);

--- a/moc/03-defines.patch
+++ b/moc/03-defines.patch
@@ -1,0 +1,55 @@
+Author: John Fitzgerald <mocmaint@daper.net>
+Date:   Wed May 10 14:43:14 2017 +1200
+
+    Maint: Migrate to AV_-prefixed #defines.
+
+diff --git a/decoder_plugins/ffmpeg/ffmpeg.c b/decoder_plugins/ffmpeg/ffmpeg.c
+index 26feaf0..9ffd289 100644
+--- a/decoder_plugins/ffmpeg/ffmpeg.c
++++ b/decoder_plugins/ffmpeg/ffmpeg.c
+@@ -55,6 +55,16 @@
+ #include "files.h"
+ #include "lists.h"
+ 
++#ifndef AV_CODEC_CAP_DELAY
++# define AV_CODEC_CAP_DELAY CODEC_CAP_DELAY
++# define AV_CODEC_CAP_EXPERIMENTAL CODEC_CAP_EXPERIMENTAL
++# define AV_CODEC_CAP_TRUNCATED CODEC_CAP_TRUNCATED
++#endif
++
++#ifndef AV_CODEC_FLAG_TRUNCATED
++# define AV_CODEC_FLAG_TRUNCATED CODEC_FLAG_TRUNCATED
++#endif
++
+ /* Set SEEK_IN_DECODER to 1 if you'd prefer seeking to be delay until
+  * the next time ffmpeg_decode() is called.  This will provide seeking
+  * in formats for which FFmpeg falsely reports seek errors, but could
+@@ -727,7 +737,7 @@ static void *ffmpeg_open_internal (struct ffmpeg_data *data)
+ 	 * FFmpeg/LibAV in use.  For some versions this will be caught in
+ 	 * *_find_stream_info() above and misreported as an unfound codec
+ 	 * parameters error. */
+-	if (data->codec->capabilities & CODEC_CAP_EXPERIMENTAL) {
++	if (data->codec->capabilities & AV_CODEC_CAP_EXPERIMENTAL) {
+ 		decoder_error (&data->error, ERROR_FATAL, 0,
+ 				"The codec is experimental and may damage MOC: %s",
+ 				data->codec->name);
+@@ -735,8 +745,8 @@ static void *ffmpeg_open_internal (struct ffmpeg_data *data)
+ 	}
+ 
+ 	set_downmixing (data);
+-	if (data->codec->capabilities & CODEC_CAP_TRUNCATED)
+-		data->enc->flags |= CODEC_FLAG_TRUNCATED;
++	if (data->codec->capabilities & AV_CODEC_CAP_TRUNCATED)
++		data->enc->flags |= AV_CODEC_FLAG_TRUNCATED;
+ 
+ 	if (avcodec_open2 (data->enc, data->codec, NULL) < 0)
+ 	{
+@@ -754,7 +764,7 @@ static void *ffmpeg_open_internal (struct ffmpeg_data *data)
+ 
+ 	data->sample_width = sfmt_Bps (data->fmt);
+ 
+-	if (data->codec->capabilities & CODEC_CAP_DELAY)
++	if (data->codec->capabilities & AV_CODEC_CAP_DELAY)
+ 		data->delay = true;
+ 	data->seek_broken = is_seek_broken (data);
+ 	data->timing_broken = is_timing_broken (data->ic);

--- a/moc/04-lockmgr-2.5.2.patch
+++ b/moc/04-lockmgr-2.5.2.patch
@@ -1,0 +1,44 @@
+diff --git a/decoder_plugins/ffmpeg/ffmpeg.c b/decoder_plugins/ffmpeg/ffmpeg.c
+index 4ea635a..f26afab 100644
+--- a/decoder_plugins/ffmpeg/ffmpeg.c
++++ b/decoder_plugins/ffmpeg/ffmpeg.c
+@@ -430,7 +430,7 @@ static void load_video_extns (lists_t_strs *list)
+ }
+ 
+ /* Handle FFmpeg's locking requirements. */
+-#ifdef HAVE_LOCKMGR_REGISTER
++#if HAVE_LIBAV || LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58,9,100)
+ static int locking_cb (void **mutex, enum AVLockOp op)
+ {
+ 	int result;
+@@ -514,10 +514,6 @@ static bool is_timing_broken (AVFormatContext *ic)
+ 
+ static void ffmpeg_init ()
+ {
+-#ifdef HAVE_LOCKMGR_REGISTER
+-	int rc;
+-#endif
+-
+ #ifdef DEBUG
+ 	av_log_set_level (AV_LOG_INFO);
+ #else
+@@ -531,8 +527,8 @@ static void ffmpeg_init ()
+ 	load_audio_extns (supported_extns);
+ 	load_video_extns (supported_extns);
+ 
+-#ifdef HAVE_LOCKMGR_REGISTER
+-	rc = av_lockmgr_register (locking_cb);
++#if HAVE_LIBAV || LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58,9,100)
++	int rc = av_lockmgr_register (locking_cb);
+ 	if (rc < 0)
+ 		fatal ("Lock manager initialisation failed");
+ #endif
+@@ -540,7 +536,7 @@ static void ffmpeg_init ()
+ 
+ static void ffmpeg_destroy ()
+ {
+-#ifdef HAVE_LOCKMGR_REGISTER
++#if HAVE_LIBAV || LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58,9,100)
+ 	av_lockmgr_register (NULL);
+ #endif
+ 

--- a/moc/04-lockmgr.patch
+++ b/moc/04-lockmgr.patch
@@ -1,0 +1,58 @@
+Author: John Fitzgerald <mocmaint@daper.net>
+Date:   Sun Jan 21 20:09:22 2018 +1300
+
+    Maint: A client-provided FFmpeg lock manager is no longer required.
+
+diff --git a/decoder_plugins/ffmpeg/ffmpeg.c b/decoder_plugins/ffmpeg/ffmpeg.c
+index 9ffd289..304d3ce 100644
+--- a/decoder_plugins/ffmpeg/ffmpeg.c
++++ b/decoder_plugins/ffmpeg/ffmpeg.c
+@@ -310,6 +310,7 @@ static void load_video_extns (lists_t_strs *list)
+ }
+ 
+ /* Handle FFmpeg's locking requirements. */
++#if HAVE_LIBAV || LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58,9,100)
+ static int locking_cb (void **mutex, enum AVLockOp op)
+ {
+ 	int result;
+@@ -340,6 +341,7 @@ static int locking_cb (void **mutex, enum AVLockOp op)
+ 
+ 	return result;
+ }
++#endif
+ 
+ /* Here we attempt to determine if FFmpeg/LibAV has trashed the 'duration'
+  * and 'bit_rate' fields in AVFormatContext for large files.  Determining
+@@ -384,8 +386,6 @@ static bool is_timing_broken (AVFormatContext *ic)
+ 
+ static void ffmpeg_init ()
+ {
+-	int rc;
+-
+ #ifndef NDEBUG
+ # ifdef DEBUG
+ 	av_log_set_level (AV_LOG_INFO);
+@@ -401,18 +401,22 @@ static void ffmpeg_init ()
+ 	load_audio_extns (supported_extns);
+ 	load_video_extns (supported_extns);
+ 
+-	rc = av_lockmgr_register (locking_cb);
++#if HAVE_LIBAV || LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58,9,100)
++	int rc = av_lockmgr_register (locking_cb);
+ 	if (rc < 0) {
+ 		char buf[128];
+ 
+ 		av_strerror (rc, buf, sizeof (buf));
+ 		fatal ("Lock manager initialisation failed: %s", buf);
+ 	}
++#endif
+ }
+ 
+ static void ffmpeg_destroy ()
+ {
++#if HAVE_LIBAV || LIBAVCODEC_VERSION_INT < AV_VERSION_INT(58,9,100)
+ 	av_lockmgr_register (NULL);
++#endif
+ 
+ 	av_log_set_level (AV_LOG_QUIET);
+ 	ffmpeg_log_repeats (NULL);

--- a/moc/05-audio4-2.5.2.patch
+++ b/moc/05-audio4-2.5.2.patch
@@ -1,0 +1,39 @@
+diff --git a/decoder_plugins/ffmpeg/ffmpeg.c b/decoder_plugins/ffmpeg/ffmpeg.c
+index f26afab..834967f 100644
+--- a/decoder_plugins/ffmpeg/ffmpeg.c
++++ b/decoder_plugins/ffmpeg/ffmpeg.c
+@@ -1246,6 +1246,9 @@ static AVPacket *get_packet (struct ffmpeg_data *data)
+ 	return NULL;
+ }
+ 
++#ifdef HAVE_AVCODEC_RECEIVE_FRAME
++  GCC_DIAG_OFF(deprecated-declarations)
++#endif
+ #ifndef HAVE_AVCODEC_DECODE_AUDIO4
+ /* Decode samples from packet data using pre-avcodec_decode_audio4(). */
+ static int decode_packet (struct ffmpeg_data *data, AVPacket *pkt,
+@@ -1396,6 +1399,10 @@ static int decode_packet (struct ffmpeg_data *data, AVPacket *pkt,
+ 	return filled;
+ }
+ #endif
++#ifdef HAVE_AVCODEC_RECEIVE_FRAME
++  GCC_DIAG_ON(deprecated-declarations)
++#endif
++
+ 
+ #if SEEK_IN_DECODER
+ static bool seek_in_stream (struct ffmpeg_data *data)
+diff --git a/decoder_plugins/ffmpeg/ffmpeg.m4 b/decoder_plugins/ffmpeg/ffmpeg.m4
+index cf818d3..21f6d00 100644
+--- a/decoder_plugins/ffmpeg/ffmpeg.m4
++++ b/decoder_plugins/ffmpeg/ffmpeg.m4
+@@ -142,6 +142,9 @@ then
+ 				[Define to 1 if you have the `avcodec_free_context' function.])])
+ 		AC_CHECK_MEMBERS([struct AVStream.codecpar], [], [],
+ 	                     [#include <libavformat/avformat.h>])
++		AC_SEARCH_LIBS(avcodec_receive_frame, avcodec,
++			[AC_DEFINE([HAVE_AVCODEC_RECEIVE_FRAME], 1,
++				[Define to 1 if you have the `avcodec_receive_frame' function.])])
+ 		AC_CHECK_DECLS([CODEC_ID_PCM_S8], , ,
+ 		                 [#include <libavcodec/avcodec.h>])
+ 		AC_CHECK_DECLS([CODEC_ID_PCM_S8_PLANAR], , ,

--- a/moc/05-audio4.patch
+++ b/moc/05-audio4.patch
@@ -1,0 +1,49 @@
+Author: John Fitzgerald <mocmaint@daper.net>
+Date:   Mon May 8 17:42:53 2017 +1200
+
+    Maint: Squelch avcodec_decode_audio4() deprecation.
+    
+    We will address this later as it requires some renovations, but avoid
+    bug reports for now.
+    
+    We know about it, we'll suppress it, we'll fix it... eventually.
+
+diff --git a/decoder_plugins/ffmpeg/ffmpeg.c b/decoder_plugins/ffmpeg/ffmpeg.c
+index 304d3ce..39012ae 100644
+--- a/decoder_plugins/ffmpeg/ffmpeg.c
++++ b/decoder_plugins/ffmpeg/ffmpeg.c
+@@ -1009,6 +1009,9 @@ static AVPacket *get_packet (struct ffmpeg_data *data)
+ }
+ 
+ /* Decode samples from packet data. */
++#ifdef HAVE_AVCODEC_RECEIVE_FRAME
++  GCC_DIAG_OFF(deprecated-declarations)
++#endif
+ static int decode_packet (struct ffmpeg_data *data, AVPacket *pkt,
+                           char *buf, int buf_len)
+ {
+@@ -1085,6 +1088,10 @@ static int decode_packet (struct ffmpeg_data *data, AVPacket *pkt,
+ 
+ 	return filled;
+ }
++#ifdef HAVE_AVCODEC_RECEIVE_FRAME
++  GCC_DIAG_ON(deprecated-declarations)
++#endif
++
+ 
+ #if SEEK_IN_DECODER
+ static bool seek_in_stream (struct ffmpeg_data *data)
+diff --git a/decoder_plugins/ffmpeg/ffmpeg.m4 b/decoder_plugins/ffmpeg/ffmpeg.m4
+index de68d6e..4028ec2 100644
+--- a/decoder_plugins/ffmpeg/ffmpeg.m4
++++ b/decoder_plugins/ffmpeg/ffmpeg.m4
+@@ -56,6 +56,9 @@ then
+ 				[Define to 1 if you have the `avcodec_free_context' function.])])
+ 		AC_CHECK_MEMBERS([struct AVStream.codecpar], [], [],
+ 	                     [#include <libavformat/avformat.h>])
++		AC_SEARCH_LIBS(avcodec_receive_frame, avcodec,
++			[AC_DEFINE([HAVE_AVCODEC_RECEIVE_FRAME], 1,
++				[Define to 1 if you have the `avcodec_receive_frame' function.])])
+         CPPFLAGS="$save_CPPFLAGS"
+         CFLAGS="$save_CFLAGS"
+         LIBS="$save_LIBS"


### PR DESCRIPTION
For 2.6-alpha3, John Fitzgerald (upstream) provided via email

01-codec.patch
02-codecpar.patch
03-defines.patch
04-lockmgr.patch
05-audio4.patch

I have backported those to 2.5.2 as

01-codec-2.5.2.patch
02-codecpar-2.5.2.patch
03-defines-2.5.2.patch
04-lockmgr-2.5.2.patch
05-audio4-2.5.2.patch