### PR TITLE
binutils: add patch for new mach-o load commands

### DIFF
--- a/binutils/add_mach_o_command.patch
+++ b/binutils/add_mach_o_command.patch
@@ -1,0 +1,47 @@
+From ddea148b3da27eb681504bf341f45abb7a74580b Mon Sep 17 00:00:00 2001
+From: Nick Clifton <nickc@redhat.com>
+Date: Tue, 6 Nov 2018 17:09:40 +0000
+Subject: [PATCH] Add support for a couple of new Mach-O commands.
+
+	PR 23742
+	* mach-o.c (bfd_mach_o_read_command): Accept and ignore
+	BFD_MACH_O_LC_LINKER_OPTIONS and BFD_MACH_O_LC_BUILD_VERSION
+	commands.
+
+	* mach-o/loader.h: Add BFD_MACH_O_LC_BUILD_VERSION.
+---
+ bfd/mach-o.c            | 3 +++
+ include/mach-o/loader.h | 3 ++-
+ 4 files changed, 17 insertions(+), 1 deletion(-)
+
+diff --git a/bfd/mach-o.c b/bfd/mach-o.c
+index 1b461f5988..1d0ade3a02 100644
+--- a/bfd/mach-o.c
++++ b/bfd/mach-o.c
+@@ -4888,6 +4888,9 @@ bfd_mach_o_read_command (bfd *abfd, bfd_mach_o_load_command *command)
+       if (!bfd_mach_o_read_source_version (abfd, command))
+ 	return FALSE;
+       break;
++    case BFD_MACH_O_LC_LINKER_OPTIONS:
++    case BFD_MACH_O_LC_BUILD_VERSION:
++      break;
+     default:
+       command->len = 0;
+       _bfd_error_handler (_("%pB: unknown load command %#x"),
+diff --git a/include/mach-o/loader.h b/include/mach-o/loader.h
+index c075a8e023..9abc51c35d 100644
+--- a/include/mach-o/loader.h
++++ b/include/mach-o/loader.h
+@@ -185,7 +185,8 @@ typedef enum bfd_mach_o_load_command_type
+   BFD_MACH_O_LC_ENCRYPTION_INFO_64 = 0x2c, /* Encrypted 64 bit seg info.  */
+   BFD_MACH_O_LC_LINKER_OPTIONS = 0x2d,	/* Linker options.  */
+   BFD_MACH_O_LC_LINKER_OPTIMIZATION_HINT = 0x2e, /* Optimization hints.  */
+-  BFD_MACH_O_LC_VERSION_MIN_WATCHOS = 0x30 /* Minimal WatchOS version.  */
++  BFD_MACH_O_LC_VERSION_MIN_WATCHOS = 0x30, /* Minimal WatchOS version.  */
++  BFD_MACH_O_LC_BUILD_VERSION = 0x32     /* Records linker, SDK, OS, and tools version used.  */
+ }
+ bfd_mach_o_load_command_type;
+ 
+-- 
+2.19.1
+


### PR DESCRIPTION
This fixes using `gnm` on macOS 10.14. This is the upstream commit with the changelog portions removed in order to allow it to apply to the stable release.

https://sourceware.org/bugzilla/show_bug.cgi?id=23728
https://github.com/Homebrew/homebrew-core/issues/32516