### PR TITLE
pyside: patch to support build in superenv

### DIFF
--- a/pyside/pyside-homebrew.patch
+++ b/pyside/pyside-homebrew.patch
@@ -1,0 +1,61 @@
+diff --git a/sources/shiboken2/ApiExtractor/clangparser/compilersupport.cpp b/sources/shiboken2/ApiExtractor/clangparser/compilersupport.cpp
+index 65545489..9d8b454e 100644
+--- a/sources/shiboken2/ApiExtractor/clangparser/compilersupport.cpp
++++ b/sources/shiboken2/ApiExtractor/clangparser/compilersupport.cpp
+@@ -29,6 +29,8 @@
+ #include "compilersupport.h"
+ #include "header_paths.h"
+ 
++#include <reporthandler.h>
++
+ #include <QtCore/QDebug>
+ #include <QtCore/QProcess>
+ #include <QtCore/QStringList>
+@@ -82,6 +84,36 @@ static bool runProcess(const QString &program, const QStringList &arguments,
+ 
+ static QByteArray frameworkPath() { return QByteArrayLiteral(" (framework directory)"); }
+ 
++#if defined(Q_OS_MACOS)
++static void filterHomebrewHeaderPaths(HeaderPaths &headerPaths)
++{
++    QByteArray homebrewPrefix = qgetenv("HOMEBREW_OPT");
++
++    // If HOMEBREW_OPT is found we assume that the build is happening
++    // inside a brew environment, which means we need to filter out
++    // the -isystem flags added by the brew clang shim. This is needed
++    // because brew passes the Qt include paths as system include paths
++    // and because our parser ignores system headers, Qt classes won't
++    // be found and thus compilation errors will occur.
++    if (homebrewPrefix.isEmpty())
++        return;
++
++    qCInfo(lcShiboken) << "Found HOMEBREW_OPT with value:" << homebrewPrefix
++                       << "Assuming homebrew build environment.";
++
++    HeaderPaths::iterator it = headerPaths.begin();
++    while (it != headerPaths.end()) {
++        if (it->path.startsWith(homebrewPrefix)) {
++            qCInfo(lcShiboken) << "Filtering out homebrew include path: "
++                               << it->path;
++            it = headerPaths.erase(it);
++        } else {
++            ++it;
++        }
++    }
++}
++#endif
++
+ // Determine g++'s internal include paths from the output of
+ // g++ -E -x c++ - -v </dev/null
+ // Output looks like:
+@@ -117,6 +149,10 @@ static HeaderPaths gppInternalIncludePaths(const QString &compiler)
+             isIncludeDir = true;
+         }
+     }
++
++#if defined(Q_OS_MACOS)
++    filterHomebrewHeaderPaths(result);
++#endif
+     return result;
+ }
+ #endif // Q_CC_MSVC


### PR DESCRIPTION
Issue: https://bugreports.qt.io/browse/PYSIDE-731

Upstream patch: http://code.qt.io/cgit/pyside/pyside-setup.git/commit/?h=5.11&id=5662706937bd6a1449538539e3a503c6cbc45399

The upstream patch needs an extra #include statement to be applied directly on 5.11.0. 

Further info about the formula: https://github.com/Homebrew/homebrew-core/pull/29699