### PR TITLE
Update arm.patch

### DIFF
--- a/emacs/arm.patch
+++ b/emacs/arm.patch
@@ -1,24 +1,208 @@
+diff -ur a/build-aux/config.guess b/build-aux/config.guess
+--- a/build-aux/config.guess	2020-07-29 15:40:41.000000000 -0600
++++ b/build-aux/config.guess	2020-11-25 15:44:16.000000000 -0700
+@@ -2,7 +2,7 @@
+ # Attempt to guess a canonical system name.
+ #   Copyright 1992-2020 Free Software Foundation, Inc.
+ 
+-timestamp='2019-09-10'
++timestamp='2020-08-17'
+ 
+ # This file is free software; you can redistribute it and/or modify it
+ # under the terms of the GNU General Public License as published by
+@@ -50,7 +50,7 @@
+ GNU config.guess ($timestamp)
+ 
+ Originally written by Per Bothner.
+-Copyright 1992-2019 Free Software Foundation, Inc.
++Copyright 1992-2020 Free Software Foundation, Inc.
+ 
+ This is free software; see the source for copying conditions.  There is NO
+ warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE."
+@@ -99,6 +99,8 @@
+ trap 'test -z "$tmp" || rm -fr "$tmp"' 0 1 2 13 15
+ 
+ set_cc_for_build() {
++    # prevent multiple calls if $tmp is already set
++    test "$tmp" && return 0
+     : "${TMPDIR=/tmp}"
+     # shellcheck disable=SC2039
+     { tmp=`(umask 077 && mktemp -d "$TMPDIR/cgXXXXXX") 2>/dev/null` && test -n "$tmp" && test -d "$tmp" ; } ||
+@@ -402,7 +404,7 @@
+ 	# If there is a compiler, see if it is configured for 64-bit objects.
+ 	# Note that the Sun cc does not turn __LP64__ into 1 like gcc does.
+ 	# This test works for both compilers.
+-	if [ "$CC_FOR_BUILD" != no_compiler_found ]; then
++	if test "$CC_FOR_BUILD" != no_compiler_found; then
+ 	    if (echo '#ifdef __amd64'; echo IS_64BIT_ARCH; echo '#endif') | \
+ 		(CCOPTS="" $CC_FOR_BUILD -E - 2>/dev/null) | \
+ 		grep IS_64BIT_ARCH >/dev/null
+@@ -542,10 +544,10 @@
+     AViiON:dgux:*:*)
+ 	# DG/UX returns AViiON for all architectures
+ 	UNAME_PROCESSOR=`/usr/bin/uname -p`
+-	if [ "$UNAME_PROCESSOR" = mc88100 ] || [ "$UNAME_PROCESSOR" = mc88110 ]
++	if test "$UNAME_PROCESSOR" = mc88100 || test "$UNAME_PROCESSOR" = mc88110
+ 	then
+-	    if [ "$TARGET_BINARY_INTERFACE"x = m88kdguxelfx ] || \
+-	       [ "$TARGET_BINARY_INTERFACE"x = x ]
++	    if test "$TARGET_BINARY_INTERFACE"x = m88kdguxelfx || \
++	       test "$TARGET_BINARY_INTERFACE"x = x
+ 	    then
+ 		echo m88k-dg-dgux"$UNAME_RELEASE"
+ 	    else
+@@ -578,7 +580,7 @@
+ 	echo i386-ibm-aix
+ 	exit ;;
+     ia64:AIX:*:*)
+-	if [ -x /usr/bin/oslevel ] ; then
++	if test -x /usr/bin/oslevel ; then
+ 		IBM_REV=`/usr/bin/oslevel`
+ 	else
+ 		IBM_REV="$UNAME_VERSION.$UNAME_RELEASE"
+@@ -618,7 +620,7 @@
+ 	else
+ 		IBM_ARCH=powerpc
+ 	fi
+-	if [ -x /usr/bin/lslpp ] ; then
++	if test -x /usr/bin/lslpp ; then
+ 		IBM_REV=`/usr/bin/lslpp -Lqc bos.rte.libc |
+ 			   awk -F: '{ print $3 }' | sed s/[0-9]*$/0/`
+ 	else
+@@ -653,7 +655,7 @@
+ 	    9000/31?)            HP_ARCH=m68000 ;;
+ 	    9000/[34]??)         HP_ARCH=m68k ;;
+ 	    9000/[678][0-9][0-9])
+-		if [ -x /usr/bin/getconf ]; then
++		if test -x /usr/bin/getconf; then
+ 		    sc_cpu_version=`/usr/bin/getconf SC_CPU_VERSION 2>/dev/null`
+ 		    sc_kernel_bits=`/usr/bin/getconf SC_KERNEL_BITS 2>/dev/null`
+ 		    case "$sc_cpu_version" in
+@@ -667,7 +669,7 @@
+ 			esac ;;
+ 		    esac
+ 		fi
+-		if [ "$HP_ARCH" = "" ]; then
++		if test "$HP_ARCH" = ""; then
+ 		    set_cc_for_build
+ 		    sed 's/^		//' << EOF > "$dummy.c"
+ 
+@@ -706,7 +708,7 @@
+ 		    test -z "$HP_ARCH" && HP_ARCH=hppa
+ 		fi ;;
+ 	esac
+-	if [ "$HP_ARCH" = hppa2.0w ]
++	if test "$HP_ARCH" = hppa2.0w
+ 	then
+ 	    set_cc_for_build
+ 
+@@ -780,7 +782,7 @@
+ 	echo hppa1.0-hp-osf
+ 	exit ;;
+     i*86:OSF1:*:*)
+-	if [ -x /usr/sbin/sysversion ] ; then
++	if test -x /usr/sbin/sysversion ; then
+ 	    echo "$UNAME_MACHINE"-unknown-osf1mk
+ 	else
+ 	    echo "$UNAME_MACHINE"-unknown-osf1
+@@ -924,7 +926,7 @@
+ 	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+ 	exit ;;
+     alpha:Linux:*:*)
+-	case `sed -n '/^cpu model/s/^.*: \(.*\)/\1/p' < /proc/cpuinfo` in
++	case `sed -n '/^cpu model/s/^.*: \(.*\)/\1/p' /proc/cpuinfo 2>/dev/null` in
+ 	  EV5)   UNAME_MACHINE=alphaev5 ;;
+ 	  EV56)  UNAME_MACHINE=alphaev56 ;;
+ 	  PCA56) UNAME_MACHINE=alphapca56 ;;
+@@ -1093,7 +1095,17 @@
+ 	echo "$UNAME_MACHINE"-dec-linux-"$LIBC"
+ 	exit ;;
+     x86_64:Linux:*:*)
+-	echo "$UNAME_MACHINE"-pc-linux-"$LIBC"
++	set_cc_for_build
++	LIBCABI=$LIBC
++	if test "$CC_FOR_BUILD" != no_compiler_found; then
++	    if (echo '#ifdef __ILP32__'; echo IS_X32; echo '#endif') | \
++		(CCOPTS="" $CC_FOR_BUILD -E - 2>/dev/null) | \
++		grep IS_X32 >/dev/null
++	    then
++		LIBCABI="$LIBC"x32
++	    fi
++	fi
++	echo "$UNAME_MACHINE"-pc-linux-"$LIBCABI"
+ 	exit ;;
+     xtensa*:Linux:*:*)
+ 	echo "$UNAME_MACHINE"-unknown-linux-"$LIBC"
+@@ -1282,7 +1294,7 @@
+ 	echo mips-sony-newsos6
+ 	exit ;;
+     R[34]000:*System_V*:*:* | R4000:UNIX_SYSV:*:* | R*000:UNIX_SV:*:*)
+-	if [ -d /usr/nec ]; then
++	if test -d /usr/nec; then
+ 		echo mips-nec-sysv"$UNAME_RELEASE"
+ 	else
+ 		echo mips-unknown-sysv"$UNAME_RELEASE"
+@@ -1330,6 +1342,9 @@
+     *:Rhapsody:*:*)
+ 	echo "$UNAME_MACHINE"-apple-rhapsody"$UNAME_RELEASE"
+ 	exit ;;
++    arm64:Darwin:*:*)
++	echo aarch64-apple-darwin"$UNAME_RELEASE"
++	exit ;;
+     *:Darwin:*:*)
+ 	UNAME_PROCESSOR=`uname -p`
+ 	case $UNAME_PROCESSOR in
+@@ -1344,7 +1359,7 @@
+ 	else
+ 	    set_cc_for_build
+ 	fi
+-	if [ "$CC_FOR_BUILD" != no_compiler_found ]; then
++	if test "$CC_FOR_BUILD" != no_compiler_found; then
+ 	    if (echo '#ifdef __LP64__'; echo IS_64BIT_ARCH; echo '#endif') | \
+ 		   (CCOPTS="" $CC_FOR_BUILD -E - 2>/dev/null) | \
+ 		   grep IS_64BIT_ARCH >/dev/null
+@@ -1627,6 +1642,12 @@
+   https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess
+ and
+   https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub
++EOF
++
++year=`echo $timestamp | sed 's,-.*,,'`
++# shellcheck disable=SC2003
++if test "`expr "\`date +%Y\`" - "$year"`" -lt 3 ; then
++   cat >&2 <<EOF
+ 
+ If $0 has already been updated, send the following data and any
+ information you think might be pertinent to config-patches@gnu.org to
+@@ -1654,6 +1675,7 @@
+ UNAME_SYSTEM  = "$UNAME_SYSTEM"
+ UNAME_VERSION = "$UNAME_VERSION"
+ EOF
++fi
+ 
+ exit 1
+ 
 diff -ur a/configure b/configure
 --- a/configure	2020-08-04 13:43:32.000000000 -0600
-+++ b/configure	2020-11-25 12:08:44.000000000 -0700
++++ b/configure	2020-11-25 15:45:10.000000000 -0700
 @@ -4978,7 +4978,7 @@
    *-apple-darwin* )
      case "${canonical}" in
        *-apple-darwin[0-9].*) unported=yes ;;
 -      i[3456]86-* | x86_64-* )  ;;
-+      i[3456]86-* | x86_64-* | arm-* ) ;;
++      i[3456]86-* | x86_64-* | arm-* | aarch64-* ) ;;
        * )            unported=yes ;;
      esac
      opsys=darwin
 diff -ur a/configure.ac b/configure.ac
 --- a/configure.ac	2020-07-29 15:40:41.000000000 -0600
-+++ b/configure.ac	2020-11-25 12:04:56.000000000 -0700
++++ b/configure.ac	2020-11-25 15:45:00.000000000 -0700
 @@ -703,7 +703,7 @@
    *-apple-darwin* )
      case "${canonical}" in
        *-apple-darwin[0-9].*) unported=yes ;;
 -      i[3456]86-* | x86_64-* )  ;;
-+      i[3456]86-* | x86_64-* | arm-* ) ;;
++      i[3456]86-* | x86_64-* | arm-* | aarch64-* ) ;;
        * )            unported=yes ;;
      esac
      opsys=darwin


### PR DESCRIPTION
When testing the Formula changes it became clear that config.guess also needed to be updated. This fixed the detection of the system triple to be aarch64-apple-darwin. See https://github.com/emacs-mirror/emacs/commit/5d89a9c2846d32b4726faaf5c8652f3f23dc7d73. To catch that update this patch now brings config.guess to to the same version as emacs master.