### PR TITLE
smartmontools: add patch for 7.0

### DIFF
--- a/smartmontools/smartd.cpp.patch
+++ b/smartmontools/smartd.cpp.patch
@@ -1,12 +1,15 @@
 diff -u a/smartd.cpp b/smartd.cpp
 --- a/smartd.cpp	2018-12-20 22:02:39.000000000 +0900
 +++ b/smartd.cpp	2019-07-19 10:27:07.000000000 +0900
-@@ -1149,7 +1149,7 @@
+@@ -1149,7 +1149,11 @@
    mail->lastsent=epoch;
  
    // print warning string into message
--  char message[256];
++#ifdef __APPLE__
 +  char message[512];
++#else
+   char message[256];
++#endif // __APPLE__
    va_list ap;
    va_start(ap, fmt);
    vsnprintf(message, sizeof(message), fmt, ap);

--- a/smartmontools/smartd.cpp.patch
+++ b/smartmontools/smartd.cpp.patch
@@ -1,0 +1,12 @@
+diff -u a/smartd.cpp b/smartd.cpp
+--- a/smartd.cpp	2018-12-20 22:02:39.000000000 +0900
++++ b/smartd.cpp	2019-07-19 10:27:07.000000000 +0900
+@@ -1149,7 +1149,7 @@
+   mail->lastsent=epoch;
+ 
+   // print warning string into message
+-  char message[256];
++  char message[512];
+   va_list ap;
+   va_start(ap, fmt);
+   vsnprintf(message, sizeof(message), fmt, ap);


### PR DESCRIPTION
If `DEVICESCAN` is specified in `smartd.conf`, the end of the message is cut because the buffer length is not enough.

Example: `Device:` was cut. 
```
Device: IOService:/AppleACPIPlatformExpert/PCI0@0/AppleACPIPCI/RP21@1B,4/IOPP/PXSX@0/IOPP/pci-bridge@4/IOPP/pci-bridge@0/IOPP/pci-bridge@0/IOPP/pci1b21,625@0/AppleAHCI/PRT0@0/IOAHCIDevice@0/AppleAHCIDiskDriver/IOAHCIBlockStorageDevice, ATA error count inc

Device info:
ST8000DM004-2CX188, S/N:WCT1NET7, WWN:5-000c50-0c00c0c0a, FW:0001, 8.00 TB
```
