### PR TITLE
erlang@20: Xcode 11.4+ Catalina build patch

### DIFF
--- a/erlang/otp20_xcode11.4.patch
+++ b/erlang/otp20_xcode11.4.patch
@@ -1,0 +1,26 @@
+diff --git a/erts/configure.in b/erts/configure.in
+index 4a4f478..ab26ee5 100644
+--- a/erts/configure.in
++++ b/erts/configure.in
+@@ -937,21 +937,6 @@ dnl for now that is the way we do it.
+ USER_LD=$LD
+ USER_LDFLAGS="$LDFLAGS"
+ LD='$(CC)'
+-case $host_os in
+-     darwin*)
+-	saved_LDFLAGS="$LDFLAGS"
+-	LDFLAGS="$LDFLAGS -Wl,-no_weak_imports"
+-	AC_TRY_LINK([],[],
+-		[
+-			LD_MAY_BE_WEAK=no
+-		],
+-		[
+-			LD_MAY_BE_WEAK=yes
+-			LDFLAGS="$saved_LDFLAGS"
+-		]);;
+-    *)
+-	LD_MAY_BE_WEAK=no;;
+-esac
+ 
+ AC_SUBST(LD)
+ 


### PR DESCRIPTION
Fixes https://bugs.erlang.org/browse/ERL-1205. Backported from upstream (https://github.com/erlang/otp/pull/2577) because no official patch planned.