### PR TITLE
screen: Patch for build error on Xcode 12

### DIFF
--- a/screen/screen-xcode-12.diff
+++ b/screen/screen-xcode-12.diff
@@ -1,0 +1,22 @@
+diff --git a/configure.ac b/configure.ac
+index c0f02df..e28fc6a 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -284,10 +284,15 @@ dnl    ****  select()  ****
+ dnl
+ 
+ AC_CHECKING(select)
+-AC_TRY_LINK(,[select(0, 0, 0, 0, 0);],, 
++AC_TRY_LINK([
++#include <sys/select.h>
++],[select(0, 0, 0, 0, 0);],,
+ LIBS="$LIBS -lnet -lnsl"
+ AC_CHECKING(select with $LIBS)
+-AC_TRY_LINK(,[select(0, 0, 0, 0, 0);],, 
++AC_TRY_LINK([
++#include <sys/select.h>
++],[select(0, 0, 0, 0, 0);],,
++
+ AC_MSG_ERROR(!!! no select - no screen))
+ )
+ dnl


### PR DESCRIPTION
```
configure: checking select with  -lnet -lnsl...
configure: error: !!! no select - no screen
```

https://github.com/Homebrew/homebrew-core/issues/64785#issuecomment-727265877

There are more errors after this which I'll get to shortly, but this at least makes a start on `screen`'s Big Sur Intel build failures.
