### PR TITLE
Backport go 1.10/1.11 load commands patch

### DIFF
--- a/go@1.9/go_19_load_commands.patch
+++ b/go@1.9/go_19_load_commands.patch
@@ -1,0 +1,115 @@
+From fbdde43b561ef934f75a30f9f371e7fbac45bd7e Mon Sep 17 00:00:00 2001
+From: Misty De Meo <mistydemeo@gmail.com>
+Date: Fri, 15 Jun 2018 11:25:57 -0700
+Subject: [PATCH] From 1a92cdbfc10e0c66f2e015264a39159c055a5c15 Mon Sep 17
+ 00:00:00 2001 From: Misty De Meo <mistydemeo@gmail.com> Date: Fri, 15 Jun
+ 2018 18:15:50 +0000 Subject: [PATCH] ld/macho: add all missing load commands
+
+The ld/macho code currently understands a subset of the mach-o load
+commands. I've encountered one of these in the wild in a Go-produced
+binary, which tripped up the Go linker because its switch statement
+expects its list of load commands to be exhaustive; the rest I've
+added for the sake of completion.
+
+The ruby-macho library is a good non-Darwin header resource for these:
+https://github.com/homebrew/ruby-macho
+
+Fixes #25908
+---
+ .../link/internal/ld/macho_combine_dwarf.go   | 73 +++++++++++++------
+ 1 file changed, 52 insertions(+), 21 deletions(-)
+
+diff --git a/src/cmd/link/internal/ld/macho_combine_dwarf.go b/src/cmd/link/internal/ld/macho_combine_dwarf.go
+index 8c6c4a86ac..515f798a9c 100644
+--- a/src/cmd/link/internal/ld/macho_combine_dwarf.go
++++ b/src/cmd/link/internal/ld/macho_combine_dwarf.go
+@@ -21,26 +21,57 @@ var dwarfaddr, linkaddr int64
+ var linkoffset uint32
+ 
+ const (
+-	LC_ID_DYLIB             = 0xd
+-	LC_LOAD_DYLINKER        = 0xe
+-	LC_PREBOUND_DYLIB       = 0x10
+-	LC_LOAD_WEAK_DYLIB      = 0x18
+-	LC_UUID                 = 0x1b
+-	LC_RPATH                = 0x8000001c
+-	LC_CODE_SIGNATURE       = 0x1d
+-	LC_SEGMENT_SPLIT_INFO   = 0x1e
+-	LC_REEXPORT_DYLIB       = 0x8000001f
+-	LC_ENCRYPTION_INFO      = 0x21
+-	LC_DYLD_INFO            = 0x22
+-	LC_DYLD_INFO_ONLY       = 0x80000022
+-	LC_VERSION_MIN_MACOSX   = 0x24
+-	LC_VERSION_MIN_IPHONEOS = 0x25
+-	LC_FUNCTION_STARTS      = 0x26
+-	LC_MAIN                 = 0x80000028
+-	LC_DATA_IN_CODE         = 0x29
+-	LC_SOURCE_VERSION       = 0x2A
+-	LC_DYLIB_CODE_SIGN_DRS  = 0x2B
+-	LC_ENCRYPTION_INFO_64   = 0x2C
++	LC_SEGMENT                  = 0x1
++	LC_SYMTAB                   = 0x2
++	LC_SYMSEG                   = 0x3
++	LC_THREAD                   = 0x4
++	LC_UNIXTHREAD               = 0x5
++	LC_LOADFVMLIB               = 0x6
++	LC_IDFVMLIB                 = 0x7
++	LC_IDENT                    = 0x8
++	LC_FVMFILE                  = 0x9
++	LC_PREPAGE                  = 0xa
++	LC_DYSYMTAB                 = 0xb
++	LC_LOAD_DYLIB               = 0xc
++	LC_ID_DYLIB                 = 0xd
++	LC_LOAD_DYLINKER            = 0xe
++	LC_ID_DYLINKER              = 0xf
++	LC_PREBOUND_DYLIB           = 0x10
++	LC_ROUTINES                 = 0x11
++	LC_SUB_FRAMEWORK            = 0x12
++	LC_SUB_UMBRELLA             = 0x13
++	LC_SUB_CLIENT               = 0x14
++	LC_SUB_LIBRARY              = 0x15
++	LC_TWOLEVEL_HINTS           = 0x16
++	LC_PREBIND_CKSUM            = 0x17
++	LC_LOAD_WEAK_DYLIB          = 0x18
++	LC_SEGMENT_64               = 0x19
++	LC_ROUTINES_64              = 0x1a
++	LC_UUID                     = 0x1b
++	LC_RPATH                    = 0x8000001c
++	LC_CODE_SIGNATURE           = 0x1d
++	LC_SEGMENT_SPLIT_INFO       = 0x1e
++	LC_REEXPORT_DYLIB           = 0x8000001f
++	LC_LAZY_LOAD_DYLIB          = 0x20
++	LC_ENCRYPTION_INFO          = 0x21
++	LC_DYLD_INFO                = 0x22
++	LC_DYLD_INFO_ONLY           = 0x80000022
++	LC_LOAD_UPWARD_DYLIB        = 0x80000023
++	LC_VERSION_MIN_MACOSX       = 0x24
++	LC_VERSION_MIN_IPHONEOS     = 0x25
++	LC_FUNCTION_STARTS          = 0x26
++	LC_DYLD_ENVIRONMENT         = 0x27
++	LC_MAIN                     = 0x80000028
++	LC_DATA_IN_CODE             = 0x29
++	LC_SOURCE_VERSION           = 0x2A
++	LC_DYLIB_CODE_SIGN_DRS      = 0x2B
++	LC_ENCRYPTION_INFO_64       = 0x2C
++	LC_LINKER_OPTION            = 0x2D
++	LC_LINKER_OPTIMIZATION_HINT = 0x2E
++	LC_VERSION_MIN_TVOS         = 0x2F
++	LC_VERSION_MIN_WATCHOS      = 0x30
++	LC_VERSION_NOTE             = 0x31
++	LC_BUILD_VERSION            = 0x32
+ 
+ 	pageAlign = 12 // 4096 = 1 << 12
+ )
+@@ -242,7 +273,7 @@ func machoCombineDwarf(inexe, dsym, outexe string) error {
+ 			err = machoUpdateLoadCommand(reader, &linkEditDataCmd{}, "DataOff")
+ 		case LC_ENCRYPTION_INFO, LC_ENCRYPTION_INFO_64:
+ 			err = machoUpdateLoadCommand(reader, &encryptionInfoCmd{}, "CryptOff")
+-		case macho.LoadCmdDylib, macho.LoadCmdThread, macho.LoadCmdUnixThread, LC_PREBOUND_DYLIB, LC_UUID, LC_VERSION_MIN_MACOSX, LC_VERSION_MIN_IPHONEOS, LC_SOURCE_VERSION, LC_MAIN, LC_LOAD_DYLINKER, LC_LOAD_WEAK_DYLIB, LC_REEXPORT_DYLIB, LC_RPATH, LC_ID_DYLIB:
++		case macho.LoadCmdDylib, macho.LoadCmdThread, macho.LoadCmdUnixThread, LC_PREBOUND_DYLIB, LC_UUID, LC_VERSION_MIN_MACOSX, LC_VERSION_MIN_IPHONEOS, LC_SOURCE_VERSION, LC_MAIN, LC_LOAD_DYLINKER, LC_LOAD_WEAK_DYLIB, LC_REEXPORT_DYLIB, LC_RPATH, LC_ID_DYLIB, LC_SYMSEG, LC_LOADFVMLIB, LC_IDFVMLIB, LC_IDENT, LC_FVMFILE, LC_PREPAGE, LC_ID_DYLINKER, LC_ROUTINES, LC_SUB_FRAMEWORK, LC_SUB_UMBRELLA, LC_SUB_CLIENT, LC_SUB_LIBRARY, LC_TWOLEVEL_HINTS, LC_PREBIND_CKSUM, LC_ROUTINES_64, LC_LAZY_LOAD_DYLIB, LC_LOAD_UPWARD_DYLIB, LC_DYLD_ENVIRONMENT, LC_LINKER_OPTION, LC_LINKER_OPTIMIZATION_HINT, LC_VERSION_MIN_TVOS, LC_VERSION_MIN_WATCHOS, LC_VERSION_NOTE, LC_BUILD_VERSION:
+ 			// Nothing to update
+ 		default:
+ 			err = fmt.Errorf("Unknown load command 0x%x (%s)\n", int(cmd.Cmd), cmd.Cmd)
+-- 
+2.17.1
+


### PR DESCRIPTION
This is upstream as https://github.com/golang/go/commit/1a92cdbfc10e0c66f2e015264a39159c055a5c15. Changes in the code structure meant this had to be changed slightly for 1.8 and 1.9.