### PR TITLE
Add llvm 11.0.0 patch for llvm-config output

### DIFF
--- a/llvm/11.0.0-llvm.diff
+++ b/llvm/11.0.0-llvm.diff
@@ -1,0 +1,20 @@
+--- llvm-11.0.0.src/lib/WindowsManifest/CMakeLists.txt	2020-10-07 12:10:48.000000000 +0200
++++ llvm-11.0.0.src/lib/WindowsManifest/CMakeLists.txt	2020-10-13 21:16:16.000000000 +0200
+@@ -8,16 +8,6 @@
+ if(LIBXML2_LIBRARIES)
+   target_link_libraries(LLVMWindowsManifest PUBLIC ${LIBXML2_LIBRARIES})
+ 
+-  get_filename_component(xml2_library ${LIBXML2_LIBRARIES} NAME)
+-  if (CMAKE_STATIC_LIBRARY_PREFIX AND
+-      xml2_library MATCHES "^${CMAKE_STATIC_LIBRARY_PREFIX}.*${CMAKE_STATIC_LIBRARY_SUFFIX}$")
+-    string(REGEX REPLACE "^${CMAKE_STATIC_LIBRARY_PREFIX}" "" xml2_library ${xml2_library})
+-    string(REGEX REPLACE "${CMAKE_STATIC_LIBRARY_SUFFIX}$" "" xml2_library ${xml2_library})
+-  elseif (CMAKE_SHARED_LIBRARY_PREFIX AND
+-          xml2_library MATCHES "^${CMAKE_SHARED_LIBRARY_PREFIX}.*${CMAKE_SHARED_LIBRARY_SUFFIX}$")
+-    string(REGEX REPLACE "^${CMAKE_SHARED_LIBRARY_PREFIX}" "" xml2_library ${xml2_library})
+-    string(REGEX REPLACE "${CMAKE_SHARED_LIBRARY_SUFFIX}$" "" xml2_library ${xml2_library})
+-  endif()
+   set_property(TARGET LLVMWindowsManifest PROPERTY
+-    LLVM_SYSTEM_LIBS ${xml2_library})
++    LLVM_SYSTEM_LIBS ${LIBXML2_LIBRARIES})
+ endif()


### PR DESCRIPTION
This commit adds a patch for llvm 11.0.0 formula for `llvm-config`
with `--system-libs` option which incorrectly reports `-llibxml2.tbd`
instead of `-lxml2`.

Thanks @jedisct1 for working this patch out!