### PR TITLE
perl: Resolve macOS 11.0+ version check blocker

### DIFF
--- a/perl/version_check.patch
+++ b/perl/version_check.patch
@@ -1,0 +1,58 @@
+diff --git a/AUTHORS b/AUTHORS
+index e4ea405d985b1e12849537d0920b10ec29913800..a05246b0474954cecda2f1171134d1a0b3b73f41 100644
+--- a/AUTHORS
++++ b/AUTHORS
+@@ -31,6 +31,7 @@ Abir Viqar                     <abiviq@hushmail.com>
+ Achim Bohnet                   <ach@mpe.mpg.de>
+ Achim Gratz                    <achim.gratz@stromeko.de>
+ Adam Flott                     <adam@npjh.com>
++Adam Hartley                   <git@ahartley.com>
+ Adam Kennedy                   <adam@ali.as>
+ Adam Krolnik                   <adamk@gypsy.cyrix.com>
+ Adam Milner                    <carmiac@nmt.edu>
+diff --git a/hints/darwin.sh b/hints/darwin.sh
+index 0a91bc083c01c5649e930c2d4be61c8a5febfef9..fdfbdd4a3b9438a79d414c14aeaeb2820e213897 100644
+--- a/hints/darwin.sh
++++ b/hints/darwin.sh
+@@ -301,7 +301,7 @@ case "$osvers" in  # Note: osvers is the kernel version, not the 10.x
+    # We now use MACOSX_DEPLOYMENT_TARGET, if set, as an override by
+    # capturing its value and adding it to the flags.
+     case "$MACOSX_DEPLOYMENT_TARGET" in
+-    10.*)
++    [1-9][0-9].*)
+       add_macosx_version_min ccflags $MACOSX_DEPLOYMENT_TARGET
+       add_macosx_version_min ldflags $MACOSX_DEPLOYMENT_TARGET
+       ;;
+@@ -313,7 +313,7 @@ case "$osvers" in  # Note: osvers is the kernel version, not the 10.x
+ 
+ *** Unexpected MACOSX_DEPLOYMENT_TARGET=$MACOSX_DEPLOYMENT_TARGET
+ ***
+-*** Please either set it to 10.something, or to empty.
++*** Please either set it to a valid macOS version number (e.g., 10.15) or to empty.
+ 
+ EOM
+       exit 1
+@@ -327,7 +327,7 @@ EOM
+     # "ProductVersion:    10.11"     "10.11"
+         prodvers=`sw_vers|awk '/^ProductVersion:/{print $2}'|awk -F. '{print $1"."$2}'`
+     case "$prodvers" in
+-    10.*)
++    [1-9][0-9].*)
+       add_macosx_version_min ccflags $prodvers
+       add_macosx_version_min ldflags $prodvers
+       ;;
+@@ -342,11 +342,10 @@ EOM
+       exit 1
+     esac
+ 
+-    # The X in 10.X
+-    prodvers_minor=$(echo $prodvers|awk -F. '{print $2}')
++    darwin_major=$(echo $osvers|awk -F. '{print $1}')
+ 
+-    # macOS (10.12) deprecated syscall().
+-    if [ "$prodvers_minor" -ge 12 ]; then
++    # macOS 10.12 (darwin 16.0.0) deprecated syscall().
++    if [ "$darwin_major" -ge 16 ]; then
+         d_syscall='undef'
+         # If deploying to pre-10.12, suppress Time::HiRes's detection of the system clock_gettime()
+         case "$MACOSX_DEPLOYMENT_TARGET" in


### PR DESCRIPTION
Patch is based on this PR: https://github.com/Perl/perl5/pull/17946

Until this PR is merged the formula is blocked, so creating a patch as the PR is being modified/changed as the options moving forward are discussed