### PR TITLE
gmp: add arm64 compatibility patch

### DIFF
--- a/gmp/6.2.0-arm.patch
+++ b/gmp/6.2.0-arm.patch
@@ -1,0 +1,182 @@
+diff --git a/configure.ac b/configure.ac
+index 024cacb..8012bde 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -3699,6 +3699,14 @@ if test "$gmp_asm_syntax_testing" != no; then
+       case $ABI in
+         32)
+ 	  GMP_INCLUDE_MPN(arm/arm-defs.m4) ;;
++        64)
++          case $host in
++            *-*-darwin*)
++              GMP_INCLUDE_MPN(arm64/darwin.m4) ;;
++            *)
++              GMP_INCLUDE_MPN(arm64/arm64-defs.m4) ;;
++          esac
++          ;;
+       esac
+       ;;
+     hppa*-*-*)
+diff --git a/mpn/arm64/arm64-defs.m4 b/mpn/arm64/arm64-defs.m4
+new file mode 100644
+index 0000000..a45e915
+--- /dev/null
++++ b/mpn/arm64/arm64-defs.m4
+@@ -0,0 +1,47 @@
++divert(-1)
++
++dnl  m4 macros for ARM64 ELF assembler.
++
++dnl  Copyright 2020 Free Software Foundation, Inc.
++
++dnl  This file is part of the GNU MP Library.
++dnl
++dnl  The GNU MP Library is free software; you can redistribute it and/or modify
++dnl  it under the terms of either:
++dnl
++dnl    * the GNU Lesser General Public License as published by the Free
++dnl      Software Foundation; either version 3 of the License, or (at your
++dnl      option) any later version.
++dnl
++dnl  or
++dnl
++dnl    * the GNU General Public License as published by the Free Software
++dnl      Foundation; either version 2 of the License, or (at your option) any
++dnl      later version.
++dnl
++dnl  or both in parallel, as here.
++dnl
++dnl  The GNU MP Library is distributed in the hope that it will be useful, but
++dnl  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
++dnl  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++dnl  for more details.
++dnl
++dnl  You should have received copies of the GNU General Public License and the
++dnl  GNU Lesser General Public License along with the GNU MP Library.  If not,
++dnl  see https://www.gnu.org/licenses/.
++
++
++dnl  Standard commenting is with @, the default m4 # is for constants and we
++dnl  don't want to disable macro expansions in or after them.
++
++changecom
++
++ifdef(`PIC',`dnl
++define(`LEA_HI', `adrp	$1, :got:$2')dnl
++define(`LEA_LO', `ldr	$1, [$1, #:got_lo12:$2]')dnl
++',`dnl
++define(`LEA_HI', `adrp	$1, $2')dnl
++define(`LEA_LO', `add	$1, $1, :lo12:$2')dnl
++')dnl
++
++divert
+diff --git a/mpn/arm64/bdiv_q_1.asm b/mpn/arm64/bdiv_q_1.asm
+index 2e189b8..4226524 100644
+--- a/mpn/arm64/bdiv_q_1.asm
++++ b/mpn/arm64/bdiv_q_1.asm
+@@ -61,15 +61,9 @@ PROLOGUE(mpn_bdiv_q_1)
+ 	clz	cnt, x6
+ 	lsr	d, d, cnt
+ 
+-ifdef(`PIC',`
+-	adrp	x7, :got:__gmp_binvert_limb_table
++	LEA_HI(	x7, binvert_limb_table)
+ 	ubfx	x6, d, 1, 7
+-	ldr	x7, [x7, #:got_lo12:__gmp_binvert_limb_table]
+-',`
+-	adrp	x7, __gmp_binvert_limb_table
+-	ubfx	x6, d, 1, 7
+-	add	x7, x7, :lo12:__gmp_binvert_limb_table
+-')
++	LEA_LO(	x7, binvert_limb_table)
+ 	ldrb	w6, [x7, x6]
+ 	ubfiz	x7, x6, 1, 8
+ 	umull	x6, w6, w6
+@@ -81,7 +75,7 @@ ifdef(`PIC',`
+ 	mul	x6, x6, x6
+ 	msub	di, x6, d, x7
+ 
+-	b	mpn_pi1_bdiv_q_1
++	b	__pi1_bdiv_q_1
+ EPILOGUE()
+ 
+ PROLOGUE(mpn_pi1_bdiv_q_1)
+diff --git a/mpn/arm64/darwin.m4 b/mpn/arm64/darwin.m4
+new file mode 100644
+index 0000000..5dfb746
+--- /dev/null
++++ b/mpn/arm64/darwin.m4
+@@ -0,0 +1,42 @@
++divert(-1)
++
++dnl  m4 macros for ARM64 Darwin assembler.
++
++dnl  Copyright 2020 Free Software Foundation, Inc.
++
++dnl  This file is part of the GNU MP Library.
++dnl
++dnl  The GNU MP Library is free software; you can redistribute it and/or modify
++dnl  it under the terms of either:
++dnl
++dnl    * the GNU Lesser General Public License as published by the Free
++dnl      Software Foundation; either version 3 of the License, or (at your
++dnl      option) any later version.
++dnl
++dnl  or
++dnl
++dnl    * the GNU General Public License as published by the Free Software
++dnl      Foundation; either version 2 of the License, or (at your option) any
++dnl      later version.
++dnl
++dnl  or both in parallel, as here.
++dnl
++dnl  The GNU MP Library is distributed in the hope that it will be useful, but
++dnl  WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
++dnl  or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++dnl  for more details.
++dnl
++dnl  You should have received copies of the GNU General Public License and the
++dnl  GNU Lesser General Public License along with the GNU MP Library.  If not,
++dnl  see https://www.gnu.org/licenses/.
++
++
++dnl  Standard commenting is with @, the default m4 # is for constants and we
++dnl  don't want to disable macro expansions in or after them.
++
++changecom
++
++define(`LEA_HI',`adrp	$1, $2@GOTPAGE')dnl
++define(`LEA_LO',`ldr	$1, [$1, $2@GOTPAGEOFF]')dnl
++
++divert
+diff --git a/mpn/arm64/invert_limb.asm b/mpn/arm64/invert_limb.asm
+index a94b0e9..6a99bf0 100644
+--- a/mpn/arm64/invert_limb.asm
++++ b/mpn/arm64/invert_limb.asm
+@@ -41,9 +41,9 @@ C Compiler generated, mildly edited.  Could surely be further optimised.
+ ASM_START()
+ PROLOGUE(mpn_invert_limb)
+ 	lsr	x2, x0, #54
+-	adrp	x1, approx_tab
++	LEA_HI(	x1, approx_tab)
+ 	and	x2, x2, #0x1fe
+-	add	x1, x1, :lo12:approx_tab
++	LEA_LO(	x1, approx_tab)
+ 	ldrh	w3, [x1,x2]
+ 	lsr	x4, x0, #24
+ 	add	x4, x4, #1
+diff --git a/mpn/asm-defs.m4 b/mpn/asm-defs.m4
+index 7b7e53e..5032f69 100644
+--- a/mpn/asm-defs.m4
++++ b/mpn/asm-defs.m4
+@@ -1508,6 +1508,10 @@ deflit(__clz_tab,
+ m4_assert_defined(`GSYM_PREFIX')
+ `GSYM_PREFIX`'MPN(`clz_tab')')
+ 
++deflit(__pi1_bdiv_q_1,
++m4_assert_defined(`GSYM_PREFIX')
++`GSYM_PREFIX`'MPN(`pi1_bdiv_q_1')')
++
+ deflit(binvert_limb_table,
+ m4_assert_defined(`GSYM_PREFIX')
+ `GSYM_PREFIX`'__gmp_binvert_limb_table')


### PR DESCRIPTION
This commit consolidates the two patches proposed in https://github.com/Homebrew/homebrew-core/pull/57315.
