### PR TITLE
Add pointer comparison patch for bochs

### DIFF
--- a/bochs/pointer_comp.patch
+++ b/bochs/pointer_comp.patch
@@ -1,5 +1,5 @@
 --- config.cc   2018-06-01 22:18:19.000000000 -0500
-+++ config1.cc  2018-06-01 22:18:02.000000000 -0500
++++ config.cc  2018-06-01 22:18:02.000000000 -0500
 @@ -3258,7 +3258,7 @@
 
      fprintf(fp, ", biosdetect=%s", SIM->get_param_enum("biosdetect", base)->get_selected());

--- a/bochs/pointer_comp.patch
+++ b/bochs/pointer_comp.patch
@@ -1,5 +1,6 @@
---- config.cc   2018-06-01 22:18:19.000000000 -0500
-+++ config.cc  2018-06-01 22:18:02.000000000 -0500
+diff -pur a/config.cc b/config.cc
+--- a/config.cc   2018-06-01 22:18:19.000000000 -0500
++++ b/config.cc   2018-06-01 22:18:02.000000000 -0500
 @@ -3258,7 +3258,7 @@
 
      fprintf(fp, ", biosdetect=%s", SIM->get_param_enum("biosdetect", base)->get_selected());

--- a/bochs/pointer_comp.patch
+++ b/bochs/pointer_comp.patch
@@ -1,0 +1,10 @@
+--- config.cc   2018-06-01 22:18:19.000000000 -0500
++++ config1.cc  2018-06-01 22:18:02.000000000 -0500
+@@ -3258,7 +3258,7 @@
+
+     fprintf(fp, ", biosdetect=%s", SIM->get_param_enum("biosdetect", base)->get_selected());
+
+-    if (SIM->get_param_string("model", base)->getptr()>0) {
++    if (SIM->get_param_string("model", base)->getptr() != 0) {
+         fprintf(fp, ", model=\"%s\"", SIM->get_param_string("model", base)->getptr());
+     }


### PR DESCRIPTION
This fixes a compile error on newer versions of clang/llvm:

```
config.cc:3261:55: error: ordered comparison between pointer and zero ('char *' and 'int')
    if (SIM->get_param_string("model", base)->getptr()>0) {
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
1 error generated.
```