### PR TITLE
acmetool: add patch for 0.0.67 (remove gopath)

### DIFF
--- a/acmetool/stable-gomod.diff
+++ b/acmetool/stable-gomod.diff
@@ -1,0 +1,137 @@
+From 7b7ac8c75e936dcefff2c8b2903eb5c442db345f Mon Sep 17 00:00:00 2001
+From: Mike L <cl.jeremy@qq.com>
+Date: Thu, 9 Jul 2020 06:28:26 +0200
+Subject: [PATCH] support go modules for stable
+
+---
+ go.mod | 42 ++++++++++++++++++++++++++++++++++
+ go.sum | 71 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 113 insertions(+)
+ create mode 100644 go.mod
+ create mode 100644 go.sum
+
+diff --git a/go.mod b/go.mod
+new file mode 100644
+index 0000000000000000000000000000000000000000..c0e9ce68f6926727683189ced94a0365d48df7ab
+--- /dev/null
++++ b/go.mod
+@@ -0,0 +1,42 @@
++module github.com/hlandau/acme
++
++require (
++	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
++	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
++	github.com/coreos/go-systemd v0.0.0-20180108085132-cc4f39464dc7
++	github.com/fatih/color v1.7.0 // indirect
++	github.com/godbus/dbus v4.1.0+incompatible // indirect
++	github.com/hlandau/buildinfo v0.0.0-20161112115716-337a29b54997 // indirect
++	github.com/hlandau/dexlogconfig v0.0.0-20161112114350-244f29bd2608
++	github.com/hlandau/goutils v0.0.0-20160722130800-0cdb66aea5b8
++	github.com/hlandau/xlog v1.0.0
++	github.com/jmhodges/clock v0.0.0-20160418191101-880ee4c33548
++	github.com/mattn/go-colorable v0.1.0 // indirect
++	github.com/mattn/go-isatty v0.0.4 // indirect
++	github.com/mattn/go-runewidth v0.0.3-0.20170510074858-97311d9f7767 // indirect
++	github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7
++	github.com/ogier/pflag v0.0.2-0.20160129220114-45c278ab3607 // indirect
++	github.com/peterhellberg/link v1.0.1-0.20171231092049-8768c6d4dc56
++	github.com/satori/go.uuid v1.2.1-0.20180103174451-36e9d2ebbde5
++	github.com/shiena/ansicolor v0.0.0-20151119151921-a422bbe96644 // indirect
++	github.com/stretchr/testify v1.3.0 // indirect
++	golang.org/x/crypto v0.0.0-20180119165957-a66000089151
++	golang.org/x/net v0.0.0-20180112015858-5ccada7d0a7b
++	golang.org/x/sys v0.0.0-20180117170059-2c42eef0765b // indirect
++	golang.org/x/text v0.3.1-0.20171227012246-e19ae1496984 // indirect
++	gopkg.in/alecthomas/kingpin.v2 v2.2.6
++	gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 // indirect
++	gopkg.in/cheggaaa/pb.v1 v1.0.20
++	gopkg.in/hlandau/configurable.v1 v1.0.1 // indirect
++	gopkg.in/hlandau/easyconfig.v1 v1.0.16
++	gopkg.in/hlandau/service.v2 v2.0.16
++	gopkg.in/hlandau/svcutils.v1 v1.0.10
++	gopkg.in/square/go-jose.v1 v1.1.0
++	gopkg.in/tylerb/graceful.v1 v1.2.15
++	gopkg.in/yaml.v2 v2.0.0
++)
++
++exclude (
++	github.com/btcsuite/winsvc v1.0.0
++	github.com/erikdubbelboer/gspt v0.0.0-20190125194910-e68493906b83
++)
+diff --git a/go.sum b/go.sum
+new file mode 100644
+index 0000000000000000000000000000000000000000..f2478e2518229304796aefd018ba154ec8536ce4
+--- /dev/null
++++ b/go.sum
+@@ -0,0 +1,71 @@
++github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5VpdgMhJosfJnn5/FoN2SRZ4p7fJNX58YPaU=
++github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
++github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
++github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
++github.com/coreos/go-systemd v0.0.0-20180108085132-cc4f39464dc7 h1:e3u8KWFMR3irlDo1Z/tL8Hsz1MJmCLkSoX5AZRMKZkg=
++github.com/coreos/go-systemd v0.0.0-20180108085132-cc4f39464dc7/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
++github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
++github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
++github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
++github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
++github.com/godbus/dbus v4.1.0+incompatible h1:WqqLRTsQic3apZUK9qC5sGNfXthmPXzUZ7nQPrNITa4=
++github.com/godbus/dbus v4.1.0+incompatible/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
++github.com/hlandau/buildinfo v0.0.0-20161112115716-337a29b54997 h1:pSU4Sj7AD5qh+4V5FRlpiw3DpuNQ459c3j8h2F38q74=
++github.com/hlandau/buildinfo v0.0.0-20161112115716-337a29b54997/go.mod h1:Oara+TmqGrvsLVEj5YkFe+PP9cSkp0kFD2PFQ5gjHok=
++github.com/hlandau/dexlogconfig v0.0.0-20161112114350-244f29bd2608 h1:ouW4TuIFOsfgql1NgzTHGgW6esZ41RW5NZwHz3ALXn8=
++github.com/hlandau/dexlogconfig v0.0.0-20161112114350-244f29bd2608/go.mod h1:JpXGCMr2CULPTjnwD8PL9A7YipEitrd+xSHTIK8orHU=
++github.com/hlandau/goutils v0.0.0-20160722130800-0cdb66aea5b8 h1:9aNGW7btNlVqbcqAc2YVwjI0fhZFmoZHkC3+ZJyt1DM=
++github.com/hlandau/goutils v0.0.0-20160722130800-0cdb66aea5b8/go.mod h1:pYz0KEJgONY133I+1Pkmn6MLptkdKyz3SHgGmpDWyFI=
++github.com/hlandau/xlog v1.0.0 h1:tcFGp86iK+v6NwbyuG9wyLB77SBkvAJUjOkRJo3H8C0=
++github.com/hlandau/xlog v1.0.0/go.mod h1:aZl5hrokGCtnAFcvft2givQmKZYVfHRvQJbjoqI2lm8=
++github.com/jmhodges/clock v0.0.0-20160418191101-880ee4c33548 h1:dYTbLf4m0a5u0KLmPfB6mgxbcV7588bOCx79hxa5Sr4=
++github.com/jmhodges/clock v0.0.0-20160418191101-880ee4c33548/go.mod h1:hGT6jSUVzF6no3QaDSMLGLEHtHSBSefs+MgcDWnmhmo=
++github.com/mattn/go-colorable v0.1.0 h1:v2XXALHHh6zHfYTJ+cSkwtyffnaOyR1MXaA91mTrb8o=
++github.com/mattn/go-colorable v0.1.0/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
++github.com/mattn/go-isatty v0.0.4 h1:bnP0vzxcAdeI1zdubAl5PjU6zsERjGZb7raWodagDYs=
++github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
++github.com/mattn/go-runewidth v0.0.3-0.20170510074858-97311d9f7767 h1:/Df5WsCmjFyY0AT2fgEvlF2fHQ6sWyuRzgYXvgSh4ec=
++github.com/mattn/go-runewidth v0.0.3-0.20170510074858-97311d9f7767/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
++github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7 h1:DpOJ2HYzCv8LZP15IdmG+YdwD2luVPHITV96TkirNBM=
++github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
++github.com/ogier/pflag v0.0.2-0.20160129220114-45c278ab3607 h1:xZoOomu8/sOa+6Q469LrXeyq2YsmkhZo8wU6EzNWMDg=
++github.com/ogier/pflag v0.0.2-0.20160129220114-45c278ab3607/go.mod h1:zkFki7tvTa0tafRvTBIZTvzYyAu6kQhPZFnshFFPE+g=
++github.com/peterhellberg/link v1.0.1-0.20171231092049-8768c6d4dc56 h1:Cmq36Ot4ufJdk4Pz3fZpJ/RtHpOXG1AjjY8LslRzpWU=
++github.com/peterhellberg/link v1.0.1-0.20171231092049-8768c6d4dc56/go.mod h1:gtSlOT4jmkY8P47hbTc8PTgiDDWpdPbFYl75keYyBB8=
++github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
++github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
++github.com/satori/go.uuid v1.2.1-0.20180103174451-36e9d2ebbde5 h1:Jw7W4WMfQDxsXvfeFSaS2cHlY7bAF4MGrgnbd0+Uo78=
++github.com/satori/go.uuid v1.2.1-0.20180103174451-36e9d2ebbde5/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
++github.com/shiena/ansicolor v0.0.0-20151119151921-a422bbe96644 h1:X+yvsM2yrEktyI+b2qND5gpH8YhURn0k8OCaeRnkINo=
++github.com/shiena/ansicolor v0.0.0-20151119151921-a422bbe96644/go.mod h1:nkxAfR/5quYxwPZhyDxgasBMnRtBZd0FCEpawpjMUFg=
++github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
++github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
++github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
++golang.org/x/crypto v0.0.0-20180119165957-a66000089151 h1:du7dTgoJooIwkyksVuOCfUbQDgZE9oIUdVk/v/tqou4=
++golang.org/x/crypto v0.0.0-20180119165957-a66000089151/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
++golang.org/x/net v0.0.0-20180112015858-5ccada7d0a7b h1:Xu6Gf1IrU0c8CSJqWR43Bh8vb+Ft3jVIUahRiqL1oaI=
++golang.org/x/net v0.0.0-20180112015858-5ccada7d0a7b/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
++golang.org/x/sys v0.0.0-20180117170059-2c42eef0765b h1:mxo/dXmtEd5rXc/ZzMKg0qDhMT+51+LvV65S9dP6nh4=
++golang.org/x/sys v0.0.0-20180117170059-2c42eef0765b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
++golang.org/x/text v0.3.1-0.20171227012246-e19ae1496984 h1:4S3Dic2vY09agWhKAjYa6buMB7HsLkVrliEHZclmmSU=
++golang.org/x/text v0.3.1-0.20171227012246-e19ae1496984/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
++gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
++gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
++gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
++gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
++gopkg.in/cheggaaa/pb.v1 v1.0.20 h1:kgQVoCjFPiI1fNjdWthabnG1rOAb+/7Z6KeGk2aeZ/w=
++gopkg.in/cheggaaa/pb.v1 v1.0.20/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
++gopkg.in/hlandau/configurable.v1 v1.0.1 h1:rH8g/WXZu2b/eyLagvsqUf9q5mO66hfGHW5L4rm8ktk=
++gopkg.in/hlandau/configurable.v1 v1.0.1/go.mod h1:rlyQpcii/QkMGudMSMoe3jjHAgqLZuqg0hQkiUcNfF8=
++gopkg.in/hlandau/easyconfig.v1 v1.0.16 h1:ldFeTZmzPDiiFbyeV8eOMVLAqSCWI0rg8W3GK3Z9wH0=
++gopkg.in/hlandau/easyconfig.v1 v1.0.16/go.mod h1:fljDHM+/VAXpyEN/45q6RFtcOFnUaF1Wgr6p4LLICoU=
++gopkg.in/hlandau/service.v2 v2.0.16 h1:mmaXq+/O4vXTWEGHdVy+Cy5S7h2djyu8Rodm6qE3oV4=
++gopkg.in/hlandau/service.v2 v2.0.16/go.mod h1:3f+96gui2lGv8llWOAUPi9+oI+TOBIyvlVHa1DUwliA=
++gopkg.in/hlandau/svcutils.v1 v1.0.10 h1:eIasSJy56y3H3rJ0US4EJURTAfHXItiehMxZRRs7TrU=
++gopkg.in/hlandau/svcutils.v1 v1.0.10/go.mod h1:aAoYFMVAq2ck6z8av+FBxzX/qX1ehmUIc5PgGBf+P3I=
++gopkg.in/square/go-jose.v1 v1.1.0 h1:T/KcERvxOFKL2QzwvOsP0l5xRvvhTlwcTxw5qad61pQ=
++gopkg.in/square/go-jose.v1 v1.1.0/go.mod h1:QpYS+a4WhS+DTlyQIi6Ka7MS3SuR9a055rgXNEe6EiA=
++gopkg.in/tylerb/graceful.v1 v1.2.15 h1:1JmOyhKqAyX3BgTXMI84LwT6FOJ4tP2N9e2kwTCM0nQ=
++gopkg.in/tylerb/graceful.v1 v1.2.15/go.mod h1:yBhekWvR20ACXVObSSdD3u6S9DeSylanL2PAbAC/uJ8=
++gopkg.in/yaml.v2 v2.0.0 h1:uUkhRGrsEyx/laRdeS6YIQKIys8pg+lRSRdVMTYjivs=
++gopkg.in/yaml.v2 v2.0.0/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=


### PR DESCRIPTION
For building with go modules. Upstream has no branch to merge stable patches.