### PR TITLE
qt: Added qt3d -no-avx2 compilation fix 

### DIFF
--- a/qt/qt3d-no-avx2-compile-fix.diff
+++ b/qt/qt3d-no-avx2-compile-fix.diff
@@ -1,0 +1,53 @@
+From b456a7d47a36dc3429a5e7bac7665b12d257efea Mon Sep 17 00:00:00 2001
+From: Laurent Rineau <laurent.rineau@cgal.org>
+Date: Thu, 11 Jun 2020 12:55:17 +0200
+Subject: [PATCH] Fix compilation error with -no-avx2
+
+Change-Id: I1aa49328226d5e3f1da4bd86704c7fad44da6ad9
+Pick-to: dev 5.15 5.14
+---
+
+diff --git a/src/core/transforms/vector3d_sse.cpp b/src/core/transforms/vector3d_sse.cpp
+index 151cbb9..3a369e2 100644
+--- a/src/core/transforms/vector3d_sse.cpp
++++ b/src/core/transforms/vector3d_sse.cpp
+@@ -39,7 +39,7 @@
+ 
+ #include <private/qsimd_p.h>
+ 
+-#ifdef __AVX2__
++#if defined(__AVX2__) && defined(QT_COMPILER_SUPPORTS_AVX2)
+ #include "matrix4x4_avx2_p.h"
+ #else
+ #include "matrix4x4_sse_p.h"
+@@ -66,7 +66,7 @@
+     m_xyzw = _mm_mul_ps(v.m_xyzw, _mm_set_ps(0.0f, 1.0f, 1.0f, 1.0f));
+ }
+ 
+-#ifdef __AVX2__
++#if defined(__AVX2__) && defined(QT_COMPILER_SUPPORTS_AVX2)
+ 
+ Vector3D_SSE Vector3D_SSE::unproject(const Matrix4x4_AVX2 &modelView, const Matrix4x4_AVX2 &projection, const QRect &viewport) const
+ {
+diff --git a/src/core/transforms/vector3d_sse_p.h b/src/core/transforms/vector3d_sse_p.h
+index bc25cd7..7729405 100644
+--- a/src/core/transforms/vector3d_sse_p.h
++++ b/src/core/transforms/vector3d_sse_p.h
+@@ -178,7 +178,7 @@
+         return ((_mm_movemask_ps(_mm_cmpeq_ps(m_xyzw, _mm_set_ps1(0.0f))) & 0x7) == 0x7);
+     }
+ 
+-#ifdef __AVX2__
++#if defined(__AVX2__) && defined(QT_COMPILER_SUPPORTS_AVX2)
+     Q_3DCORE_PRIVATE_EXPORT Vector3D_SSE unproject(const Matrix4x4_AVX2 &modelView, const Matrix4x4_AVX2 &projection, const QRect &viewport) const;
+     Q_3DCORE_PRIVATE_EXPORT Vector3D_SSE project(const Matrix4x4_AVX2 &modelView, const Matrix4x4_AVX2 &projection, const QRect &viewport) const;
+ #else
+@@ -348,7 +348,7 @@
+ 
+     friend class Vector4D_SSE;
+ 
+-#ifdef __AVX2__
++#if defined(__AVX2__) && defined(QT_COMPILER_SUPPORTS_AVX2)
+     friend class Matrix4x4_AVX2;
+     friend Q_3DCORE_PRIVATE_EXPORT Vector3D_SSE operator*(const Vector3D_SSE &vector, const Matrix4x4_AVX2 &matrix);
+     friend Q_3DCORE_PRIVATE_EXPORT Vector3D_SSE operator*(const Matrix4x4_AVX2 &matrix, const Vector3D_SSE &vector);


### PR DESCRIPTION
Patch from: https://codereview.qt-project.org/c/qt/qt3d/+/303990

Patch is only available to download anonymously either in a zip archive or base64 encoded.

[homebrew-core#65128](https://github.com/Homebrew/homebrew-core/pull/65128#issuecomment-730153095)