### PR TITLE
lbzip2: patch for 2.5

### DIFF
--- a/lbzip2/gnulib-vasnprintf-port-to-macOS-10-13.diff
+++ b/lbzip2/gnulib-vasnprintf-port-to-macOS-10-13.diff
@@ -1,0 +1,25 @@
+--- lib/vasnprintf.c~	2020-08-06 19:19:48.000000000 +0200
++++ lib/vasnprintf.c	2020-08-06 19:19:58.000000000 +0200
+@@ -4870,7 +4870,11 @@
+ #endif
+                   *fbp = dp->conversion;
+ #if USE_SNPRINTF
+-# if !(((__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3)) && !defined __UCLIBC__) || ((defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__))
++# if ! (((__GLIBC__ > 2                                                 \
++          || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 3))                  \
++         && !defined __UCLIBC__)                                        \
++        || (defined __APPLE__ && defined __MACH__)                      \
++        || ((defined _WIN32 || defined __WIN32__) && ! defined __CYGWIN__))
+                 fbp[1] = '%';
+                 fbp[2] = 'n';
+                 fbp[3] = '\0';
+@@ -4884,6 +4888,9 @@
+                    in format strings in writable memory may crash the program
+                    (if compiled with _FORTIFY_SOURCE=2), so we should avoid it
+                    in this situation.  */
++                /* macOS 10.13 High Sierra behaves like glibc with
++                   _FORTIFY_SOURCE=2, and older macOS releases
++                   presumably do not need %n.  */
+                 /* On native Windows systems (such as mingw), we can avoid using
+                    %n because:
+                      - Although the gl_SNPRINTF_TRUNCATION_C99 test fails,


### PR DESCRIPTION
Fix crash on macOS >= 10.13 due to an incompatibility in the embedded gnulib.

Original patch here: https://lists.gnu.org/archive/html/bug-gnulib/2017-07/msg00058.html