### PR TITLE
hfstospell: add patch to avoid C++17

### DIFF
--- a/hfstospell/no-cxx17.diff
+++ b/hfstospell/no-cxx17.diff
@@ -1,0 +1,112 @@
+diff --git a/configure b/configure
+index 724f9ee..4b4ce60 100755
+--- a/configure
++++ b/configure
+@@ -18472,73 +18472,7 @@ ac_compile='$CXX -c $CXXFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ ac_link='$CXX -o conftest$ac_exeext $CXXFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ ac_compiler_gnu=$ac_cv_cxx_compiler_gnu
+ 
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether C++ compiler accepts -std=c++17" >&5
+-$as_echo_n "checking whether C++ compiler accepts -std=c++17... " >&6; }
+-if ${ax_cv_check_cxxflags___std_cpp17+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-
+-  ax_check_save_flags=$CXXFLAGS
+-  CXXFLAGS="$CXXFLAGS  -std=c++17"
+-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+-/* end confdefs.h.  */
+-
+-int
+-main ()
+-{
+-
+-  ;
+-  return 0;
+-}
+-_ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
+-  ax_cv_check_cxxflags___std_cpp17=yes
+-else
+-  ax_cv_check_cxxflags___std_cpp17=no
+-fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+-  CXXFLAGS=$ax_check_save_flags
+-fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cxxflags___std_cpp17" >&5
+-$as_echo "$ax_cv_check_cxxflags___std_cpp17" >&6; }
+-if test x"$ax_cv_check_cxxflags___std_cpp17" = xyes; then :
+-  CXXFLAGS="$CXXFLAGS -std=c++17"
+-else
+-
+- { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether C++ compiler accepts -std=c++1z" >&5
+-$as_echo_n "checking whether C++ compiler accepts -std=c++1z... " >&6; }
+-if ${ax_cv_check_cxxflags___std_cpp1z+:} false; then :
+-  $as_echo_n "(cached) " >&6
+-else
+-
+-  ax_check_save_flags=$CXXFLAGS
+-  CXXFLAGS="$CXXFLAGS  -std=c++1z"
+-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+-/* end confdefs.h.  */
+-
+-int
+-main ()
+-{
+-
+-  ;
+-  return 0;
+-}
+-_ACEOF
+-if ac_fn_cxx_try_compile "$LINENO"; then :
+-  ax_cv_check_cxxflags___std_cpp1z=yes
+-else
+-  ax_cv_check_cxxflags___std_cpp1z=no
+-fi
+-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+-  CXXFLAGS=$ax_check_save_flags
+-fi
+-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_check_cxxflags___std_cpp1z" >&5
+-$as_echo "$ax_cv_check_cxxflags___std_cpp1z" >&6; }
+-if test x"$ax_cv_check_cxxflags___std_cpp1z" = xyes; then :
+-  CXXFLAGS="$CXXFLAGS -std=c++1z"
+-else
+-
+-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether C++ compiler accepts -std=c++14" >&5
++{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether C++ compiler accepts -std=c++14" >&5
+ $as_echo_n "checking whether C++ compiler accepts -std=c++14... " >&6; }
+ if ${ax_cv_check_cxxflags___std_cpp14+:} false; then :
+   $as_echo_n "(cached) " >&6
+@@ -18571,7 +18505,7 @@ if test x"$ax_cv_check_cxxflags___std_cpp14" = xyes; then :
+   CXXFLAGS="$CXXFLAGS -std=c++14"
+ else
+ 
+-   { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether C++ compiler accepts -std=c++1y" >&5
++ { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether C++ compiler accepts -std=c++1y" >&5
+ $as_echo_n "checking whether C++ compiler accepts -std=c++1y... " >&6; }
+ if ${ax_cv_check_cxxflags___std_cpp1y+:} false; then :
+   $as_echo_n "(cached) " >&6
+@@ -18604,7 +18538,7 @@ if test x"$ax_cv_check_cxxflags___std_cpp1y" = xyes; then :
+   CXXFLAGS="$CXXFLAGS -std=c++1y"
+ else
+ 
+-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether C++ compiler accepts -std=c++11" >&5
++  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether C++ compiler accepts -std=c++11" >&5
+ $as_echo_n "checking whether C++ compiler accepts -std=c++11... " >&6; }
+ if ${ax_cv_check_cxxflags___std_cpp11+:} false; then :
+   $as_echo_n "(cached) " >&6
+@@ -18637,13 +18571,7 @@ if test x"$ax_cv_check_cxxflags___std_cpp11" = xyes; then :
+   CXXFLAGS="$CXXFLAGS -std=c++11"
+ else
+ 
+-     as_fn_error $? "could not enable C++11 or newer" "$LINENO" 5
+-
+-fi
+-
+-
+-fi
+-
++   as_fn_error $? "could not enable C++11 or newer" "$LINENO" 5
+ 
+ fi
+ 


### PR DESCRIPTION
Adapt https://github.com/hfst/hfst-ospell/pull/41 to apply to configure

Goes together with https://github.com/Homebrew/homebrew-core/pull/29269.