### PR TITLE
tmux: Add two backported patches for 2.9a

### DIFF
--- a/tmux/2.9a--001-38b8a198-backport.patch
+++ b/tmux/2.9a--001-38b8a198-backport.patch
@@ -1,0 +1,106 @@
+diff --git a/layout-set.c b/layout-set.c
+index 3a088a4c..12b4780f 100644
+--- a/layout-set.c
++++ b/layout-set.c
+@@ -185,7 +185,7 @@ layout_set_main_h(struct window *w)
+ {
+ 	struct window_pane	*wp;
+ 	struct layout_cell	*lc, *lcmain, *lcother, *lcchild;
+-	u_int			 n, mainh, otherh, sx;
++	u_int			 n, mainh, otherh, sx, sy;
+ 
+ 	layout_print_cell(w->layout_root, __func__, 1);
+ 
+@@ -195,22 +195,25 @@ layout_set_main_h(struct window *w)
+ 		return;
+ 	n--;	/* take off main pane */
+ 
++	/* Find available height - take off one line for the border. */
++	sy = w->sy - 1;
++
+ 	/* Get the main pane height and work out the other pane height. */
+ 	mainh = options_get_number(w->options, "main-pane-height");
+-	if (mainh + PANE_MINIMUM + 1 >= w->sy) {
+-		if (w->sy <= PANE_MINIMUM + 1 + PANE_MINIMUM)
++	if (mainh + PANE_MINIMUM >= sy) {
++		if (sy <= PANE_MINIMUM + PANE_MINIMUM)
+ 			mainh = PANE_MINIMUM;
+ 		else
+-			mainh = w->sy - (PANE_MINIMUM + 1);
++			mainh = sy - PANE_MINIMUM;
+ 		otherh = PANE_MINIMUM;
+ 	} else {
+ 		otherh = options_get_number(w->options, "other-pane-height");
+ 		if (otherh == 0)
+-			otherh = w->sy - mainh;
+-		else if (otherh > w->sy || w->sy - otherh < mainh)
+-			otherh = w->sy - mainh;
++			otherh = sy - mainh;
++		else if (otherh > sy || sy - otherh < mainh)
++			otherh = sy - mainh;
+ 		else
+-			mainh = w->sy - otherh;
++			mainh = sy - otherh;
+ 	}
+ 
+ 	/* Work out what width is needed. */
+@@ -221,7 +224,7 @@ layout_set_main_h(struct window *w)
+ 	/* Free old tree and create a new root. */
+ 	layout_free(w);
+ 	lc = w->layout_root = layout_create_cell(NULL);
+-	layout_set_size(lc, sx, mainh + otherh, 0, 0);
++	layout_set_size(lc, sx, mainh + otherh + 1, 0, 0);
+ 	layout_make_node(lc, LAYOUT_TOPBOTTOM);
+ 
+ 	/* Create the main pane. */
+@@ -269,7 +272,7 @@ layout_set_main_v(struct window *w)
+ {
+ 	struct window_pane	*wp;
+ 	struct layout_cell	*lc, *lcmain, *lcother, *lcchild;
+-	u_int			 n, mainw, otherw, sy;
++	u_int			 n, mainw, otherw, sx, sy;
+ 
+ 	layout_print_cell(w->layout_root, __func__, 1);
+ 
+@@ -279,22 +282,25 @@ layout_set_main_v(struct window *w)
+ 		return;
+ 	n--;	/* take off main pane */
+ 
++	/* Find available width - take off one line for the border. */
++	sx = w->sx - 1;
++
+ 	/* Get the main pane width and work out the other pane width. */
+ 	mainw = options_get_number(w->options, "main-pane-width");
+-	if (mainw + PANE_MINIMUM + 1 >= w->sx) {
+-		if (w->sx <= PANE_MINIMUM + 1 + PANE_MINIMUM)
++	if (mainw + PANE_MINIMUM >= sx) {
++		if (sx <= PANE_MINIMUM + PANE_MINIMUM)
+ 			mainw = PANE_MINIMUM;
+ 		else
+-			mainw = w->sx - (PANE_MINIMUM + 1);
++			mainw = sx - PANE_MINIMUM;
+ 		otherw = PANE_MINIMUM;
+ 	} else {
+ 		otherw = options_get_number(w->options, "other-pane-width");
+ 		if (otherw == 0)
+-			otherw = w->sx - mainw;
+-		else if (otherw > w->sx || w->sx - otherw < mainw)
+-			otherw = w->sx - mainw;
++			otherw = sx - mainw;
++		else if (otherw > sx || sx - otherw < mainw)
++			otherw = sx - mainw;
+ 		else
+-			mainw = w->sx - otherw;
++			mainw = sx - otherw;
+ 	}
+ 
+ 	/* Work out what height is needed. */
+@@ -305,7 +311,7 @@ layout_set_main_v(struct window *w)
+ 	/* Free old tree and create a new root. */
+ 	layout_free(w);
+ 	lc = w->layout_root = layout_create_cell(NULL);
+-	layout_set_size(lc, mainw + otherw, sy, 0, 0);
++	layout_set_size(lc, mainw + otherw + 1, sy, 0, 0);
+ 	layout_make_node(lc, LAYOUT_LEFTRIGHT);
+ 
+ 	/* Create the main pane. */

--- a/tmux/2.9a--002-bbe8ebf9-backport.patch
+++ b/tmux/2.9a--002-bbe8ebf9-backport.patch
@@ -1,0 +1,96 @@
+diff --git a/layout-custom.c b/layout-custom.c
+index 9886afe1..47df1cba 100644
+--- a/layout-custom.c
++++ b/layout-custom.c
+@@ -116,13 +116,49 @@ layout_append(struct layout_cell *lc, char *buf, size_t len)
+ 	return (0);
+ }
+ 
++/* Check layout sizes fit. */
++static int
++layout_check(struct layout_cell *lc)
++{
++	struct layout_cell	*lcchild;
++	u_int			 n = 0;
++
++	switch (lc->type) {
++	case LAYOUT_WINDOWPANE:
++		break;
++	case LAYOUT_LEFTRIGHT:
++		TAILQ_FOREACH(lcchild, &lc->cells, entry) {
++			if (lcchild->sy != lc->sy)
++				return (0);
++			if (!layout_check(lcchild))
++				return (0);
++			n += lcchild->sx + 1;
++		}
++		if (n - 1 != lc->sx)
++			return (0);
++		break;
++	case LAYOUT_TOPBOTTOM:
++		TAILQ_FOREACH(lcchild, &lc->cells, entry) {
++			if (lcchild->sx != lc->sx)
++				return (0);
++			if (!layout_check(lcchild))
++				return (0);
++			n += lcchild->sy + 1;
++		}
++		if (n - 1 != lc->sy)
++			return (0);
++		break;
++	}
++	return (1);
++}
++
+ /* Parse a layout string and arrange window as layout. */
+ int
+ layout_parse(struct window *w, const char *layout)
+ {
+ 	struct layout_cell	*lc, *lcchild;
+ 	struct window_pane	*wp;
+-	u_int			 npanes, ncells, sx, sy;
++	u_int			 npanes, ncells, sx = 0, sy = 0;
+ 	u_short			 csum;
+ 
+ 	/* Check validity. */
+@@ -153,8 +189,38 @@ layout_parse(struct window *w, const char *layout)
+ 		layout_destroy_cell(w, lcchild, &lc);
+ 	}
+ 
+-	/* Save the old window size and resize to the layout size. */
+-	sx = w->sx; sy = w->sy;
++	/*
++	 * It appears older versions of tmux were able to generate layouts with
++	 * an incorrect top cell size - if it is larger than the top child then
++	 * correct that (if this is still wrong the check code will catch it).
++	 */
++	switch (lc->type) {
++	case LAYOUT_WINDOWPANE:
++		break;
++	case LAYOUT_LEFTRIGHT:
++		TAILQ_FOREACH(lcchild, &lc->cells, entry) {
++			sy = lcchild->sy + 1;
++			sx += lcchild->sx + 1;
++		}
++		break;
++	case LAYOUT_TOPBOTTOM:
++		TAILQ_FOREACH(lcchild, &lc->cells, entry) {
++			sx = lcchild->sx + 1;
++			sy += lcchild->sy + 1;
++		}
++		break;
++	}
++	if (lc->sx != sx || lc->sy != sy) {
++		log_debug("fix layout %u,%u to %u,%u", lc->sx, lc->sy, sx,sy);
++		layout_print_cell(lc, __func__, 0);
++		lc->sx = sx - 1; lc->sy = sy - 1;
++	}
++
++	/* Check the new layout. */
++	if (!layout_check(lc))
++		return (-1);
++
++	/* Resize to the layout size. */
+ 	window_resize(w, lc->sx, lc->sy);
+ 
+ 	/* Destroy the old layout and swap to the new. */


### PR DESCRIPTION
- 2.9a--001-38b8a198-backport.patch is https://github.com/tmux/tmux/commit/38b8a198bac62c16d351c54ed83ead29a2e0ecc8
- 2.9a--002-bbe8ebf9-backport.patch is https://github.com/tmux/tmux/commit/bbe8ebf9c26e45fd8c402627b84b3646db445d45

Both are fixing respective tmux server crashes:
- https://github.com/tmux/tmux/issues/1736
- https://github.com/tmux/tmux/issues/1930

Tmux server crash is high impact situation as that causes implict detachment of mux'ed
processes any may cause loss of work.

Canonical tmux is following OpenBSD logic of compile-your-own-the-world, hence maintainers haven't yet scheduled date for tmux 3.0 and 3.1 releases
which will contain patches in mainline branches. Until that time, last
stable release (`2.9a`) is prone to aforementioned crashes unless
patched directly.