### PR TITLE
openjdk@11: fix build on Xcode 12

### DIFF
--- a/openjdk@11/xcode12.diff
+++ b/openjdk@11/xcode12.diff
@@ -1,0 +1,35 @@
+diff --git a/src/hotspot/share/runtime/sharedRuntime.cpp b/src/hotspot/share/runtime/sharedRuntime.cpp
+index ea0fc28..909d647 100644
+--- a/src/hotspot/share/runtime/sharedRuntime.cpp
++++ b/src/hotspot/share/runtime/sharedRuntime.cpp
+@@ -2811,8 +2811,8 @@ void AdapterHandlerLibrary::create_native_wrapper(const methodHandle& method) {
+     BufferBlob*  buf = buffer_blob(); // the temporary code buffer in CodeCache
+     if (buf != NULL) {
+       CodeBuffer buffer(buf);
+-      double locs_buf[20];
+-      buffer.insts()->initialize_shared_locs((relocInfo*)locs_buf, sizeof(locs_buf) / sizeof(relocInfo));
++      struct { double data[20]; } locs_buf;
++      buffer.insts()->initialize_shared_locs((relocInfo*)&locs_buf, sizeof(locs_buf) / sizeof(relocInfo));
+       MacroAssembler _masm(&buffer);
+
+       // Fill in the signature array, for the calling-convention call.
+diff --git a/src/java.desktop/macosx/native/libawt_lwawt/awt/CSystemColors.m b/src/java.desktop/macosx/native/libawt_lwawt/awt/CSystemColors.m
+index d437d6d..5591a56 100644
+--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/CSystemColors.m
++++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/CSystemColors.m
+@@ -1,5 +1,5 @@
+ /*
+- * Copyright (c) 2011, 2012, Oracle and/or its affiliates. All rights reserved.
++ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+  *
+  * This code is free software; you can redistribute it and/or modify it
+@@ -126,7 +126,7 @@ static JNF_STATIC_MEMBER_CACHE(jm_systemColorsChanged, jc_LWCToolkit, "systemCol
+ + (NSColor*)getColor:(NSUInteger)colorIndex useAppleColor:(BOOL)useAppleColor {
+     NSColor* result = nil;
+
+-    if (colorIndex < (useAppleColor) ? sun_lwawt_macosx_LWCToolkit_NUM_APPLE_COLORS : java_awt_SystemColor_NUM_COLORS) {
++    if (colorIndex < ((useAppleColor) ? sun_lwawt_macosx_LWCToolkit_NUM_APPLE_COLORS : java_awt_SystemColor_NUM_COLORS)) {
+         result = (useAppleColor ? appleColors : sColors)[colorIndex];
+     }
+     else {


### PR DESCRIPTION
This patch backports the following changes (to get built `openjdk@11` on Xcode 12):

- https://github.com/openjdk/jdk/commit/f80a6066e45c3d53a61715abfe71abc3b2e162a1 (https://bugs.openjdk.java.net/browse/JDK-8253375)
- https://github.com/openjdk/jdk/commit/4622a18a72c30c4fc72c166bee7de42903e1d036 (https://bugs.openjdk.java.net/browse/JDK-8253791)