### PR TITLE
python: fix patch for macOS arm64

### DIFF
--- a/python/arm64-3.9.patch
+++ b/python/arm64-3.9.patch
@@ -1,6 +1,7 @@
-diff -pur a/Lib/_osx_support.py b/Lib/_osx_support.py
---- a/Lib/_osx_support.py	2020-10-05 17:07:58.000000000 +0200
-+++ b/Lib/_osx_support.py	2020-11-05 14:43:47.000000000 +0100
+diff --git a/Lib/_osx_support.py b/Lib/_osx_support.py
+index e9efce7..8a696ee 100644
+--- a/Lib/_osx_support.py
++++ b/Lib/_osx_support.py
 @@ -110,6 +110,26 @@ def _get_system_version():
  
      return _SYSTEM_VERSION
@@ -53,7 +54,7 @@ diff -pur a/Lib/_osx_support.py b/Lib/_osx_support.py
  
  def _find_appropriate_compiler(_config_vars):
      """Find appropriate C compiler for extension module builds"""
-@@ -331,6 +355,12 @@ def compiler_fixup(compiler_so, cc_args)
+@@ -331,6 +355,12 @@ def compiler_fixup(compiler_so, cc_args):
              except ValueError:
                  break
  
@@ -66,7 +67,7 @@ diff -pur a/Lib/_osx_support.py b/Lib/_osx_support.py
      if 'ARCHFLAGS' in os.environ and not stripArch:
          # User specified different -arch flags in the environ,
          # see also distutils.sysconfig
-@@ -481,6 +511,8 @@ def get_platform_osx(_config_vars, osnam
+@@ -481,6 +511,8 @@ def get_platform_osx(_config_vars, osname, release, machine):
  
              if len(archs) == 1:
                  machine = archs[0]
@@ -75,9 +76,10 @@ diff -pur a/Lib/_osx_support.py b/Lib/_osx_support.py
              elif archs == ('i386', 'ppc'):
                  machine = 'fat'
              elif archs == ('i386', 'x86_64'):
-diff -pur a/Lib/ctypes/macholib/dyld.py b/Lib/ctypes/macholib/dyld.py
---- a/Lib/ctypes/macholib/dyld.py	2020-10-05 17:07:58.000000000 +0200
-+++ b/Lib/ctypes/macholib/dyld.py	2020-11-05 14:43:47.000000000 +0100
+diff --git a/Lib/ctypes/macholib/dyld.py b/Lib/ctypes/macholib/dyld.py
+index 9d86b05..1c3f8fd 100644
+--- a/Lib/ctypes/macholib/dyld.py
++++ b/Lib/ctypes/macholib/dyld.py
 @@ -6,6 +6,11 @@ import os
  from ctypes.macholib.framework import framework_info
  from ctypes.macholib.dylib import dylib_info
@@ -90,7 +92,7 @@ diff -pur a/Lib/ctypes/macholib/dyld.py b/Lib/ctypes/macholib/dyld.py
  
  __all__ = [
      'dyld_find', 'framework_find',
-@@ -122,8 +127,15 @@ def dyld_find(name, executable_path=None
+@@ -122,8 +127,15 @@ def dyld_find(name, executable_path=None, env=None):
                  dyld_executable_path_search(name, executable_path),
                  dyld_default_search(name, env),
              ), env):
@@ -106,9 +108,10 @@ diff -pur a/Lib/ctypes/macholib/dyld.py b/Lib/ctypes/macholib/dyld.py
      raise ValueError("dylib %s could not be found" % (name,))
  
  def framework_find(fn, executable_path=None, env=None):
-diff -pur a/Lib/ctypes/test/test_macholib.py b/Lib/ctypes/test/test_macholib.py
---- a/Lib/ctypes/test/test_macholib.py	2020-10-05 17:07:58.000000000 +0200
-+++ b/Lib/ctypes/test/test_macholib.py	2020-11-05 14:43:47.000000000 +0100
+diff --git a/Lib/ctypes/test/test_macholib.py b/Lib/ctypes/test/test_macholib.py
+index 6b35269..a1bac26 100644
+--- a/Lib/ctypes/test/test_macholib.py
++++ b/Lib/ctypes/test/test_macholib.py
 @@ -45,19 +45,22 @@ def find_lib(name):
  class MachOTest(unittest.TestCase):
      @unittest.skipUnless(sys.platform == "darwin", 'OSX-specific test')
@@ -138,9 +141,10 @@ diff -pur a/Lib/ctypes/test/test_macholib.py b/Lib/ctypes/test/test_macholib.py
  
  if __name__ == "__main__":
      unittest.main()
-diff -pur a/Lib/distutils/tests/test_build_ext.py b/Lib/distutils/tests/test_build_ext.py
---- a/Lib/distutils/tests/test_build_ext.py	2020-10-05 17:07:58.000000000 +0200
-+++ b/Lib/distutils/tests/test_build_ext.py	2020-11-05 14:43:47.000000000 +0100
+diff --git a/Lib/distutils/tests/test_build_ext.py b/Lib/distutils/tests/test_build_ext.py
+index 5e47e07..5a32e03 100644
+--- a/Lib/distutils/tests/test_build_ext.py
++++ b/Lib/distutils/tests/test_build_ext.py
 @@ -492,7 +492,7 @@ class BuildExtTestCase(TempdirManager,
          # format the target value as defined in the Apple
          # Availability Macros.  We can't use the macro names since
@@ -150,10 +154,11 @@ diff -pur a/Lib/distutils/tests/test_build_ext.py b/Lib/distutils/tests/test_bui
              # for 10.1 through 10.9.x -> "10n0"
              target = '%02d%01d0' % target
          else:
-diff -pur a/Lib/test/test_bytes.py b/Lib/test/test_bytes.py
---- a/Lib/test/test_bytes.py	2020-10-05 17:07:58.000000000 +0200
-+++ b/Lib/test/test_bytes.py	2020-11-05 14:43:47.000000000 +0100
-@@ -1034,6 +1034,7 @@ class BytesTest(BaseBytesTest, unittest.
+diff --git a/Lib/test/test_bytes.py b/Lib/test/test_bytes.py
+index 770e2c5..05568f2 100644
+--- a/Lib/test/test_bytes.py
++++ b/Lib/test/test_bytes.py
+@@ -1034,6 +1034,7 @@ class BytesTest(BaseBytesTest, unittest.TestCase):
              c_char_p)
  
          PyBytes_FromFormat = pythonapi.PyBytes_FromFormat
@@ -161,9 +166,10 @@ diff -pur a/Lib/test/test_bytes.py b/Lib/test/test_bytes.py
          PyBytes_FromFormat.restype = py_object
  
          # basic tests
-diff -pur a/Lib/test/test_platform.py b/Lib/test/test_platform.py
---- a/Lib/test/test_platform.py	2020-10-05 17:07:58.000000000 +0200
-+++ b/Lib/test/test_platform.py	2020-11-05 14:43:47.000000000 +0100
+diff --git a/Lib/test/test_platform.py b/Lib/test/test_platform.py
+index a5c35df..bd953b5 100644
+--- a/Lib/test/test_platform.py
++++ b/Lib/test/test_platform.py
 @@ -245,7 +245,7 @@ class PlatformTest(unittest.TestCase):
              self.assertEqual(res[1], ('', '', ''))
  
@@ -173,10 +179,11 @@ diff -pur a/Lib/test/test_platform.py b/Lib/test/test_platform.py
              else:
                  self.assertEqual(res[2], 'PowerPC')
  
-diff -pur a/Lib/test/test_posix.py b/Lib/test/test_posix.py
---- a/Lib/test/test_posix.py	2020-10-05 17:07:58.000000000 +0200
-+++ b/Lib/test/test_posix.py	2020-11-05 14:43:47.000000000 +0100
-@@ -1905,6 +1905,233 @@ class TestPosixSpawnP(unittest.TestCase,
+diff --git a/Lib/test/test_posix.py b/Lib/test/test_posix.py
+index be121ae..6300e95 100644
+--- a/Lib/test/test_posix.py
++++ b/Lib/test/test_posix.py
+@@ -1905,6 +1905,233 @@ class TestPosixSpawnP(unittest.TestCase, _PosixSpawnMixin):
          assert_python_ok(*args, PATH=path)
  
  
@@ -418,10 +425,11 @@ diff -pur a/Lib/test/test_posix.py b/Lib/test/test_posix.py
          )
      finally:
          support.reap_children()
-diff -pur a/Lib/test/test_time.py b/Lib/test/test_time.py
---- a/Lib/test/test_time.py	2020-10-05 17:07:58.000000000 +0200
-+++ b/Lib/test/test_time.py	2020-11-05 14:43:47.000000000 +0100
-@@ -1040,6 +1040,36 @@ class TestOldPyTime(CPyTimeTestCase, uni
+diff --git a/Lib/test/test_time.py b/Lib/test/test_time.py
+index 80e43fa..71931dd 100644
+--- a/Lib/test/test_time.py
++++ b/Lib/test/test_time.py
+@@ -1040,6 +1040,36 @@ class TestOldPyTime(CPyTimeTestCase, unittest.TestCase):
              with self.assertRaises(ValueError):
                  pytime_object_to_timespec(float('nan'), time_rnd)
  
@@ -458,9 +466,10 @@ diff -pur a/Lib/test/test_time.py b/Lib/test/test_time.py
  
  if __name__ == "__main__":
      unittest.main()
-diff -pur a/Lib/test/test_unicode.py b/Lib/test/test_unicode.py
---- a/Lib/test/test_unicode.py	2020-10-05 17:07:58.000000000 +0200
-+++ b/Lib/test/test_unicode.py	2020-11-05 14:43:47.000000000 +0100
+diff --git a/Lib/test/test_unicode.py b/Lib/test/test_unicode.py
+index 2ee4e64..23508c5 100644
+--- a/Lib/test/test_unicode.py
++++ b/Lib/test/test_unicode.py
 @@ -2523,11 +2523,13 @@ class CAPITest(unittest.TestCase):
      def test_from_format(self):
          support.import_module('ctypes')
@@ -475,9 +484,10 @@ diff -pur a/Lib/test/test_unicode.py b/Lib/test/test_unicode.py
          _PyUnicode_FromFormat.restype = py_object
  
          def PyUnicode_FromFormat(format, *args):
-diff -pur a/Mac/BuildScript/build-installer.py b/Mac/BuildScript/build-installer.py
---- a/Mac/BuildScript/build-installer.py	2020-10-05 17:07:58.000000000 +0200
-+++ b/Mac/BuildScript/build-installer.py	2020-11-05 14:43:47.000000000 +0100
+diff --git a/Mac/BuildScript/build-installer.py b/Mac/BuildScript/build-installer.py
+index a58b922..4935c0f 100755
+--- a/Mac/BuildScript/build-installer.py
++++ b/Mac/BuildScript/build-installer.py
 @@ -116,7 +116,8 @@ WORKDIR = "/tmp/_py"
  DEPSRC = os.path.join(WORKDIR, 'third-party')
  DEPSRC = os.path.expanduser('~/Universal/other-sources')
@@ -488,7 +498,7 @@ diff -pur a/Mac/BuildScript/build-installer.py b/Mac/BuildScript/build-installer
                         '64-bit': ('x86_64', 'ppc64',),
                         'intel':  ('i386', 'x86_64'),
                         'intel-32':  ('i386',),
-@@ -124,6 +125,7 @@ universal_opts_map = { '32-bit': ('i386'
+@@ -124,6 +125,7 @@ universal_opts_map = { '32-bit': ('i386', 'ppc',),
                         '3-way':  ('ppc', 'i386', 'x86_64'),
                         'all':    ('i386', 'ppc', 'x86_64', 'ppc64',) }
  default_target_map = {
@@ -542,7 +552,7 @@ diff -pur a/Mac/BuildScript/build-installer.py b/Mac/BuildScript/build-installer
                install='make TCL_LIBRARY=%(TCL_LIBRARY)s && make install TCL_LIBRARY=%(TCL_LIBRARY)s DESTDIR=%(DESTDIR)s'%{
                    "DESTDIR": shellQuote(os.path.join(WORKDIR, 'libraries')),
                    "TCL_LIBRARY": shellQuote('/Library/Frameworks/Python.framework/Versions/%s/lib/tcl8.6'%(getVersion())),
-@@ -801,6 +828,7 @@ def build_universal_openssl(basedir, arc
+@@ -801,6 +828,7 @@ def build_universal_openssl(basedir, archList):
          arch_opts = {
              "i386": ["darwin-i386-cc"],
              "x86_64": ["darwin64-x86_64-cc", "enable-ec_nistp_64_gcc_128"],
@@ -550,11 +560,11 @@ diff -pur a/Mac/BuildScript/build-installer.py b/Mac/BuildScript/build-installer
              "ppc": ["darwin-ppc-cc"],
              "ppc64": ["darwin64-ppc-cc"],
          }
-Only in b/Mac/BuildScript: openssl-mac-arm64.patch
-diff -pur a/Mac/README.rst b/Mac/README.rst
---- a/Mac/README.rst	2020-10-05 17:07:58.000000000 +0200
-+++ b/Mac/README.rst	2020-11-05 14:43:47.000000000 +0100
-@@ -120,6 +120,8 @@ support ppc (Xcode 4 on 10.6 and later s
+diff --git a/Mac/README.rst b/Mac/README.rst
+index ec7d873..f3638aa 100644
+--- a/Mac/README.rst
++++ b/Mac/README.rst
+@@ -120,6 +120,8 @@ support ppc (Xcode 4 on 10.6 and later systems).  The flavor can be specified
  using the configure option ``--with-universal-archs=VALUE``. The following
  values are available:
  
@@ -563,7 +573,7 @@ diff -pur a/Mac/README.rst b/Mac/README.rst
    * ``intel``:	  ``i386``, ``x86_64``
  
    * ``intel-32``: ``i386``
-@@ -155,6 +157,8 @@ following combinations of SDKs and unive
+@@ -155,6 +157,8 @@ following combinations of SDKs and universal-archs flavors are available:
  
    * 10.15 and later SDKs support ``intel-64`` only
  
@@ -572,7 +582,7 @@ diff -pur a/Mac/README.rst b/Mac/README.rst
  The makefile for a framework build will also install ``python3.x-32``
  binaries when the universal architecture includes at least one 32-bit
  architecture (that is, for all flavors but ``64-bit`` and ``intel-64``).
-@@ -352,6 +356,39 @@ A framework install also installs some a
+@@ -352,6 +356,39 @@ A framework install also installs some applications in ``/Applications/Python X.
  And lastly a framework installation installs files in ``/usr/local/bin``, all of
  them symbolic links to files in ``/Library/Frameworks/Python.framework/Versions/X.Y/bin``.
  
@@ -612,10 +622,11 @@ diff -pur a/Mac/README.rst b/Mac/README.rst
  
  Resources
  =========
-diff -pur a/Mac/Tools/pythonw.c b/Mac/Tools/pythonw.c
---- a/Mac/Tools/pythonw.c	2020-10-05 17:07:58.000000000 +0200
-+++ b/Mac/Tools/pythonw.c	2020-11-05 14:43:47.000000000 +0100
-@@ -95,9 +95,6 @@ setup_spawnattr(posix_spawnattr_t* spawn
+diff --git a/Mac/Tools/pythonw.c b/Mac/Tools/pythonw.c
+index c8bd3ba..78813e8 100644
+--- a/Mac/Tools/pythonw.c
++++ b/Mac/Tools/pythonw.c
+@@ -95,9 +95,6 @@ setup_spawnattr(posix_spawnattr_t* spawnattr)
      size_t count;
      cpu_type_t cpu_types[1];
      short flags = 0;
@@ -625,7 +636,7 @@ diff -pur a/Mac/Tools/pythonw.c b/Mac/Tools/pythonw.c
  
      if ((errno = posix_spawnattr_init(spawnattr)) != 0) {
          err(2, "posix_spawnattr_int");
-@@ -119,10 +116,16 @@ setup_spawnattr(posix_spawnattr_t* spawn
+@@ -119,10 +116,16 @@ setup_spawnattr(posix_spawnattr_t* spawnattr)
  
  #elif defined(__ppc__)
      cpu_types[0] = CPU_TYPE_POWERPC;
@@ -652,10 +663,10 @@ diff -pur a/Mac/Tools/pythonw.c b/Mac/Tools/pythonw.c
          posix_spawnattr_t spawnattr = NULL;
  
          setup_spawnattr(&spawnattr);
-Only in b/Misc: NEWS.d
-diff -pur a/Modules/_ctypes/callbacks.c b/Modules/_ctypes/callbacks.c
---- a/Modules/_ctypes/callbacks.c	2020-10-05 17:07:58.000000000 +0200
-+++ b/Modules/_ctypes/callbacks.c	2020-11-05 14:43:47.000000000 +0100
+diff --git a/Modules/_ctypes/callbacks.c b/Modules/_ctypes/callbacks.c
+index 2abfa67..39cace5 100644
+--- a/Modules/_ctypes/callbacks.c
++++ b/Modules/_ctypes/callbacks.c
 @@ -1,6 +1,8 @@
  #include "Python.h"
  #include "frameobject.h"
@@ -674,7 +685,7 @@ diff -pur a/Modules/_ctypes/callbacks.c b/Modules/_ctypes/callbacks.c
      PyObject_GC_Del(self);
  }
  
-@@ -361,8 +363,7 @@ CThunkObject *_ctypes_alloc_callback(PyO
+@@ -361,8 +363,7 @@ CThunkObject *_ctypes_alloc_callback(PyObject *callable,
  
      assert(CThunk_CheckExact((PyObject *)p));
  
@@ -684,7 +695,7 @@ diff -pur a/Modules/_ctypes/callbacks.c b/Modules/_ctypes/callbacks.c
      if (p->pcl_write == NULL) {
          PyErr_NoMemory();
          goto error;
-@@ -408,13 +409,35 @@ CThunkObject *_ctypes_alloc_callback(PyO
+@@ -408,13 +409,35 @@ CThunkObject *_ctypes_alloc_callback(PyObject *callable,
                       "ffi_prep_cif failed with %d", result);
          goto error;
      }
@@ -725,9 +736,10 @@ diff -pur a/Modules/_ctypes/callbacks.c b/Modules/_ctypes/callbacks.c
      if (result != FFI_OK) {
          PyErr_Format(PyExc_RuntimeError,
                       "ffi_prep_closure failed with %d", result);
-diff -pur a/Modules/_ctypes/callproc.c b/Modules/_ctypes/callproc.c
---- a/Modules/_ctypes/callproc.c	2020-10-05 17:07:58.000000000 +0200
-+++ b/Modules/_ctypes/callproc.c	2020-11-05 14:43:47.000000000 +0100
+diff --git a/Modules/_ctypes/callproc.c b/Modules/_ctypes/callproc.c
+index 6030cc3..b0a36a3 100644
+--- a/Modules/_ctypes/callproc.c
++++ b/Modules/_ctypes/callproc.c
 @@ -57,6 +57,8 @@
  #include "Python.h"
  #include "structmember.h"         // PyMemberDef
@@ -748,7 +760,7 @@ diff -pur a/Modules/_ctypes/callproc.c b/Modules/_ctypes/callproc.c
  #ifdef MS_WIN32
  #include <malloc.h>
  #endif
-@@ -812,7 +818,8 @@ static int _call_function_pointer(int fl
+@@ -812,7 +818,8 @@ static int _call_function_pointer(int flags,
                                    ffi_type **atypes,
                                    ffi_type *restype,
                                    void *resmem,
@@ -758,7 +770,7 @@ diff -pur a/Modules/_ctypes/callproc.c b/Modules/_ctypes/callproc.c
  {
      PyThreadState *_save = NULL; /* For Py_BLOCK_THREADS and Py_UNBLOCK_THREADS */
      PyObject *error_object = NULL;
-@@ -835,14 +842,70 @@ static int _call_function_pointer(int fl
+@@ -835,14 +842,70 @@ static int _call_function_pointer(int flags,
      if ((flags & FUNCFLAG_CDECL) == 0)
          cc = FFI_STDCALL;
  #endif
@@ -849,7 +861,7 @@ diff -pur a/Modules/_ctypes/callproc.c b/Modules/_ctypes/callproc.c
          goto cleanup;
  
  #ifdef WORDS_BIGENDIAN
-@@ -1398,6 +1460,42 @@ copy_com_pointer(PyObject *self, PyObjec
+@@ -1398,6 +1460,42 @@ copy_com_pointer(PyObject *self, PyObject *args)
  }
  #else
  
@@ -892,7 +904,7 @@ diff -pur a/Modules/_ctypes/callproc.c b/Modules/_ctypes/callproc.c
  static PyObject *py_dl_open(PyObject *self, PyObject *args)
  {
      PyObject *name, *name2;
-@@ -1887,6 +1985,8 @@ buffer_info(PyObject *self, PyObject *ar
+@@ -1887,6 +1985,8 @@ buffer_info(PyObject *self, PyObject *arg)
      return Py_BuildValue("siN", dict->format, dict->ndim, shape);
  }
  
@@ -901,20 +913,21 @@ diff -pur a/Modules/_ctypes/callproc.c b/Modules/_ctypes/callproc.c
  PyMethodDef _ctypes_module_methods[] = {
      {"get_errno", get_errno, METH_NOARGS},
      {"set_errno", set_errno, METH_VARARGS},
-@@ -1909,6 +2009,9 @@ PyMethodDef _ctypes_module_methods[] = {
+@@ -1908,6 +2008,9 @@ PyMethodDef _ctypes_module_methods[] = {
+      "dlopen(name, flag={RTLD_GLOBAL|RTLD_LOCAL}) open a shared library"},
      {"dlclose", py_dl_close, METH_VARARGS, "dlclose a library"},
      {"dlsym", py_dl_sym, METH_VARARGS, "find symbol in shared library"},
- #endif
++#endif
 +#ifdef HAVE_DYLD_SHARED_CACHE_CONTAINS_PATH
 +     {"_dyld_shared_cache_contains_path", py_dyld_shared_cache_contains_path, METH_VARARGS, "check if path is in the shared cache"},
-+#endif
+ #endif
      {"alignment", align_func, METH_O, alignment_doc},
      {"sizeof", sizeof_func, METH_O, sizeof_doc},
-     {"byref", byref, METH_VARARGS, byref_doc},
-diff -pur a/Modules/_ctypes/ctypes.h b/Modules/_ctypes/ctypes.h
---- a/Modules/_ctypes/ctypes.h	2020-10-05 17:07:58.000000000 +0200
-+++ b/Modules/_ctypes/ctypes.h	2020-11-05 14:43:47.000000000 +0100
-@@ -366,6 +366,14 @@ PyObject *_ctypes_get_errobj(int **pspac
+diff --git a/Modules/_ctypes/ctypes.h b/Modules/_ctypes/ctypes.h
+index 1effccf..3f20031 100644
+--- a/Modules/_ctypes/ctypes.h
++++ b/Modules/_ctypes/ctypes.h
+@@ -366,6 +366,14 @@ PyObject *_ctypes_get_errobj(int **pspace);
  extern PyObject *ComError;
  #endif
  
@@ -929,9 +942,10 @@ diff -pur a/Modules/_ctypes/ctypes.h b/Modules/_ctypes/ctypes.h
  /*
   Local Variables:
   compile-command: "python setup.py -q build install --home ~"
-diff -pur a/Modules/_ctypes/malloc_closure.c b/Modules/_ctypes/malloc_closure.c
---- a/Modules/_ctypes/malloc_closure.c	2020-10-05 17:07:58.000000000 +0200
-+++ b/Modules/_ctypes/malloc_closure.c	2020-11-05 14:43:47.000000000 +0100
+diff --git a/Modules/_ctypes/malloc_closure.c b/Modules/_ctypes/malloc_closure.c
+index f9cdb33..4f220e4 100644
+--- a/Modules/_ctypes/malloc_closure.c
++++ b/Modules/_ctypes/malloc_closure.c
 @@ -89,16 +89,27 @@ static void more_core(void)
  /******************************************************************/
  
@@ -962,9 +976,24 @@ diff -pur a/Modules/_ctypes/malloc_closure.c b/Modules/_ctypes/malloc_closure.c
      ITEM *item;
      if (!free_list)
          more_core();
-diff -pur a/Modules/getpath.c b/Modules/getpath.c
---- a/Modules/getpath.c	2020-10-05 17:07:58.000000000 +0200
-+++ b/Modules/getpath.c	2020-11-05 14:43:47.000000000 +0100
+diff --git a/Modules/_decimal/libmpdec/mpdecimal.h b/Modules/_decimal/libmpdec/mpdecimal.h
+index 2815a8c..fd6398d 100644
+--- a/Modules/_decimal/libmpdec/mpdecimal.h
++++ b/Modules/_decimal/libmpdec/mpdecimal.h
+@@ -121,6 +121,9 @@ const char *mpd_version(void);
+   #elif defined(__x86_64__)
+     #define CONFIG_64
+     #define ASM
++  #elif defined(__aarch64__)
++    #define CONFIG_64
++    #define ANSI
+   #else
+     #error "unknown architecture for universal build."
+   #endif
+diff --git a/Modules/getpath.c b/Modules/getpath.c
+index a84c858..4035819 100644
+--- a/Modules/getpath.c
++++ b/Modules/getpath.c
 @@ -923,11 +923,7 @@ static PyStatus
  calculate_program_macos(wchar_t **abs_path_p)
  {
@@ -977,9 +1006,10 @@ diff -pur a/Modules/getpath.c b/Modules/getpath.c
  
      /* On Mac OS X, if a script uses an interpreter of the form
         "#!/opt/python2.3/bin/python", the kernel only passes "python"
-diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
---- a/Modules/posixmodule.c	2020-10-05 17:07:58.000000000 +0200
-+++ b/Modules/posixmodule.c	2020-11-05 14:50:46.000000000 +0100
+diff --git a/Modules/posixmodule.c b/Modules/posixmodule.c
+index 01e8bcb..6c0dbcd 100644
+--- a/Modules/posixmodule.c
++++ b/Modules/posixmodule.c
 @@ -7,18 +7,6 @@
     of the compiler used.  Different compilers define their own feature
     test macro, e.g. '_MSC_VER'. */
@@ -1127,7 +1157,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
  #ifdef __cplusplus
  extern "C" {
  #endif
-@@ -2308,6 +2417,10 @@ posix_do_stat(PyObject *module, const ch
+@@ -2308,6 +2417,10 @@ posix_do_stat(PyObject *module, const char *function_name, path_t *path,
      STRUCT_STAT st;
      int result;
  
@@ -1138,7 +1168,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
  #if !defined(MS_WINDOWS) && !defined(HAVE_FSTATAT) && !defined(HAVE_LSTAT)
      if (follow_symlinks_specified(function_name, follow_symlinks))
          return NULL;
-@@ -2334,15 +2447,27 @@ posix_do_stat(PyObject *module, const ch
+@@ -2334,15 +2447,27 @@ posix_do_stat(PyObject *module, const char *function_name, path_t *path,
      else
  #endif /* HAVE_LSTAT */
  #ifdef HAVE_FSTATAT
@@ -1169,7 +1199,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
      if (result != 0) {
          return path_error(path);
      }
-@@ -2760,6 +2885,10 @@ os_access_impl(PyObject *module, path_t 
+@@ -2760,6 +2885,10 @@ os_access_impl(PyObject *module, path_t *path, int mode, int dir_fd,
      int result;
  #endif
  
@@ -1180,7 +1210,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
  #ifndef HAVE_FACCESSAT
      if (follow_symlinks_specified("access", follow_symlinks))
          return -1;
-@@ -2794,17 +2923,40 @@ os_access_impl(PyObject *module, path_t 
+@@ -2794,17 +2923,40 @@ os_access_impl(PyObject *module, path_t *path, int mode, int dir_fd,
      if ((dir_fd != DEFAULT_DIR_FD) ||
          effective_ids ||
          !follow_symlinks) {
@@ -1227,7 +1257,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
      return_value = !result;
  #endif
  
-@@ -3002,6 +3154,7 @@ os_chmod_impl(PyObject *module, path_t *
+@@ -3002,6 +3154,7 @@ os_chmod_impl(PyObject *module, path_t *path, int mode, int dir_fd,
  
  #ifdef HAVE_FCHMODAT
      int fchmodat_nofollow_unsupported = 0;
@@ -1235,7 +1265,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
  #endif
  
  #if !(defined(HAVE_FCHMODAT) || defined(HAVE_LCHMOD))
-@@ -3037,42 +3190,56 @@ os_chmod_impl(PyObject *module, path_t *
+@@ -3037,42 +3190,56 @@ os_chmod_impl(PyObject *module, path_t *path, int mode, int dir_fd,
      if (path->fd != -1)
          result = fchmod(path->fd, mode);
      else
@@ -1315,7 +1345,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
          if (fchmodat_nofollow_unsupported) {
              if (dir_fd != DEFAULT_DIR_FD)
                  dir_fd_and_follow_symlinks_invalid("chmod",
-@@ -3082,10 +3249,10 @@ os_chmod_impl(PyObject *module, path_t *
+@@ -3082,10 +3249,10 @@ os_chmod_impl(PyObject *module, path_t *path, int mode, int dir_fd,
              return NULL;
          }
          else
@@ -1328,7 +1358,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
  
      Py_RETURN_NONE;
  }
-@@ -3373,6 +3540,10 @@ os_chown_impl(PyObject *module, path_t *
+@@ -3373,6 +3540,10 @@ os_chown_impl(PyObject *module, path_t *path, uid_t uid, gid_t gid,
  {
      int result;
  
@@ -1339,7 +1369,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
  #if !(defined(HAVE_LCHOWN) || defined(HAVE_FCHOWNAT))
      if (follow_symlinks_specified("chown", follow_symlinks))
          return NULL;
-@@ -3381,19 +3552,6 @@ os_chown_impl(PyObject *module, path_t *
+@@ -3381,19 +3552,6 @@ os_chown_impl(PyObject *module, path_t *path, uid_t uid, gid_t gid,
          fd_and_follow_symlinks_invalid("chown", path->fd, follow_symlinks))
          return NULL;
  
@@ -1359,7 +1389,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
      if (PySys_Audit("os.chown", "OIIi", path->object, uid, gid,
                      dir_fd == DEFAULT_DIR_FD ? -1 : dir_fd) < 0) {
          return NULL;
-@@ -3411,14 +3569,28 @@ os_chown_impl(PyObject *module, path_t *
+@@ -3411,14 +3569,28 @@ os_chown_impl(PyObject *module, path_t *path, uid_t uid, gid_t gid,
      else
  #endif
  #ifdef HAVE_FCHOWNAT
@@ -1390,7 +1420,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
      if (result)
          return path_error(path);
  
-@@ -3664,6 +3836,9 @@ os_link_impl(PyObject *module, path_t *s
+@@ -3664,6 +3836,9 @@ os_link_impl(PyObject *module, path_t *src, path_t *dst, int src_dir_fd,
  #else
      int result;
  #endif
@@ -1400,7 +1430,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
  
  #ifndef HAVE_LINKAT
      if ((src_dir_fd != DEFAULT_DIR_FD) || (dst_dir_fd != DEFAULT_DIR_FD)) {
-@@ -3698,15 +3873,43 @@ os_link_impl(PyObject *module, path_t *s
+@@ -3698,15 +3873,43 @@ os_link_impl(PyObject *module, path_t *src, path_t *dst, int src_dir_fd,
  #ifdef HAVE_LINKAT
      if ((src_dir_fd != DEFAULT_DIR_FD) ||
          (dst_dir_fd != DEFAULT_DIR_FD) ||
@@ -1448,7 +1478,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
      if (result)
          return path_error2(src, dst);
  #endif /* MS_WINDOWS */
-@@ -3829,6 +4032,7 @@ _posix_listdir(path_t *path, PyObject *l
+@@ -3829,6 +4032,7 @@ _posix_listdir(path_t *path, PyObject *list)
      errno = 0;
  #ifdef HAVE_FDOPENDIR
      if (path->fd != -1) {
@@ -1456,7 +1486,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
          /* closedir() closes the FD, so we duplicate it */
          fd = _Py_dup(path->fd);
          if (fd == -1)
-@@ -3839,6 +4043,11 @@ _posix_listdir(path_t *path, PyObject *l
+@@ -3839,6 +4043,11 @@ _posix_listdir(path_t *path, PyObject *list)
          Py_BEGIN_ALLOW_THREADS
          dirp = fdopendir(fd);
          Py_END_ALLOW_THREADS
@@ -1468,7 +1498,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
      }
      else
  #endif
-@@ -4152,6 +4361,9 @@ os_mkdir_impl(PyObject *module, path_t *
+@@ -4152,6 +4361,9 @@ os_mkdir_impl(PyObject *module, path_t *path, int mode, int dir_fd)
  /*[clinic end generated code: output=a70446903abe821f input=e965f68377e9b1ce]*/
  {
      int result;
@@ -1478,7 +1508,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
  
      if (PySys_Audit("os.mkdir", "Oii", path->object, mode,
                      dir_fd == DEFAULT_DIR_FD ? -1 : dir_fd) < 0) {
-@@ -4168,9 +4380,14 @@ os_mkdir_impl(PyObject *module, path_t *
+@@ -4168,9 +4380,14 @@ os_mkdir_impl(PyObject *module, path_t *path, int mode, int dir_fd)
  #else
      Py_BEGIN_ALLOW_THREADS
  #if HAVE_MKDIRAT
@@ -1495,7 +1525,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
  #endif
  #if defined(__WATCOMC__) && !defined(__QNX__)
          result = mkdir(path->narrow);
-@@ -4178,6 +4395,14 @@ os_mkdir_impl(PyObject *module, path_t *
+@@ -4178,6 +4395,14 @@ os_mkdir_impl(PyObject *module, path_t *path, int mode, int dir_fd)
          result = mkdir(path->narrow, mode);
  #endif
      Py_END_ALLOW_THREADS
@@ -1510,7 +1540,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
      if (result < 0)
          return path_error(path);
  #endif /* MS_WINDOWS */
-@@ -4287,6 +4512,10 @@ internal_rename(path_t *src, path_t *dst
+@@ -4287,6 +4512,10 @@ internal_rename(path_t *src, path_t *dst, int src_dir_fd, int dst_dir_fd, int is
      const char *function_name = is_replace ? "replace" : "rename";
      int dir_fd_specified;
  
@@ -1521,7 +1551,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
  #ifdef MS_WINDOWS
      BOOL result;
      int flags = is_replace ? MOVEFILE_REPLACE_EXISTING : 0;
-@@ -4326,13 +4555,25 @@ internal_rename(path_t *src, path_t *dst
+@@ -4326,13 +4555,25 @@ internal_rename(path_t *src, path_t *dst, int src_dir_fd, int dst_dir_fd, int is
  
      Py_BEGIN_ALLOW_THREADS
  #ifdef HAVE_RENAMEAT
@@ -1550,7 +1580,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
      if (result)
          return path_error2(src, dst);
  #endif
-@@ -4408,6 +4649,9 @@ os_rmdir_impl(PyObject *module, path_t *
+@@ -4408,6 +4649,9 @@ os_rmdir_impl(PyObject *module, path_t *path, int dir_fd)
  /*[clinic end generated code: output=080eb54f506e8301 input=38c8b375ca34a7e2]*/
  {
      int result;
@@ -1560,7 +1590,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
  
      if (PySys_Audit("os.rmdir", "Oi", path->object,
                      dir_fd == DEFAULT_DIR_FD ? -1 : dir_fd) < 0) {
-@@ -4420,14 +4664,26 @@ os_rmdir_impl(PyObject *module, path_t *
+@@ -4420,14 +4664,26 @@ os_rmdir_impl(PyObject *module, path_t *path, int dir_fd)
      result = !RemoveDirectoryW(path->wide);
  #else
  #ifdef HAVE_UNLINKAT
@@ -1589,7 +1619,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
      if (result)
          return path_error(path);
  
-@@ -4571,6 +4827,9 @@ os_unlink_impl(PyObject *module, path_t 
+@@ -4571,6 +4827,9 @@ os_unlink_impl(PyObject *module, path_t *path, int dir_fd)
  /*[clinic end generated code: output=621797807b9963b1 input=d7bcde2b1b2a2552]*/
  {
      int result;
@@ -1599,7 +1629,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
  
      if (PySys_Audit("os.remove", "Oi", path->object,
                      dir_fd == DEFAULT_DIR_FD ? -1 : dir_fd) < 0) {
-@@ -4584,15 +4843,27 @@ os_unlink_impl(PyObject *module, path_t 
+@@ -4584,15 +4843,27 @@ os_unlink_impl(PyObject *module, path_t *path, int dir_fd)
      result = !Py_DeleteFileW(path->wide);
  #else
  #ifdef HAVE_UNLINKAT
@@ -1710,7 +1740,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
  #endif
  }
  
-@@ -4828,7 +5143,15 @@ utime_nofollow_symlinks(utime_t *ut, con
+@@ -4828,7 +5143,15 @@ utime_nofollow_symlinks(utime_t *ut, const char *path)
  static int
  utime_default(utime_t *ut, const char *path)
  {
@@ -1727,7 +1757,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
      UTIME_TO_TIMESPEC;
      return utimensat(DEFAULT_DIR_FD, path, time, 0);
  #elif defined(HAVE_UTIMES)
-@@ -5037,9 +5360,10 @@ os_utime_impl(PyObject *module, path_t *
+@@ -5037,9 +5360,10 @@ os_utime_impl(PyObject *module, path_t *path, PyObject *times, PyObject *ns,
  #endif
  
  #if defined(HAVE_FUTIMESAT) || defined(HAVE_UTIMENSAT)
@@ -1740,7 +1770,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
  #endif
  
  #if defined(HAVE_FUTIMES) || defined(HAVE_FUTIMENS)
-@@ -5052,6 +5376,14 @@ os_utime_impl(PyObject *module, path_t *
+@@ -5052,6 +5376,14 @@ os_utime_impl(PyObject *module, path_t *path, PyObject *times, PyObject *ns,
  
      Py_END_ALLOW_THREADS
  
@@ -1755,7 +1785,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
      if (result < 0) {
          /* see previous comment about not putting filename in error here */
          posix_error();
-@@ -5450,6 +5782,9 @@ parse_posix_spawn_flags(PyObject *module
+@@ -5450,6 +5782,9 @@ parse_posix_spawn_flags(PyObject *module, const char *func_name, PyObject *setpg
      }
  
      if (setsid) {
@@ -1765,7 +1795,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
  #ifdef POSIX_SPAWN_SETSID
          all_flags |= POSIX_SPAWN_SETSID;
  #elif defined(POSIX_SPAWN_SETSID_NP)
-@@ -5458,6 +5793,14 @@ parse_posix_spawn_flags(PyObject *module
+@@ -5458,6 +5793,14 @@ parse_posix_spawn_flags(PyObject *module, const char *func_name, PyObject *setpg
          argument_unavailable_error(func_name, "setsid");
          return -1;
  #endif
@@ -1780,7 +1810,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
      }
  
     if (setsigmask) {
-@@ -8068,16 +8411,30 @@ os_readlink_impl(PyObject *module, path_
+@@ -8068,16 +8411,30 @@ os_readlink_impl(PyObject *module, path_t *path, int dir_fd)
  #if defined(HAVE_READLINK)
      char buffer[MAXPATHLEN+1];
      ssize_t length;
@@ -1814,7 +1844,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
      if (length < 0) {
          return path_error(path);
      }
-@@ -8273,6 +8630,9 @@ os_symlink_impl(PyObject *module, path_t
+@@ -8273,6 +8630,9 @@ os_symlink_impl(PyObject *module, path_t *src, path_t *dst,
      static int windows_has_symlink_unprivileged_flag = TRUE;
  #else
      int result;
@@ -1824,7 +1854,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
  #endif
  
      if (PySys_Audit("os.symlink", "OOi", src->object, dst->object,
-@@ -8335,14 +8695,25 @@ os_symlink_impl(PyObject *module, path_t
+@@ -8335,14 +8695,25 @@ os_symlink_impl(PyObject *module, path_t *src, path_t *dst,
      }
  
      Py_BEGIN_ALLOW_THREADS
@@ -1854,7 +1884,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
      if (result)
          return path_error2(src, dst);
  #endif
-@@ -8613,6 +8984,9 @@ os_open_impl(PyObject *module, path_t *p
+@@ -8613,6 +8984,9 @@ os_open_impl(PyObject *module, path_t *path, int flags, int mode, int dir_fd)
  {
      int fd;
      int async_err = 0;
@@ -1864,7 +1894,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
  
  #ifdef O_CLOEXEC
      int *atomic_flag_works = &_Py_open_cloexec_works;
-@@ -8637,9 +9011,15 @@ os_open_impl(PyObject *module, path_t *p
+@@ -8637,9 +9011,15 @@ os_open_impl(PyObject *module, path_t *path, int flags, int mode, int dir_fd)
          fd = _wopen(path->wide, flags, mode);
  #else
  #ifdef HAVE_OPENAT
@@ -1883,7 +1913,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
  #endif /* HAVE_OPENAT */
              fd = open(path->narrow, flags, mode);
  #endif /* !MS_WINDOWS */
-@@ -8647,6 +9027,13 @@ os_open_impl(PyObject *module, path_t *p
+@@ -8647,6 +9027,13 @@ os_open_impl(PyObject *module, path_t *path, int flags, int mode, int dir_fd)
      } while (fd < 0 && errno == EINTR && !(async_err = PyErr_CheckSignals()));
      _Py_END_SUPPRESS_IPH
  
@@ -1897,7 +1927,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
      if (fd < 0) {
          if (!async_err)
              PyErr_SetFromErrnoWithFilenameObject(PyExc_OSError, path->object);
-@@ -9229,12 +9616,25 @@ os_preadv_impl(PyObject *module, int fd,
+@@ -9229,12 +9616,25 @@ os_preadv_impl(PyObject *module, int fd, PyObject *buffers, Py_off_t offset,
      } while (n < 0 && errno == EINTR && !(async_err = PyErr_CheckSignals()));
  #else
      do {
@@ -1923,7 +1953,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
  #endif
  
      iov_cleanup(iov, buf, cnt);
-@@ -9841,6 +10241,15 @@ os_pwritev_impl(PyObject *module, int fd
+@@ -9841,6 +10241,15 @@ os_pwritev_impl(PyObject *module, int fd, PyObject *buffers, Py_off_t offset,
          Py_END_ALLOW_THREADS
      } while (result < 0 && errno == EINTR && !(async_err = PyErr_CheckSignals()));
  #else
@@ -1939,7 +1969,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
      do {
          Py_BEGIN_ALLOW_THREADS
          _Py_BEGIN_SUPPRESS_IPH
-@@ -9848,6 +10257,11 @@ os_pwritev_impl(PyObject *module, int fd
+@@ -9848,6 +10257,11 @@ os_pwritev_impl(PyObject *module, int fd, PyObject *buffers, Py_off_t offset,
          _Py_END_SUPPRESS_IPH
          Py_END_ALLOW_THREADS
      } while (result < 0 && errno == EINTR && !(async_err = PyErr_CheckSignals()));
@@ -1951,7 +1981,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
  #endif
  
      iov_cleanup(iov, buf, cnt);
-@@ -10737,13 +11151,6 @@ os_statvfs_impl(PyObject *module, path_t
+@@ -10737,13 +11151,6 @@ os_statvfs_impl(PyObject *module, path_t *path)
      Py_BEGIN_ALLOW_THREADS
  #ifdef HAVE_FSTATVFS
      if (path->fd != -1) {
@@ -1965,7 +1995,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
          result = fstatvfs(path->fd, &st);
      }
      else
-@@ -12817,12 +13224,15 @@ DirEntry_fetch_stat(PyObject *module, Di
+@@ -12817,12 +13224,15 @@ DirEntry_fetch_stat(PyObject *module, DirEntry *self, int follow_symlinks)
      const char *path = PyBytes_AS_STRING(ub);
      if (self->dir_fd != DEFAULT_DIR_FD) {
  #ifdef HAVE_FSTATAT
@@ -1983,7 +2013,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
      }
      else
  #endif
-@@ -13609,6 +14019,7 @@ os_scandir_impl(PyObject *module, path_t
+@@ -13609,6 +14019,7 @@ os_scandir_impl(PyObject *module, path_t *path)
      errno = 0;
  #ifdef HAVE_FDOPENDIR
      if (path->fd != -1) {
@@ -1991,7 +2021,7 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
          /* closedir() closes the FD, so we duplicate it */
          fd = _Py_dup(path->fd);
          if (fd == -1)
-@@ -13617,6 +14028,11 @@ os_scandir_impl(PyObject *module, path_t
+@@ -13617,6 +14028,11 @@ os_scandir_impl(PyObject *module, path_t *path)
          Py_BEGIN_ALLOW_THREADS
          iterator->dirp = fdopendir(fd);
          Py_END_ALLOW_THREADS
@@ -2337,9 +2367,10 @@ diff -pur a/Modules/posixmodule.c b/Modules/posixmodule.c
      PyModule_AddObject(m, "_have_functions", list);
  
      return 0;
-diff -pur a/Modules/timemodule.c b/Modules/timemodule.c
---- a/Modules/timemodule.c	2020-10-05 17:07:58.000000000 +0200
-+++ b/Modules/timemodule.c	2020-11-05 14:43:47.000000000 +0100
+diff --git a/Modules/timemodule.c b/Modules/timemodule.c
+index 8a4d149..2faf579 100644
+--- a/Modules/timemodule.c
++++ b/Modules/timemodule.c
 @@ -51,6 +51,15 @@
  #define _Py_tzname tzname
  #endif
@@ -2385,7 +2416,7 @@ diff -pur a/Modules/timemodule.c b/Modules/timemodule.c
  #endif   /* HAVE_CLOCK_GETRES */
  
  #ifdef HAVE_PTHREAD_GETCPUCLOCKID
-@@ -1162,31 +1186,35 @@ _PyTime_GetProcessTimeWithInfo(_PyTime_t
+@@ -1162,31 +1186,35 @@ _PyTime_GetProcessTimeWithInfo(_PyTime_t *tp, _Py_clock_info_t *info)
  #if defined(HAVE_CLOCK_GETTIME) \
      && (defined(CLOCK_PROCESS_CPUTIME_ID) || defined(CLOCK_PROF))
      struct timespec ts;
@@ -2439,7 +2470,7 @@ diff -pur a/Modules/timemodule.c b/Modules/timemodule.c
      }
  #endif
  
-@@ -1373,6 +1401,16 @@ _PyTime_GetThreadTimeWithInfo(_PyTime_t 
+@@ -1373,6 +1401,16 @@ _PyTime_GetThreadTimeWithInfo(_PyTime_t *tp, _Py_clock_info_t *info)
  
  #elif defined(HAVE_CLOCK_GETTIME) && defined(CLOCK_PROCESS_CPUTIME_ID)
  #define HAVE_THREAD_TIME
@@ -2456,7 +2487,7 @@ diff -pur a/Modules/timemodule.c b/Modules/timemodule.c
  static int
  _PyTime_GetThreadTimeWithInfo(_PyTime_t *tp, _Py_clock_info_t *info)
  {
-@@ -1404,6 +1442,15 @@ _PyTime_GetThreadTimeWithInfo(_PyTime_t 
+@@ -1404,6 +1442,15 @@ _PyTime_GetThreadTimeWithInfo(_PyTime_t *tp, _Py_clock_info_t *info)
  #endif
  
  #ifdef HAVE_THREAD_TIME
@@ -2484,7 +2515,7 @@ diff -pur a/Modules/timemodule.c b/Modules/timemodule.c
  #endif
  
  
-@@ -1483,9 +1535,19 @@ time_get_clock_info(PyObject *self, PyOb
+@@ -1483,9 +1535,19 @@ time_get_clock_info(PyObject *self, PyObject *args)
      }
  #ifdef HAVE_THREAD_TIME
      else if (strcmp(name, "thread_time") == 0) {
@@ -2505,7 +2536,7 @@ diff -pur a/Modules/timemodule.c b/Modules/timemodule.c
      }
  #endif
      else {
-@@ -1766,68 +1828,116 @@ if it is -1, mktime() should guess based
+@@ -1766,68 +1828,116 @@ if it is -1, mktime() should guess based on the date and time.\n");
  static int
  time_exec(PyObject *module)
  {
@@ -2655,9 +2686,10 @@ diff -pur a/Modules/timemodule.c b/Modules/timemodule.c
  
  #endif  /* defined(HAVE_CLOCK_GETTIME) || defined(HAVE_CLOCK_SETTIME) || defined(HAVE_CLOCK_GETRES) */
  
-diff -pur a/Python/bootstrap_hash.c b/Python/bootstrap_hash.c
---- a/Python/bootstrap_hash.c	2020-10-05 17:07:58.000000000 +0200
-+++ b/Python/bootstrap_hash.c	2020-11-05 14:43:47.000000000 +0100
+diff --git a/Python/bootstrap_hash.c b/Python/bootstrap_hash.c
+index 4736930..a212f69 100644
+--- a/Python/bootstrap_hash.c
++++ b/Python/bootstrap_hash.c
 @@ -25,6 +25,16 @@
  #  include <sanitizer/msan_interface.h>
  #endif
@@ -2675,7 +2707,7 @@ diff -pur a/Python/bootstrap_hash.c b/Python/bootstrap_hash.c
  #ifdef Py_DEBUG
  int _Py_HashSecret_Initialized = 0;
  #else
-@@ -208,6 +218,16 @@ py_getrandom(void *buffer, Py_ssize_t si
+@@ -208,6 +218,16 @@ py_getrandom(void *buffer, Py_ssize_t size, int blocking, int raise)
       error.
  
     getentropy() is retried if it failed with EINTR: interrupted by a signal. */
@@ -2692,7 +2724,7 @@ diff -pur a/Python/bootstrap_hash.c b/Python/bootstrap_hash.c
  static int
  py_getentropy(char *buffer, Py_ssize_t size, int raise)
  {
-@@ -498,19 +518,21 @@ pyurandom(void *buffer, Py_ssize_t size,
+@@ -498,19 +518,21 @@ pyurandom(void *buffer, Py_ssize_t size, int blocking, int raise)
  #else
  
  #if defined(PY_GETRANDOM) || defined(PY_GETENTROPY)
@@ -2724,9 +2756,10 @@ diff -pur a/Python/bootstrap_hash.c b/Python/bootstrap_hash.c
  #endif
  
      return dev_urandom(buffer, size, raise);
-diff -pur a/Python/pytime.c b/Python/pytime.c
---- a/Python/pytime.c	2020-10-05 17:07:58.000000000 +0200
-+++ b/Python/pytime.c	2020-11-05 14:43:47.000000000 +0100
+diff --git a/Python/pytime.c b/Python/pytime.c
+index b121b43..89d63e0 100644
+--- a/Python/pytime.c
++++ b/Python/pytime.c
 @@ -5,6 +5,12 @@
  
  #if defined(__APPLE__)
@@ -2740,7 +2773,7 @@ diff -pur a/Python/pytime.c b/Python/pytime.c
  #endif
  
  #define _PyTime_check_mul_overflow(a, b) \
-@@ -683,15 +689,22 @@ pygettimeofday(_PyTime_t *tp, _Py_clock_
+@@ -683,15 +689,22 @@ pygettimeofday(_PyTime_t *tp, _Py_clock_info_t *info, int raise)
  
  #else   /* MS_WINDOWS */
      int err;
@@ -2765,7 +2798,7 @@ diff -pur a/Python/pytime.c b/Python/pytime.c
      err = clock_gettime(CLOCK_REALTIME, &ts);
      if (err) {
          if (raise) {
-@@ -715,7 +728,14 @@ pygettimeofday(_PyTime_t *tp, _Py_clock_
+@@ -715,7 +728,14 @@ pygettimeofday(_PyTime_t *tp, _Py_clock_info_t *info, int raise)
              info->resolution = 1e-9;
          }
      }
@@ -2781,7 +2814,7 @@ diff -pur a/Python/pytime.c b/Python/pytime.c
  
       /* test gettimeofday() */
      err = gettimeofday(&tv, (struct timezone *)NULL);
-@@ -735,6 +755,11 @@ pygettimeofday(_PyTime_t *tp, _Py_clock_
+@@ -735,6 +755,11 @@ pygettimeofday(_PyTime_t *tp, _Py_clock_info_t *info, int raise)
          info->monotonic = 0;
          info->adjustable = 1;
      }
@@ -2793,9 +2826,10 @@ diff -pur a/Python/pytime.c b/Python/pytime.c
  #endif   /* !HAVE_CLOCK_GETTIME */
  #endif   /* !MS_WINDOWS */
      return 0;
-diff -pur a/configure b/configure
---- a/configure	2020-10-05 17:07:58.000000000 +0200
-+++ b/configure	2020-11-05 14:43:47.000000000 +0100
+diff --git a/configure b/configure
+index 9e6fd46..16b8098 100755
+--- a/configure
++++ b/configure
 @@ -1510,8 +1510,8 @@ Optional Packages:
                            specify the kind of universal binary that should be
                            created. this option is only valid when
@@ -2860,10 +2894,12 @@ diff -pur a/configure b/configure
      		;;
      	esac
  
-@@ -11989,6 +11997,31 @@ $as_echo "no" >&6; }
+@@ -11987,6 +11995,31 @@ else
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+ $as_echo "no" >&6; }
  
- fi
- rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
++fi
++rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 +{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for _dyld_shared_cache_contains_path" >&5
 +$as_echo_n "checking for _dyld_shared_cache_contains_path... " >&6; }
 +cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -2887,14 +2923,13 @@ diff -pur a/configure b/configure
 +  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 +$as_echo "no" >&6; }
 +
-+fi
-+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+ fi
+ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
  
- { $as_echo "$as_me:${as_lineno-$LINENO}: checking for memfd_create" >&5
- $as_echo_n "checking for memfd_create... " >&6; }
-diff -pur a/configure.ac b/configure.ac
---- a/configure.ac	2020-10-05 17:07:58.000000000 +0200
-+++ b/configure.ac	2020-11-05 14:43:47.000000000 +0100
+diff --git a/configure.ac b/configure.ac
+index d60f052..f9ecb8f 100644
+--- a/configure.ac
++++ b/configure.ac
 @@ -218,7 +218,7 @@ AC_ARG_WITH(universal-archs,
      AS_HELP_STRING([--with-universal-archs=ARCH],
                     [specify the kind of universal binary that should be created. this option is
@@ -2970,9 +3005,10 @@ diff -pur a/configure.ac b/configure.ac
  
  AC_MSG_CHECKING(for memfd_create)
  AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
-diff -pur a/pyconfig.h.in b/pyconfig.h.in
---- a/pyconfig.h.in	2020-10-05 17:07:58.000000000 +0200
-+++ b/pyconfig.h.in	2020-11-05 14:43:47.000000000 +0100
+diff --git a/pyconfig.h.in b/pyconfig.h.in
+index c9589cd..f39858d 100644
+--- a/pyconfig.h.in
++++ b/pyconfig.h.in
 @@ -778,6 +778,9 @@
  /* Define if you have the 'prlimit' functions. */
  #undef HAVE_PRLIMIT
@@ -2983,9 +3019,10 @@ diff -pur a/pyconfig.h.in b/pyconfig.h.in
  /* Define to 1 if you have the <process.h> header file. */
  #undef HAVE_PROCESS_H
  
-diff -pur a/setup.py b/setup.py
---- a/setup.py	2020-10-05 17:07:58.000000000 +0200
-+++ b/setup.py	2020-11-05 14:43:47.000000000 +0100
+diff --git a/setup.py b/setup.py
+index 770866b..846b64b 100644
+--- a/setup.py
++++ b/setup.py
 @@ -239,6 +239,13 @@ def is_macosx_sdk_path(path):
                  or path.startswith('/Library/') )
  


### PR DESCRIPTION
Hi!

Python 3.9 failed to build on the new macOS arm64 because of a `#error` in `libmpdec`.