### PR TITLE
Patch for emacs 27.1 to enable building on Apple Silicon

### DIFF
--- a/emacs/arm.patch
+++ b/emacs/arm.patch
@@ -1,0 +1,24 @@
+diff -ur a/configure b/configure
+--- a/configure	2020-08-04 13:43:32.000000000 -0600
++++ b/configure	2020-11-25 12:08:44.000000000 -0700
+@@ -4978,7 +4978,7 @@
+   *-apple-darwin* )
+     case "${canonical}" in
+       *-apple-darwin[0-9].*) unported=yes ;;
+-      i[3456]86-* | x86_64-* )  ;;
++      i[3456]86-* | x86_64-* | arm-* ) ;;
+       * )            unported=yes ;;
+     esac
+     opsys=darwin
+diff -ur a/configure.ac b/configure.ac
+--- a/configure.ac	2020-07-29 15:40:41.000000000 -0600
++++ b/configure.ac	2020-11-25 12:04:56.000000000 -0700
+@@ -703,7 +703,7 @@
+   *-apple-darwin* )
+     case "${canonical}" in
+       *-apple-darwin[0-9].*) unported=yes ;;
+-      i[3456]86-* | x86_64-* )  ;;
++      i[3456]86-* | x86_64-* | arm-* ) ;;
+       * )            unported=yes ;;
+     esac
+     opsys=darwin


### PR DESCRIPTION
This PR adds a new patch that can be used to enable Apple Silicon Macs to get past configure. This is a backport of https://github.com/emacs-mirror/emacs/commit/b40a7056e53afd9d4ffdac03fd7b1b0fabb2a85d.patch from emacs master.