### PR TITLE
llvm: patch for 10.0.1

### DIFF
--- a/llvm/10.0.1-clang.diff
+++ b/llvm/10.0.1-clang.diff
@@ -1,0 +1,58 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index dc1413f4b597209a250998759711af776f8165df..ac328e1e0cdf25ffaa999482e4542db651cea46d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -110,6 +110,10 @@ if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
+   option(CLANG_ENABLE_BOOTSTRAP "Generate the clang bootstrap target" OFF)
+   option(LLVM_ENABLE_LIBXML2 "Use libxml2 if available." ON)
+
++  if(LLVM_ENABLE_ZLIB)
++    find_package(ZLIB)
++  endif()
++
+   include(AddLLVM)
+   include(TableGen)
+   include(HandleLLVMOptions)
+diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
+index 7fdc7d0be79f334b4328597f00c8ea797d5a40ee..2c6487e8c26082d2c6aec9e4958e5a35c22fdc0a 100644
+--- a/test/CMakeLists.txt
++++ b/test/CMakeLists.txt
+@@ -9,15 +9,6 @@ endif ()
+
+ string(REPLACE ${CMAKE_CFG_INTDIR} ${LLVM_BUILD_MODE} CLANG_TOOLS_DIR ${LLVM_RUNTIME_OUTPUT_INTDIR})
+
+-if(CLANG_BUILT_STANDALONE)
+-  # Set HAVE_LIBZ according to recorded LLVM_ENABLE_ZLIB value. This
+-  # value is forced to 0 if zlib was not found, so it is fine to use it
+-  # instead of HAVE_LIBZ (not recorded).
+-  if(LLVM_ENABLE_ZLIB)
+-    set(HAVE_LIBZ 1)
+-  endif()
+-endif()
+-
+ llvm_canonicalize_cmake_booleans(
+   CLANG_BUILD_EXAMPLES
+   CLANG_ENABLE_ARCMT
+@@ -25,7 +16,7 @@ llvm_canonicalize_cmake_booleans(
+   CLANG_SPAWN_CC1
+   ENABLE_BACKTRACES
+   ENABLE_EXPERIMENTAL_NEW_PASS_MANAGER
+-  HAVE_LIBZ
++  LLVM_ENABLE_ZLIB
+   LLVM_ENABLE_PER_TARGET_RUNTIME_DIR
+   LLVM_ENABLE_PLUGINS
+   LLVM_ENABLE_THREADS)
+diff --git a/test/lit.site.cfg.py.in b/test/lit.site.cfg.py.in
+index 520afab6af8296f933934cbe77074b5daf125d90..e9b35ac01771123dba1bcc096f5332b673293d9a 100644
+--- a/test/lit.site.cfg.py.in
++++ b/test/lit.site.cfg.py.in
+@@ -16,7 +16,7 @@ config.host_triple = "@LLVM_HOST_TRIPLE@"
+ config.target_triple = "@TARGET_TRIPLE@"
+ config.host_cxx = "@CMAKE_CXX_COMPILER@"
+ config.llvm_use_sanitizer = "@LLVM_USE_SANITIZER@"
+-config.have_zlib = @HAVE_LIBZ@
++config.have_zlib = @LLVM_ENABLE_ZLIB@
+ config.clang_arcmt = @CLANG_ENABLE_ARCMT@
+ config.clang_default_cxx_stdlib = "@CLANG_DEFAULT_CXX_STDLIB@"
+ config.clang_staticanalyzer = @CLANG_ENABLE_STATIC_ANALYZER@
+

--- a/llvm/10.0.1-compiiler-rt.diff
+++ b/llvm/10.0.1-compiiler-rt.diff
@@ -1,0 +1,59 @@
+diff --git a/cmake/config-ix.cmake b/cmake/config-ix.cmake
+index 3aad08e889696e66c8e3d2f9ba5d34a60edc3451..d2d9a62b96e5d1ed8e195cd3ecac6583a7d44691 100644
+--- a/cmake/config-ix.cmake
++++ b/cmake/config-ix.cmake
+@@ -124,17 +124,16 @@ check_library_exists(pthread pthread_create "" COMPILER_RT_HAS_LIBPTHREAD)
+ check_library_exists(execinfo backtrace "" COMPILER_RT_HAS_LIBEXECINFO)
+
+ # Look for terminfo library, used in unittests that depend on LLVMSupport.
+-if(LLVM_ENABLE_TERMINFO)
+-  foreach(library terminfo tinfo curses ncurses ncursesw)
+-    string(TOUPPER ${library} library_suffix)
+-    check_library_exists(
+-      ${library} setupterm "" COMPILER_RT_HAS_TERMINFO_${library_suffix})
+-    if(COMPILER_RT_HAS_TERMINFO_${library_suffix})
+-      set(COMPILER_RT_HAS_TERMINFO TRUE)
+-      set(COMPILER_RT_TERMINFO_LIB "${library}")
+-      break()
+-    endif()
+-  endforeach()
++if(LLVM_ENABLE_TERMINFO STREQUAL FORCE_ON)
++  set(MAYBE_REQUIRED REQUIRED)
++else()
++  set(MAYBE_REQUIRED)
++endif()
++find_library(COMPILER_RT_TERMINFO_LIB NAMES terminfo tinfo curses ncurses ncursesw ${MAYBE_REQUIRED})
++if(COMPILER_RT_TERMINFO_LIB)
++  set(LLVM_ENABLE_TERMINFO 1)
++else()
++  set(LLVM_ENABLE_TERMINFO 0)
+ endif()
+
+ if (ANDROID AND COMPILER_RT_HAS_LIBDL)
+diff --git a/lib/xray/tests/CMakeLists.txt b/lib/xray/tests/CMakeLists.txt
+index a1fbccaeb6d2684352495dabe9a65310a22d5cde..96a9db1ef87773e69db29a8a2ff00a2fcb7864b9 100644
+--- a/lib/xray/tests/CMakeLists.txt
++++ b/lib/xray/tests/CMakeLists.txt
+@@ -55,7 +55,7 @@ set(XRAY_UNITTEST_LINK_FLAGS
+ if (NOT APPLE)
+   # Needed by LLVMSupport.
+   append_list_if(
+-    COMPILER_RT_HAS_TERMINFO
++    LLVM_ENABLE_TERMINFO
+     -l${COMPILER_RT_TERMINFO_LIB} XRAY_UNITTEST_LINK_FLAGS)
+
+   if (COMPILER_RT_STANDALONE_BUILD)
+diff --git a/test/lit.common.configured.in b/test/lit.common.configured.in
+index b4862f74cdd02105c3aaf67787f6a1ea10ab5f56..0fb51741783e1734d9763842b7d637ae6418fa72 100644
+--- a/test/lit.common.configured.in
++++ b/test/lit.common.configured.in
+@@ -50,7 +50,7 @@ if config.enable_per_target_runtime_dir:
+ else:
+   set_default("target_suffix", "-%s" % config.target_arch)
+
+-set_default("have_zlib", "@HAVE_LIBZ@")
++set_default("have_zlib", "@LLVM_ENABLE_ZLIB@")
+ set_default("libcxx_used", "@LLVM_LIBCXX_USED@")
+
+ # LLVM tools dir can be passed in lit parameters, so try to
+

--- a/llvm/10.0.1-lld.diff
+++ b/llvm/10.0.1-lld.diff
@@ -1,0 +1,52 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 641f71c114aeea55cc535ba43b430de11614cb3b..3d293a579b5e4958e5f0878b86d3e0bd95f0cc19 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -51,6 +51,10 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+   set(LLVM_RUNTIME_OUTPUT_INTDIR ${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}/bin)
+   find_program(LLVM_TABLEGEN_EXE "llvm-tblgen" ${LLVM_TOOLS_BINARY_DIR} NO_DEFAULT_PATH)
+
++  if(LLVM_ENABLE_ZLIB)
++    find_package(ZLIB)
++  endif()
++
+   include(AddLLVM)
+   include(TableGen)
+   include(HandleLLVMOptions)
+diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
+index 8be42c46dd8ad46d25bc88ed599764fbd271389d..dc8cedf2ea095e0b02a7361a9c9a344791fe884f 100644
+--- a/test/CMakeLists.txt
++++ b/test/CMakeLists.txt
+@@ -4,17 +4,8 @@ set(LLVM_BUILD_MODE "%(build_mode)s")
+ set(LLVM_TOOLS_DIR "${LLVM_TOOLS_BINARY_DIR}/%(build_config)s")
+ set(LLVM_LIBS_DIR "${LLVM_BINARY_DIR}/lib${LLVM_LIBDIR_SUFFIX}/%(build_config)s")
+
+-if(LLD_BUILT_STANDALONE)
+-  # Set HAVE_LIBZ according to recorded LLVM_ENABLE_ZLIB value. This
+-  # value is forced to 0 if zlib was not found, so it is fine to use it
+-  # instead of HAVE_LIBZ (not recorded).
+-  if(LLVM_ENABLE_ZLIB)
+-    set(HAVE_LIBZ 1)
+-  endif()
+-endif()
+-
+ llvm_canonicalize_cmake_booleans(
+-  HAVE_LIBZ
++  LLVM_ENABLE_ZLIB
+   LLVM_LIBXML2_ENABLED
+   )
+
+diff --git a/test/lit.site.cfg.py.in b/test/lit.site.cfg.py.in
+index 02840f8d6a30361234cf76df06c1de6f72410b43..531fce15839d527db1aa706cd69c5d2871a037b4 100644
+--- a/test/lit.site.cfg.py.in
++++ b/test/lit.site.cfg.py.in
+@@ -14,7 +14,7 @@ config.lld_libs_dir = "@LLVM_LIBRARY_OUTPUT_INTDIR@"
+ config.lld_tools_dir = "@LLVM_RUNTIME_OUTPUT_INTDIR@"
+ config.target_triple = "@TARGET_TRIPLE@"
+ config.python_executable = "@PYTHON_EXECUTABLE@"
+-config.have_zlib = @HAVE_LIBZ@
++config.have_zlib = @LLVM_ENABLE_ZLIB@
+ config.sizeof_void_p = @CMAKE_SIZEOF_VOID_P@
+
+ # Support substitution of the tools and libs dirs with user parameters. This is
+

--- a/llvm/10.0.1-lldb.diff
+++ b/llvm/10.0.1-lldb.diff
@@ -1,0 +1,63 @@
+diff --git a/cmake/modules/LLDBStandalone.cmake b/cmake/modules/LLDBStandalone.cmake
+index 752113bcc6c414b06c841b094afab95992a12631..94781c35837445c1be5ec5022ec2b40d3f4fe58f 100644
+--- a/cmake/modules/LLDBStandalone.cmake
++++ b/cmake/modules/LLDBStandalone.cmake
+@@ -73,6 +73,7 @@ endif()
+ # We append the directory in which LLVMConfig.cmake lives. We expect LLVM's
+ # CMake modules to be in that directory as well.
+ list(APPEND CMAKE_MODULE_PATH "${LLVM_DIR}")
++
+ include(AddLLVM)
+ include(TableGen)
+ include(HandleLLVMOptions)
+diff --git a/source/Core/CMakeLists.txt b/source/Core/CMakeLists.txt
+index a03fe6f4800fbd488524300278281da09f4ac28d..37f48bfeda953b259aeee55f9829587226fba6ad 100644
+--- a/source/Core/CMakeLists.txt
++++ b/source/Core/CMakeLists.txt
+@@ -11,8 +11,8 @@ set(LLDB_LIBEDIT_LIBS)
+
+ if (LLDB_ENABLE_CURSES)
+   list(APPEND LLDB_CURSES_LIBS ${CURSES_LIBRARIES} ${PANEL_LIBRARIES})
+-  if(LLVM_ENABLE_TERMINFO AND HAVE_TERMINFO)
+-    list(APPEND LLDB_CURSES_LIBS ${TERMINFO_LIBS})
++  if(LLVM_ENABLE_TERMINFO)
++    list(APPEND LLDB_CURSES_LIBS ${TERMINFO_LIB})
+   endif()
+   if (LLVM_BUILD_STATIC)
+     list(APPEND LLDB_CURSES_LIBS gpm)
+diff --git a/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp b/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp
+index 0a98f6a15d755ddb5497fc636831b97e4c81a200..7cea013eea7fa16497017f5266fc4534051f2b86 100644
+--- a/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp
++++ b/source/Plugins/Process/gdb-remote/GDBRemoteCommunication.cpp
+@@ -50,7 +50,7 @@
+ #include <compression.h>
+ #endif
+
+-#if defined(HAVE_LIBZ)
++#if LLVM_ENABLE_ZLIB
+ #include <zlib.h>
+ #endif
+
+@@ -582,7 +582,7 @@ bool GDBRemoteCommunication::DecompressPacket() {
+   }
+ #endif
+
+-#if defined(HAVE_LIBZ)
++#if LLVM_ENABLE_ZLIB
+   if (decompressed_bytes == 0 && decompressed_bufsize != ULONG_MAX &&
+       decompressed_buffer != nullptr &&
+       m_compression_type == CompressionType::ZlibDeflate) {
+diff --git a/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp b/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
+index 4dafa1d494d814fe33ada149883f46067a8b5819..b2f1ee527e8b1f58331f86ce64cc905b42c5fe03 100644
+--- a/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
++++ b/source/Plugins/Process/gdb-remote/GDBRemoteCommunicationClient.cpp
+@@ -1045,7 +1045,7 @@ void GDBRemoteCommunicationClient::MaybeEnableCompression(
+   }
+ #endif
+
+-#if defined(HAVE_LIBZ)
++#if LLVM_ENABLE_ZLIB
+   if (avail_type == CompressionType::None) {
+     for (auto compression : supported_compressions) {
+       if (compression == "zlib-deflate") {
+

--- a/llvm/10.0.1-llvm.diff
+++ b/llvm/10.0.1-llvm.diff
@@ -1,0 +1,408 @@
+diff --git a/cmake/config-ix.cmake b/cmake/config-ix.cmake
+index f758366bc79d4a483bf601bedbe7b876f65843a6..0de9d4cfb8e71a4606a097189f0cabf531f784ed 100644
+--- a/cmake/config-ix.cmake
++++ b/cmake/config-ix.cmake
+@@ -9,6 +9,7 @@ include(CheckSymbolExists)
+ include(CheckFunctionExists)
+ include(CheckStructHasMember)
+ include(CheckCCompilerFlag)
++include(CMakePushCheckState)
+
+ include(CheckCompilerVersion)
+ include(HandleLLVMStdlib)
+@@ -56,7 +57,6 @@ check_include_file(sys/types.h HAVE_SYS_TYPES_H)
+ check_include_file(termios.h HAVE_TERMIOS_H)
+ check_include_file(unistd.h HAVE_UNISTD_H)
+ check_include_file(valgrind/valgrind.h HAVE_VALGRIND_VALGRIND_H)
+-check_include_file(zlib.h HAVE_ZLIB_H)
+ check_include_file(fenv.h HAVE_FENV_H)
+ check_symbol_exists(FE_ALL_EXCEPT "fenv.h" HAVE_DECL_FE_ALL_EXCEPT)
+ check_symbol_exists(FE_INEXACT "fenv.h" HAVE_DECL_FE_INEXACT)
+@@ -115,22 +115,30 @@ if(HAVE_LIBPTHREAD)
+   set(LLVM_PTHREAD_LIB ${CMAKE_THREAD_LIBS_INIT})
+ endif()
+
++if(LLVM_ENABLE_ZLIB)
++  if(LLVM_ENABLE_ZLIB STREQUAL FORCE_ON)
++    find_package(ZLIB REQUIRED)
++  elseif(NOT LLVM_USE_SANITIZER MATCHES "Memory.*")
++    find_package(ZLIB)
++  endif()
++  if(ZLIB_FOUND)
++    # Check if zlib we found is usable; for example, we may have found a 32-bit
++    # library on a 64-bit system which would result in a link-time failure.
++    cmake_push_check_state()
++    set(CMAKE_REQUIRED_INCLUDES ${ZLIB_INCLUDE_DIRS})
++    set(CMAKE_REQUIRED_LIBRARIES ${ZLIB_LIBRARY})
++    check_symbol_exists(compress2 zlib.h HAVE_ZLIB)
++    cmake_pop_check_state()
++    if(LLVM_ENABLE_ZLIB STREQUAL FORCE_ON AND NOT HAVE_ZLIB)
++      message(FATAL_ERROR "Failed to configure zlib")
++    endif()
++  endif()
++  set(LLVM_ENABLE_ZLIB "${HAVE_ZLIB}")
++endif()
++
+ # Don't look for these libraries if we're using MSan, since uninstrumented third
+ # party code may call MSan interceptors like strlen, leading to false positives.
+ if(NOT LLVM_USE_SANITIZER MATCHES "Memory.*")
+-  set(HAVE_LIBZ 0)
+-  if(LLVM_ENABLE_ZLIB)
+-    foreach(library z zlib_static zlib)
+-      string(TOUPPER ${library} library_suffix)
+-      check_library_exists(${library} compress2 "" HAVE_LIBZ_${library_suffix})
+-      if(HAVE_LIBZ_${library_suffix})
+-        set(HAVE_LIBZ 1)
+-        set(ZLIB_LIBRARIES "${library}")
+-        break()
+-      endif()
+-    endforeach()
+-  endif()
+-
+   # Don't look for these libraries on Windows.
+   if (NOT PURE_WINDOWS)
+     # Skip libedit if using ASan as it contains memory leaks.
+@@ -139,19 +147,16 @@ if(NOT LLVM_USE_SANITIZER MATCHES "Memory.*")
+     else()
+       set(HAVE_LIBEDIT 0)
+     endif()
+-    if(LLVM_ENABLE_TERMINFO)
+-      set(HAVE_TERMINFO 0)
+-      foreach(library terminfo tinfo curses ncurses ncursesw)
+-        string(TOUPPER ${library} library_suffix)
+-        check_library_exists(${library} setupterm "" HAVE_TERMINFO_${library_suffix})
+-        if(HAVE_TERMINFO_${library_suffix})
+-          set(HAVE_TERMINFO 1)
+-          set(TERMINFO_LIBS "${library}")
+-          break()
+-        endif()
+-      endforeach()
++    if(LLVM_ENABLE_TERMINFO STREQUAL FORCE_ON)
++      set(MAYBE_REQUIRED REQUIRED)
++    else()
++      set(MAYBE_REQUIRED)
++    endif()
++    find_library(TERMINFO_LIB NAMES terminfo tinfo curses ncurses ncursesw ${MAYBE_REQUIRED})
++    if(TERMINFO_LIB)
++      set(LLVM_ENABLE_TERMINFO 1)
+     else()
+-      set(HAVE_TERMINFO 0)
++      set(LLVM_ENABLE_TERMINFO 0)
+     endif()
+
+     find_library(ICONV_LIBRARY_PATH NAMES iconv libiconv libiconv-2 c)
+@@ -515,13 +520,6 @@ else( LLVM_ENABLE_THREADS )
+   message(STATUS "Threads disabled.")
+ endif()
+
+-if (LLVM_ENABLE_ZLIB )
+-  # Check if zlib is available in the system.
+-  if ( NOT HAVE_ZLIB_H OR NOT HAVE_LIBZ )
+-    set(LLVM_ENABLE_ZLIB 0)
+-  endif()
+-endif()
+-
+ if (LLVM_ENABLE_DOXYGEN)
+   message(STATUS "Doxygen enabled.")
+   find_package(Doxygen REQUIRED)
+diff --git a/cmake/modules/LLVMConfig.cmake.in b/cmake/modules/LLVMConfig.cmake.in
+index 87684ecba0f50827b3d254f930607d3c8fed81bc..c7d8ee1d492bca24195be993fa77b636bdd1e0a7 100644
+--- a/cmake/modules/LLVMConfig.cmake.in
++++ b/cmake/modules/LLVMConfig.cmake.in
+@@ -50,6 +50,9 @@ set(LLVM_ENABLE_THREADS @LLVM_ENABLE_THREADS@)
+ set(LLVM_ENABLE_UNWIND_TABLES @LLVM_ENABLE_UNWIND_TABLES@)
+
+ set(LLVM_ENABLE_ZLIB @LLVM_ENABLE_ZLIB@)
++if(LLVM_ENABLE_ZLIB)
++  find_package(ZLIB)
++endif()
+
+ set(LLVM_LIBXML2_ENABLED @LLVM_LIBXML2_ENABLED@)
+
+diff --git a/include/llvm/Config/config.h.cmake b/include/llvm/Config/config.h.cmake
+index 1a38bc15ab9d6696833149803c25948b5c6307d4..40712a67000ef5bd83ad2a447f3eb259e327ae41 100644
+--- a/include/llvm/Config/config.h.cmake
++++ b/include/llvm/Config/config.h.cmake
+@@ -109,9 +109,6 @@
+ /* Define to 1 if you have the `pthread_setname_np' function. */
+ #cmakedefine HAVE_PTHREAD_SETNAME_NP ${HAVE_PTHREAD_SETNAME_NP}
+
+-/* Define to 1 if you have the `z' library (-lz). */
+-#cmakedefine HAVE_LIBZ ${HAVE_LIBZ}
+-
+ /* Define to 1 if you have the <link.h> header file. */
+ #cmakedefine HAVE_LINK_H ${HAVE_LINK_H}
+
+@@ -212,7 +209,7 @@
+ #cmakedefine HAVE_SYS_TYPES_H ${HAVE_SYS_TYPES_H}
+
+ /* Define if the setupterm() function is supported this platform. */
+-#cmakedefine HAVE_TERMINFO ${HAVE_TERMINFO}
++#cmakedefine LLVM_ENABLE_TERMINFO ${LLVM_ENABLE_TERMINFO}
+
+ /* Define if the xar_open() function is supported this platform. */
+ #cmakedefine HAVE_LIBXAR ${HAVE_LIBXAR}
+@@ -226,9 +223,6 @@
+ /* Define to 1 if you have the <valgrind/valgrind.h> header file. */
+ #cmakedefine HAVE_VALGRIND_VALGRIND_H ${HAVE_VALGRIND_VALGRIND_H}
+
+-/* Define to 1 if you have the <zlib.h> header file. */
+-#cmakedefine HAVE_ZLIB_H ${HAVE_ZLIB_H}
+-
+ /* Have host's _alloca */
+ #cmakedefine HAVE__ALLOCA ${HAVE__ALLOCA}
+
+diff --git a/lib/Support/CMakeLists.txt b/lib/Support/CMakeLists.txt
+index ddc4d2324a057877292e4a5df0eaefd39e49aea9..7332a1a262d224d76a66967e514a390652fd035f 100644
+--- a/lib/Support/CMakeLists.txt
++++ b/lib/Support/CMakeLists.txt
+@@ -1,7 +1,16 @@
+-set(system_libs)
+-if ( LLVM_ENABLE_ZLIB AND HAVE_LIBZ )
+-  set(system_libs ${system_libs} ${ZLIB_LIBRARIES})
++if(LLVM_ENABLE_ZLIB)
++  set(imported_libs ZLIB::ZLIB)
+ endif()
++
++function(get_system_libname libpath libname)
++  get_filename_component(libpath ${libpath} NAME)
++  string(REPLACE ";" "|" PREFIXES "${CMAKE_FIND_LIBRARY_PREFIXES}")
++  string(REPLACE ";" "|" SUFFIXES "${CMAKE_FIND_LIBRARY_SUFFIXES}")
++  STRING(REGEX REPLACE "^(${PREFIXES})" "" libpath ${libpath})
++  STRING(REGEX REPLACE "(${SUFFIXES})$" "" libpath ${libpath})
++  set(${libname} "${libpath}" PARENT_SCOPE)
++endfunction()
++
+ if( MSVC OR MINGW )
+   # libuuid required for FOLDERID_Profile usage in lib/Support/Windows/Path.inc.
+   # advapi32 required for CryptAcquireContextW in lib/Support/Windows/Path.inc.
+@@ -21,10 +30,8 @@ elseif( CMAKE_HOST_UNIX )
+     STRING(REGEX REPLACE "^lib" "" Backtrace_LIBFILE ${Backtrace_LIBFILE})
+     set(system_libs ${system_libs} ${Backtrace_LIBFILE})
+   endif()
+-  if(LLVM_ENABLE_TERMINFO)
+-    if(HAVE_TERMINFO)
+-      set(system_libs ${system_libs} ${TERMINFO_LIBS})
+-    endif()
++  if( LLVM_ENABLE_TERMINFO )
++    set(imported_libs ${imported_libs} "${TERMINFO_LIB}")
+   endif()
+   if( LLVM_ENABLE_THREADS AND HAVE_LIBATOMIC )
+     set(system_libs ${system_libs} atomic)
+@@ -186,10 +193,30 @@ add_llvm_component_library(LLVMSupport
+   ${LLVM_MAIN_INCLUDE_DIR}/llvm/ADT
+   ${LLVM_MAIN_INCLUDE_DIR}/llvm/Support
+   ${Backtrace_INCLUDE_DIRS}
+-  LINK_LIBS ${system_libs} ${delayload_flags} ${Z3_LINK_FILES}
++  LINK_LIBS ${system_libs} ${imported_libs} ${delayload_flags} ${Z3_LINK_FILES}
+   )
+
+-set_property(TARGET LLVMSupport PROPERTY LLVM_SYSTEM_LIBS "${system_libs}")
++set(llvm_system_libs ${system_libs})
++
++if(LLVM_ENABLE_ZLIB)
++  # CMAKE_BUILD_TYPE is only meaningful to single-configuration generators.
++  if(CMAKE_BUILD_TYPE)
++    string(TOUPPER ${CMAKE_BUILD_TYPE} build_type)
++    get_property(zlib_library TARGET ZLIB::ZLIB PROPERTY LOCATION_${build_type})
++  endif()
++  if(NOT zlib_library)
++    get_property(zlib_library TARGET ZLIB::ZLIB PROPERTY LOCATION)
++  endif()
++  get_system_libname(${zlib_library} zlib_library)
++  set(llvm_system_libs ${llvm_system_libs} "${zlib_library}")
++endif()
++
++if(LLVM_ENABLE_TERMINFO)
++  get_system_libname(${TERMINFO_LIB} terminfo_library)
++  set(llvm_system_libs ${llvm_system_libs} "${terminfo_library}")
++endif()
++
++set_property(TARGET LLVMSupport PROPERTY LLVM_SYSTEM_LIBS "${llvm_system_libs}")
+
+ if(LLVM_WITH_Z3)
+   target_include_directories(LLVMSupport SYSTEM
+diff --git a/lib/Support/CRC.cpp b/lib/Support/CRC.cpp
+index 7ff09debe3b7c8649614b7838ab31bc3c71eed0d..2bc668beed3223129beb56a8b8f9f3a741859922 100644
+--- a/lib/Support/CRC.cpp
++++ b/lib/Support/CRC.cpp
+@@ -25,7 +25,7 @@
+
+ using namespace llvm;
+
+-#if LLVM_ENABLE_ZLIB == 0 || !HAVE_ZLIB_H
++#if !LLVM_ENABLE_ZLIB
+
+ static const uint32_t CRCTable[256] = {
+     0x00000000, 0x77073096, 0xee0e612c, 0x990951ba, 0x076dc419, 0x706af48f,
+diff --git a/lib/Support/Compression.cpp b/lib/Support/Compression.cpp
+index 97d5ffaadf8273dd42955fb570282253c1027e3f..4165a2740cd0306da65bdcda309307787b71e500 100644
+--- a/lib/Support/Compression.cpp
++++ b/lib/Support/Compression.cpp
+@@ -17,13 +17,13 @@
+ #include "llvm/Support/Compiler.h"
+ #include "llvm/Support/Error.h"
+ #include "llvm/Support/ErrorHandling.h"
+-#if LLVM_ENABLE_ZLIB == 1 && HAVE_ZLIB_H
++#if LLVM_ENABLE_ZLIB
+ #include <zlib.h>
+ #endif
+
+ using namespace llvm;
+
+-#if LLVM_ENABLE_ZLIB == 1 && HAVE_LIBZ
++#if LLVM_ENABLE_ZLIB
+ static Error createError(StringRef Err) {
+   return make_error<StringError>(Err, inconvertibleErrorCode());
+ }
+diff --git a/lib/Support/Unix/Process.inc b/lib/Support/Unix/Process.inc
+index dfe81d7e28337a1579ec74800db177d95e8b6be7..c380f6de75e252abd12027de69a3fd39c3cae51a 100644
+--- a/lib/Support/Unix/Process.inc
++++ b/lib/Support/Unix/Process.inc
+@@ -315,7 +315,7 @@ unsigned Process::StandardErrColumns() {
+   return getColumns(2);
+ }
+
+-#ifdef HAVE_TERMINFO
++#ifdef LLVM_ENABLE_TERMINFO
+ // We manually declare these extern functions because finding the correct
+ // headers from various terminfo, curses, or other sources is harder than
+ // writing their specs down.
+@@ -325,12 +325,12 @@ extern "C" int del_curterm(struct term *termp);
+ extern "C" int tigetnum(char *capname);
+ #endif
+
+-#ifdef HAVE_TERMINFO
++#ifdef LLVM_ENABLE_TERMINFO
+ static ManagedStatic<std::mutex> TermColorMutex;
+ #endif
+
+ static bool terminalHasColors(int fd) {
+-#ifdef HAVE_TERMINFO
++#ifdef LLVM_ENABLE_TERMINFO
+   // First, acquire a global lock because these C routines are thread hostile.
+   std::lock_guard<std::mutex> G(*TermColorMutex);
+
+diff --git a/test/CMakeLists.txt b/test/CMakeLists.txt
+index 38eed78f8aea0b88428615f650812765e92c6dae..e15dbb11e754720882a691b4fd0997281d42fc3f 100644
+--- a/test/CMakeLists.txt
++++ b/test/CMakeLists.txt
+@@ -1,12 +1,12 @@
+ llvm_canonicalize_cmake_booleans(
+   BUILD_SHARED_LIBS
+   HAVE_LIBXAR
+-  HAVE_LIBZ
+   HAVE_OCAMLOPT
+   HAVE_OCAML_OUNIT
+   LLVM_ENABLE_DIA_SDK
+   LLVM_ENABLE_FFI
+   LLVM_ENABLE_THREADS
++  LLVM_ENABLE_ZLIB
+   LLVM_INCLUDE_GO_TESTS
+   LLVM_LIBXML2_ENABLED
+   LLVM_LINK_LLVM_DYLIB
+diff --git a/test/lit.site.cfg.py.in b/test/lit.site.cfg.py.in
+index 6f4d5f790828132112afdd4948ff31450da37698..b872a8a0a6edebd2578a325a710c917750afcc1d 100644
+--- a/test/lit.site.cfg.py.in
++++ b/test/lit.site.cfg.py.in
+@@ -33,7 +33,7 @@ config.host_cxx = "@HOST_CXX@"
+ config.host_ldflags = '@HOST_LDFLAGS@'
+ config.llvm_use_intel_jitevents = @LLVM_USE_INTEL_JITEVENTS@
+ config.llvm_use_sanitizer = "@LLVM_USE_SANITIZER@"
+-config.have_zlib = @HAVE_LIBZ@
++config.have_zlib = @LLVM_ENABLE_ZLIB@
+ config.have_libxar = @HAVE_LIBXAR@
+ config.have_dia_sdk = @LLVM_ENABLE_DIA_SDK@
+ config.enable_ffi = @LLVM_ENABLE_FFI@
+diff --git a/unittests/Support/CompressionTest.cpp b/unittests/Support/CompressionTest.cpp
+index cc7be431b62bc392508fd342c7db0dbbde995823..51723898e950d0bd2389467eda224b2c57fcd14e 100644
+--- a/unittests/Support/CompressionTest.cpp
++++ b/unittests/Support/CompressionTest.cpp
+@@ -21,7 +21,7 @@ using namespace llvm;
+
+ namespace {
+
+-#if LLVM_ENABLE_ZLIB == 1 && HAVE_LIBZ
++#if LLVM_ENABLE_ZLIB
+
+ void TestZlibCompression(StringRef Input, int Level) {
+   SmallString<32> Compressed;
+diff --git a/utils/gn/secondary/clang/test/BUILD.gn b/utils/gn/secondary/clang/test/BUILD.gn
+index 5cdbab8da281b9a22ce43c96233ea3b11947d9e4..a16f8ea4b074241fc4d01b0c1de1ecddcc512c60 100644
+--- a/utils/gn/secondary/clang/test/BUILD.gn
++++ b/utils/gn/secondary/clang/test/BUILD.gn
+@@ -74,9 +74,9 @@ write_lit_config("lit_site_cfg") {
+   }
+
+   if (llvm_enable_zlib) {
+-    extra_values += [ "HAVE_LIBZ=1" ]
++    extra_values += [ "LLVM_ENABLE_ZLIB=1" ]
+   } else {
+-    extra_values += [ "HAVE_LIBZ=0" ]  # Must be 0.
++    extra_values += [ "LLVM_ENABLE_ZLIB=0" ]  # Must be 0.
+   }
+
+   if (host_cpu == "x64") {
+diff --git a/utils/gn/secondary/compiler-rt/test/BUILD.gn b/utils/gn/secondary/compiler-rt/test/BUILD.gn
+index c03399193babac3d46b65400618a4e50fb9e9c0f..b0c690193a2e6ff392af95f47a3d90463889b83c 100644
+--- a/utils/gn/secondary/compiler-rt/test/BUILD.gn
++++ b/utils/gn/secondary/compiler-rt/test/BUILD.gn
+@@ -85,8 +85,8 @@ write_cmake_config("lit_common_configured") {
+   }
+
+   if (llvm_enable_zlib) {
+-    values += [ "HAVE_LIBZ=1" ]
++    values += [ "LLVM_ENABLE_ZLIB=1" ]
+   } else {
+-    values += [ "HAVE_LIBZ=0" ]
++    values += [ "LLVM_ENABLE_ZLIB=0" ]
+   }
+ }
+diff --git a/utils/gn/secondary/lld/test/BUILD.gn b/utils/gn/secondary/lld/test/BUILD.gn
+index 0f8e2c13874d0e9602ecc3244020fbcefae4ca01..4479205a0233e77b9b3686449b5990f8b7aa89fe 100644
+--- a/utils/gn/secondary/lld/test/BUILD.gn
++++ b/utils/gn/secondary/lld/test/BUILD.gn
+@@ -49,9 +49,9 @@ write_lit_cfg("lit_site_cfg") {
+   }
+
+   if (llvm_enable_zlib) {
+-    extra_values += [ "HAVE_LIBZ=1" ]
++    extra_values += [ "LLVM_ENABLE_ZLIB=1" ]
+   } else {
+-    extra_values += [ "HAVE_LIBZ=0" ]  # Must be 0.
++    extra_values += [ "LLVM_ENABLE_ZLIB=0" ]  # Must be 0.
+   }
+
+   if (current_cpu == "x64" || current_cpu == "arm64" ||
+diff --git a/utils/gn/secondary/llvm/include/llvm/Config/BUILD.gn b/utils/gn/secondary/llvm/include/llvm/Config/BUILD.gn
+index 96be1e98fe9b04d4192175008ddb45793e5ae265..7a8b9e5049dc7e3366cd1aa44419fa45a3163447 100644
+--- a/utils/gn/secondary/llvm/include/llvm/Config/BUILD.gn
++++ b/utils/gn/secondary/llvm/include/llvm/Config/BUILD.gn
+@@ -294,9 +294,9 @@ write_cmake_config("config") {
+   }
+
+   if (llvm_enable_terminfo) {
+-    values += [ "HAVE_TERMINFO=1" ]
++    values += [ "LLVM_ENABLE_TERMINFO=1" ]
+   } else {
+-    values += [ "HAVE_TERMINFO=" ]
++    values += [ "LLVM_ENABLE_TERMINFO=" ]
+   }
+
+   if (llvm_enable_dia_sdk) {
+diff --git a/utils/gn/secondary/llvm/test/BUILD.gn b/utils/gn/secondary/llvm/test/BUILD.gn
+index 5ac7a72437e0fd6a4dd55ec318875b9208b662dd..b9d649a0d15ec18a4e3d82ab413f99729a1f93d5 100644
+--- a/utils/gn/secondary/llvm/test/BUILD.gn
++++ b/utils/gn/secondary/llvm/test/BUILD.gn
+@@ -166,9 +166,9 @@ write_lit_config("lit_site_cfg") {
+   }
+
+   if (llvm_enable_zlib) {
+-    extra_values += [ "HAVE_LIBZ=1" ]
++    extra_values += [ "LLVM_ENABLE_ZLIB=1" ]
+   } else {
+-    extra_values += [ "HAVE_LIBZ=0" ]  # Must be 0.
++    extra_values += [ "LLVM_ENABLE_ZLIB=0" ]  # Must be 0.
+   }
+ }
+


### PR DESCRIPTION
These patches are required to solve https://discourse.brew.sh/t/llvm-config-10-0-1-advertise-libxml2-tbd-as-system-libs/8593/1

They were constructed by backporting the following commits to llvm's 10.x branch.

```
$ git cherry-pick 8c1a79dc12f3cc600e16153961cd8cc50ba2c33b
- fix conflicts lld/test/lit.site.cfg.py.in

$ git cherry-pick bcd27d9d73f74f291fbd8b0fd1182e69a327be88
- fix conflicts lld/test/lit.site.cfg.py.in

$ git cherry-pick 1d09ecf36175f7910ffedd6d497c07b5c74c22fb
- fix conflicts lld/test/lit.site.cfg.py.in

$ git cherry-pick 38c71b7c85cac4c8de39329ff3ed682e63f61525
- fix conflicts lld/test/lit.site.cfg.py.in

$ git cherry-pick 10b1b4a231a485f1711d576e6131f6755e008abe
- fix conflicts lld/test/lit.site.cfg.py.in
- delete mlir/examples/standalone/CMakeLists.txt

$ git cherry-pick 3ab01550b632dad46f9595d74855749557ffd25c
- fix conflicts lld/test/lit.site.cfg.py.in
- fix conflicts lldb/cmake/modules/LLDBStandalone.cmake
- fix conflicts llvm/lib/Support/CMakeLists.txt
- delete mlir/examples/standalone/CMakeLists.txt

$ git cherry-pick 1adc494bce44f6004994deed61b30d4b71fe1d05
- fix conflicts lld/test/lit.site.cfg.py.in

$ git cherry-pick f3cc4df51da4331b170065e01a6a80ee05ed0c23
- fix conflicts lld/test/lit.site.cfg.py.in

$ git cherry-pick ccbc1485b55ff4acd21bcfafbf7aec4ed0fd818d
- fix conflicts lld/test/lit.site.cfg.py.in

$ git cherry-pick a4d78d23c53451ccefe0df0adfff9a1ac3077f10
- fix conflicts lld/test/lit.site.cfg.py.in

$ git cherry-pick 31e5f7120bdd2f76337686d9d169b1c00e6ee69c
- fix conflicts lld/test/lit.site.cfg.py.in

$ git cherry-pick a52173a3e56553d7b795bcf3cdadcf6433117107

$ git cherry-pick 8e4acb82f71ad4effec8895b8fc957189ce95933
```