### PR TITLE
docbook-xsl: add patch from www.linuxfromscratch.org

### DIFF
--- a/docbook-xsl/docbook-xsl-nons-1.79.2-stack_fix-1.patch
+++ b/docbook-xsl/docbook-xsl-nons-1.79.2-stack_fix-1.patch
@@ -1,0 +1,39 @@
+Submitted By:            Bruce Dubbs <bdubbs at linuxfromscratch dot org>
+Date:                    2018-01-01
+Initial Package Version: 1.78.1
+Upstream Status:         Unsure
+Origin:                  Peter De Wachter <pdewacht@gmail.com>
+Description: use EXSLT "replace" function when available
+ A recursive implementation  of string.subst is problematic,
+ long strings with many matches will cause stack overflows.
+Author: Peter De Wachter <pdewacht@gmail.com>
+Bug-Debian: https://bugs.debian.org/750593
+
+Rediffed for 1.79.2 by Bruce Dubbs
+
+diff -Naur docbook-xsl-1.79.2.orig/lib/lib.xsl docbook-xsl-1.79.2/lib/lib.xsl
+--- docbook-xsl-1.79.2.orig/lib/lib.xsl	2016-12-09 16:41:39.000000000 -0600
++++ docbook-xsl-1.79.2/lib/lib.xsl	2018-01-01 12:54:52.507332514 -0600
+@@ -6,7 +6,11 @@
+ 
+      This module implements DTD-independent functions
+ 
+-     ******************************************************************** --><xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
++     ******************************************************************** -->
++<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
++                xmlns:str="http://exslt.org/strings"
++                exclude-result-prefixes="str"
++                version="1.0">
+ 
+ <xsl:template name="dot.count">
+   <!-- Returns the number of "." characters in a string -->
+@@ -52,6 +56,9 @@
+   <xsl:param name="replacement"/>
+ 
+   <xsl:choose>
++    <xsl:when test="function-available('str:replace')">
++      <xsl:value-of select="str:replace($string, string($target), string($replacement))"/>
++    </xsl:when>
+     <xsl:when test="contains($string, $target)">
+       <xsl:variable name="rest">
+         <xsl:call-template name="string.subst">


### PR DESCRIPTION
That website has download problems, see
https://github.com/Homebrew/homebrew-core/issues/67283#issuecomment-748593231.

Original URL:
http://www.linuxfromscratch.org/patches/blfs/9.1/docbook-xsl-nons-1.79.2-stack_fix-1.patch

Signed-off-by: Stefan Weil <sw@weilnetz.de>