### PR TITLE
upscaledb: patch for 2.2.1

### DIFF
--- a/upscaledb/2.2.1.diff
+++ b/upscaledb/2.2.1.diff
@@ -1,0 +1,300 @@
+diff --git a/configure.ac b/configure.ac
+index bbedefc4..1459ecd1 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -14,8 +14,7 @@ AC_COPYRIGHT([Copyright (C) 2005-2017 Christoph Rupp (chris@crupp.de)])
+ AC_CANONICAL_HOST
+ AC_ENABLE_SHARED
+ AC_ENABLE_STATIC
+-: ${CFLAGS="-DNDEBUG"} 
+-: ${CXXFLAGS="-DNDEBUG"} 
++: ${CFLAGS="-DNDEBUG"}
+ AC_PROG_CC
+ AC_PROG_CC_STDC
+ AC_PROG_CXX
+@@ -51,9 +50,13 @@ AM_CONDITIONAL([DARWIN],  [AS_CASE([$host_os], [darwin*],  [true], [false])])
+ AM_CONDITIONAL([FREEBSD], [AS_CASE([$host_os], [freebsd*], [true], [false])])
+ AM_CONDITIONAL([LINUX],   [AS_CASE([$host_os], [linux*],   [true], [false])])
+ AM_CONDITIONAL([SUNOS],   [AS_CASE([$host_os], [solaris*], [true], [false])])
++AM_CONDITIONAL([WINDOWS], [AS_CASE([$host_os], [mingw32*], [true], [false])])
+
+ # issue 28: do not test for boost_chrono on MacOS
+ case "$host_os" in
++  *mingw32*)
++    CFLAGS="$CFLAGS -Wa,-mbig-obj"
++    ;;
+   *darwin*)
+     ;;
+   *)
+@@ -165,19 +168,28 @@ AC_ARG_ENABLE(simd,
+ if test x$enable_simd = xno; then
+   settings="$settings (no simd)"
+ else
+-  if grep -q sse4 /proc/cpuinfo; then
+-    AM_CONDITIONAL(ENABLE_SSE4, true)
+-    settings="$settings (simd-sse4)"
+-  else
+-    settings="$settings (no simd-sse4)"
+-  fi
+-
+-  if grep -q sse2 /proc/cpuinfo; then
+-    AM_CONDITIONAL(ENABLE_SSE2, true)
+-    settings="$settings (simd-sse2)"
+-  else
+-    settings="$settings (no simd-sse2)"
+-  fi
++  case "$host_os" in
++    *darwin*)
++      if sysctl -n hw.optional.sse4_1; then
++        AM_CONDITIONAL(ENABLE_SSE4, true)
++        settings="$settings (simd-sse4)"
++      fi
++      if sysctl -n hw.optional.sse2; then
++        AM_CONDITIONAL(ENABLE_SSE2, true)
++        settings="$settings (simd-sse2)"
++      fi
++      ;;
++    *)
++      if grep -q sse4 /proc/cpuinfo; then
++        AM_CONDITIONAL(ENABLE_SSE4, true)
++        settings="$settings (simd-sse4)"
++      fi
++      if grep -q sse2 /proc/cpuinfo; then
++        AM_CONDITIONAL(ENABLE_SSE2, true)
++        settings="$settings (simd-sse2)"
++      fi
++      ;;
++  esac
+ fi
+
+ # -------------------------------------------------------------------------
+@@ -246,8 +258,7 @@ else
+   AM_CONDITIONAL(WITH_BERKELEYDB, false)
+ fi
+
+-
+-CXXFLAGS=${CFLAGS}
++CXXFLAGS="$CFLAGS -std=c++0x"
+
+ # -------------------------------------------------------------------------
+ # -------------------------------------------------------------------------
+diff --git a/src/1os/file.h b/src/1os/file.h
+index 76de1330..170a8d16 100644
+--- a/src/1os/file.h
++++ b/src/1os/file.h
+@@ -19,9 +19,6 @@
+ /*
+  * A simple wrapper around a file handle. Throws exceptions in
+  * case of errors. Moves the file handle when copied.
+- *
+- * @exception_safe: strong
+- * @thread_safe: unknown
+  */
+
+ #ifndef UPS_FILE_H
+@@ -67,7 +64,7 @@ class File
+     }
+
+     // Copy constructor: moves ownership of the file handle
+-    File(File &other)
++    File(File &&other)
+       : m_fd(other.m_fd), m_mmaph(other.m_mmaph),
+         m_posix_advice(other.m_posix_advice) {
+       other.m_fd = UPS_INVALID_FD;
+@@ -80,7 +77,7 @@ class File
+     }
+
+     // Assignment operator: moves ownership of the file handle
+-    File &operator=(File &other) {
++    File &operator=(File &&other) {
+       m_fd = other.m_fd;
+       other.m_fd = UPS_INVALID_FD;
+       return *this;
+diff --git a/src/1os/os.h b/src/1os/os.h
+index d3b8ca70..ecd5d72a 100644
+--- a/src/1os/os.h
++++ b/src/1os/os.h
+@@ -18,10 +18,6 @@
+
+ /*
+  * Abstraction layer for operating system functions
+- *
+- * @exception_safe: basic // for socket
+- * @exception_safe: strong // for file
+- * @thread_safe: unknown
+  */
+
+ #ifndef UPS_OS_H
+diff --git a/src/2aes/aes.h b/src/2aes/aes.h
+index aa58902a..8d92649e 100644
+--- a/src/2aes/aes.h
++++ b/src/2aes/aes.h
+@@ -49,19 +49,20 @@ struct AesCipher
+   AesCipher(const uint8_t key[kAesBlockSize], uint64_t salt = 0) {
+     uint64_t iv[2] = {salt, 0};
+
+-    EVP_CIPHER_CTX_init(&encrypt_ctx_);
+-    EVP_EncryptInit_ex(&encrypt_ctx_, EVP_aes_128_cbc(), NULL, key,
++    encrypt_ctx_ = EVP_CIPHER_CTX_new();
++    EVP_EncryptInit_ex(encrypt_ctx_, EVP_aes_128_cbc(), NULL, key,
+                    (uint8_t *)&iv[0]);
+-    EVP_CIPHER_CTX_init(&decrypt_ctx_);
+-    EVP_DecryptInit_ex(&decrypt_ctx_, EVP_aes_128_cbc(), NULL, key,
++    decrypt_ctx_ = EVP_CIPHER_CTX_new();
++    EVP_DecryptInit_ex(decrypt_ctx_, EVP_aes_128_cbc(), NULL, key,
+                    (uint8_t *)&iv[0]);
+-    EVP_CIPHER_CTX_set_padding(&encrypt_ctx_, 0);
+-    EVP_CIPHER_CTX_set_padding(&decrypt_ctx_, 0);
++
++    EVP_CIPHER_CTX_set_padding(encrypt_ctx_, 0);
++    EVP_CIPHER_CTX_set_padding(decrypt_ctx_, 0);
+   }
+
+   ~AesCipher() {
+-    EVP_CIPHER_CTX_cleanup(&encrypt_ctx_);
+-    EVP_CIPHER_CTX_cleanup(&decrypt_ctx_);
++    EVP_CIPHER_CTX_cleanup(encrypt_ctx_);
++    EVP_CIPHER_CTX_cleanup(decrypt_ctx_);
+   }
+
+   /*
+@@ -76,11 +77,11 @@ struct AesCipher
+     /* update ciphertext, c_len is filled with the length of ciphertext
+      * generated, len is the size of plaintext in bytes */
+     int clen = (int)len;
+-    EVP_EncryptUpdate(&encrypt_ctx_, ciphertext, &clen, plaintext, (int)len);
++    EVP_EncryptUpdate(encrypt_ctx_, ciphertext, &clen, plaintext, (int)len);
+
+     /* update ciphertext with the final remaining bytes */
+     int outlen;
+-    EVP_EncryptFinal(&encrypt_ctx_, ciphertext + clen, &outlen);
++    EVP_EncryptFinal(encrypt_ctx_, ciphertext + clen, &outlen);
+   }
+
+   /*
+@@ -93,12 +94,12 @@ struct AesCipher
+     assert(len % kAesBlockSize == 0);
+
+     int plen = (int)len, flen = 0;
+-    EVP_DecryptUpdate(&decrypt_ctx_, plaintext, &plen, ciphertext, (int)len);
+-    EVP_DecryptFinal(&decrypt_ctx_, plaintext + plen, &flen);
++    EVP_DecryptUpdate(decrypt_ctx_, plaintext, &plen, ciphertext, (int)len);
++    EVP_DecryptFinal(decrypt_ctx_, plaintext + plen, &flen);
+   }
+
+-  EVP_CIPHER_CTX encrypt_ctx_;
+-  EVP_CIPHER_CTX decrypt_ctx_;
++  EVP_CIPHER_CTX *encrypt_ctx_;
++  EVP_CIPHER_CTX *decrypt_ctx_;
+ };
+
+ } // namespace upscaledb
+diff --git a/src/2device/device_disk.h b/src/2device/device_disk.h
+index 4f961f41..f67f511e 100644
+--- a/src/2device/device_disk.h
++++ b/src/2device/device_disk.h
+@@ -54,6 +54,12 @@ namespace upscaledb {
+  */
+ class DiskDevice : public Device {
+     struct State {
++      State() = default;
++      State(const State&) = delete;
++      State& operator=(const State&) = delete;
++
++      State(State&&) = default;
++      State& operator=(State&& ) = default;
+       // the database file
+       File file;
+
+@@ -94,7 +100,7 @@ class DiskDevice : public Device {
+       File file;
+       file.create(config.filename.c_str(), config.file_mode);
+       file.set_posix_advice(config.posix_advice);
+-      m_state.file = file;
++      m_state.file = std::move(file);
+     }
+
+     // opens an existing device
+@@ -105,7 +111,7 @@ class DiskDevice : public Device {
+
+       ScopedSpinlock lock(m_mutex);
+
+-      State state = m_state;
++      State state = std::move(m_state);
+       state.file.open(config.filename.c_str(), read_only);
+       state.file.set_posix_advice(config.posix_advice);
+
+@@ -146,7 +152,7 @@ class DiskDevice : public Device {
+     // closes the device
+     virtual void close() {
+       ScopedSpinlock lock(m_mutex);
+-      State state = m_state;
++      State state = std::move(m_state);
+       if (state.mmapptr)
+         state.file.munmap(state.mmapptr, state.mapped_size);
+       state.file.close();
+diff --git a/src/2worker/worker.h b/src/2worker/worker.h
+index 7865bba9..3ff140ab 100644
+--- a/src/2worker/worker.h
++++ b/src/2worker/worker.h
+@@ -81,7 +81,11 @@ struct WorkerPool {
+   // the io_service we are wrapping
+   boost::asio::io_service service;
+   boost::asio::io_service::work working;
++#if BOOST_VERSION < 106600
+   boost::asio::strand strand;
++#else
++  boost::asio::io_context::strand strand;
++#endif
+ };
+
+ inline void
+diff --git a/src/Makefile.am b/src/Makefile.am
+index a2c256f1..b47ca426 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -37,7 +37,6 @@ libupscaledb_la_SOURCES = \
+ 	1os/socket.h \
+ 	1os/os.h \
+ 	1os/os.cc \
+-	1os/os_posix.cc \
+ 	1rb/rb.h \
+ 	2aes/aes.h \
+ 	2compressor/compressor.h \
+@@ -169,14 +168,24 @@ libupscaledb_la_SOURCES = \
+ 	4uqi/value.h \
+ 	5upscaledb/upscaledb.cc
+
++if WINDOWS
++libupscaledb_la_SOURCES += 1os/os_win32.cc
++EXTRA_DIST = 1os/os_posix.cc
++else
++libupscaledb_la_SOURCES += 1os/os_posix.cc
+ EXTRA_DIST = 1os/os_win32.cc
++endif
+
+ AM_CPPFLAGS = -I../include -I$(top_srcdir)/include \
+ 			  $(BOOST_CPPFLAGS)
+ libupscaledb_la_LDFLAGS = -version-info 1:0:1 $(BOOST_SYSTEM_LDFLAGS) \
+ 			  $(BOOST_THREAD_LDFLAGS)
+ libupscaledb_la_LIBADD  = $(BOOST_SYSTEM_LIBS) $(BOOST_THREAD_LIBS) \
+-			  $(top_builddir)/3rdparty/murmurhash3/libmurmurhash3.la -ldl
++			  $(top_builddir)/3rdparty/murmurhash3/libmurmurhash3.la
++
++if !WINDOWS
++libupscaledb_la_LIBADD  += -ldl
++endif
+
+ libupscaledb_la_LIBADD  += $(top_builddir)/3rdparty/liblzf/liblzf.la \
+ 						   $(top_builddir)/3rdparty/libfor/libfor.la \
+diff --git a/unittests/simd.cpp b/unittests/simd.cpp
+index a8c885ab..3fcfcc1e 100644
+--- a/unittests/simd.cpp
++++ b/unittests/simd.cpp
+@@ -21,6 +21,7 @@
+ #include "3rdparty/catch/catch.hpp"
+
+ #include "2simd/simd.h"
++#include <array>
+
+ using namespace upscaledb;


### PR DESCRIPTION
This patch is a combination of the following changes:

- https://github.com/cruppstahl/upscaledb/pull/97 (https://github.com/cruppstahl/upscaledb/commit/e62eea7b0dbe63e5007c1cf00c11dc661313732f)
- https://github.com/cruppstahl/upscaledb/pull/98 (https://github.com/cruppstahl/upscaledb/commit/98b4105fe852704da3d32ab72cb8a4317cbb1f6c)
- https://github.com/cruppstahl/upscaledb/pull/100 (https://github.com/cruppstahl/upscaledb/commit/9e7935ba72151f0dd766079ea77b3408508bfa18)
- https://github.com/cruppstahl/upscaledb/pull/110 (https://github.com/cruppstahl/upscaledb/commit/01156f9a894136b889a0ce6ab92dc2191c61ed15)
- https://github.com/cruppstahl/upscaledb/issues/124 (https://github.com/cruppstahl/upscaledb/commit/e2b655a26ade50daa26d33bcecd1b77e4a2d5ecc)
- https://github.com/cruppstahl/upscaledb/commit/68ca8c3506d0cbaafddce3fec256cbf4ea8c44e7