### PR TITLE
upx: fix decompressing Mach executables

### DIFF
--- a/upx/fix_decompression.patch
+++ b/upx/fix_decompression.patch
@@ -1,0 +1,31 @@
+From facb6747c531acce157bef50b68eacf585e71286 Mon Sep 17 00:00:00 2001
+From: John Reiser <jreiser@BitWagon.com>
+Date: Tue, 19 Dec 2017 17:36:22 -0800
+Subject: [PATCH] bad logic for throwCantUnpack("cmdsize") [simple]
+
+https://github.com/upx/upx/issues/161
+	modified:   p_mach.cpp
+
+Adapted from https://github.com/upx/upx/commit/aefb2fa3c3c9be723076d3fd49c5a4f69121f715.
+
+Co-authored-by: Misty De Meo <mistydemeo@gmail.com>
+---
+ src/p_mach.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/p_mach.cpp b/src/p_mach.cpp
+index f0bb8660..f996d811 100644
+--- a/src/p_mach.cpp
++++ b/src/p_mach.cpp
+@@ -1568,7 +1568,7 @@ void PackMachBase<T>::unpack(OutputFile *fo)
+         memcpy(&msegcmd[j], ptr, umin(sizeof(Mach_segment_command),
+             ((Mach_command const *)ptr)->cmdsize));
+         ptr += (unsigned) ((Mach_segment_command const *)ptr)->cmdsize;
+-        if ((unsigned)(ptr - (unsigned char const *)mhdr) > ph.u_len) {
++        if ((unsigned)(ptr - (unsigned char const *)(1 + mhdr)) > ph.u_len) {
+             throwCantUnpack("cmdsize");
+         }
+     }
+-- 
+2.18.0
+


### PR DESCRIPTION
Adapts the upstream commit https://github.com/upx/upx/commit/aefb2fa3c3c9be723076d3fd49c5a4f69121f715. The upstream patch has the same logic, but doesn't apply cleanly because of surrounding refactoring.