### PR TITLE
MySQL-client: fix improper includes

### DIFF
--- a/mysql-client/use-relative-include-path-for-udf_registration_types-h.patch
+++ b/mysql-client/use-relative-include-path-for-udf_registration_types-h.patch
@@ -1,0 +1,24 @@
+https://bugs.gentoo.org/692644
+
+--- a/include/mysql.h.pp
++++ b/include/mysql.h.pp
+@@ -205,7 +205,7 @@ struct rand_struct {
+   unsigned long seed1, seed2, max_value;
+   double max_value_dbl;
+ };
+-#include <mysql/udf_registration_types.h>
++#include "mysql/udf_registration_types.h"
+ enum Item_result {
+   INVALID_RESULT = -1,
+   STRING_RESULT = 0,
+--- a/include/mysql_com.h
++++ b/include/mysql_com.h
+@@ -1031,7 +1031,7 @@ struct rand_struct {
+ };
+ 
+ /* Include the types here so existing UDFs can keep compiling */
+-#include <mysql/udf_registration_types.h>
++#include "mysql/udf_registration_types.h"
+ 
+ /**
+   @addtogroup group_cs_compresson_constants Constants when using compression


### PR DESCRIPTION
Recent MySQL client introduced a bug with includes. See these bugreports
for the details:

* https://bugs.gentoo.org/692644
* https://bugzilla.redhat.com/1623950
* https://bugs.mysql.com/92870

This patch fixes it.

Signed-off-by: Peter Lemenkov <lemenkov@gmail.com>