### PR TITLE
apr: configure rollup patch

### DIFF
--- a/apr/r1882980+1882981-configure.patch
+++ b/apr/r1882980+1882981-configure.patch
@@ -1,0 +1,111 @@
+--- apr-1.7.0/build/apr_common.m4	2020/10/29 20:16:55	1882979
++++ apr-1.7.0/build/apr_common.m4	2020/10/29 20:23:11	1882980
+@@ -495,6 +495,7 @@
+ #include <errno.h>
+ #include <string.h>
+ #include <stdio.h>
++#include <stdlib.h>
+ main()
+ {
+   char buf[1024];
+--- apr-1.7.0/build/apr_network.m4	2020/10/29 20:16:55	1882979
++++ apr-1.7.0/build/apr_network.m4	2020/10/29 20:23:11	1882980
+@@ -63,6 +63,9 @@
+ #ifdef HAVE_SYS_SOCKET_H
+ #include <sys/socket.h>
+ #endif
++#ifdef HAVE_STDLIB_H
++#include <stdlib.h>
++#endif
+ 
+ int main(void) {
+     struct addrinfo hints, *ai;
+@@ -151,6 +154,9 @@
+ #ifdef HAVE_NETINET_IN_H
+ #include <netinet/in.h>
+ #endif
++#ifdef HAVE_STDLIB_H
++#include <stdlib.h>
++#endif
+ 
+ int main(void) {
+     struct sockaddr_in sa;
+@@ -194,6 +200,9 @@
+ #ifdef HAVE_NETDB_H
+ #include <netdb.h>
+ #endif
++#ifdef HAVE_STDLIB_H
++#include <stdlib.h>
++#endif
+ 
+ int main(void) {
+     if (EAI_ADDRFAMILY < 0) {
+@@ -403,6 +412,9 @@
+ #ifndef HAVE_SOCKLEN_T
+ typedef int socklen_t;
+ #endif
++#ifdef HAVE_STDLIB_H
++#include <stdlib.h>
++#endif
+ int main(void) {
+     int listen_s, connected_s, client_s;
+     int listen_port, rc;
+@@ -588,6 +600,9 @@
+ #ifdef HAVE_FCNTL_H
+ #include <fcntl.h>
+ #endif
++#ifdef HAVE_STDLIB_H
++#include <stdlib.h>
++#endif
+ int main(void) {
+     int listen_s, connected_s, client_s;
+     int listen_port, rc;
+--- apr-1.7.0/configure.in	2020/10/29 20:16:55	1882979
++++ apr-1.7.0/configure.in	2020/10/29 20:23:11	1882980
+@@ -2214,6 +2214,7 @@
+ #include <sys/types.h>
+ #include <sys/time.h>
+ #include <sys/resource.h>
++#include <stdlib.h>
+ main()
+ {
+     struct rlimit limit;
+@@ -2250,6 +2251,7 @@
+ #include <stdlib.h>
+ #include <fcntl.h>
+ #include <semaphore.h>
++#include <stdlib.h>
+ #ifndef SEM_FAILED
+ #define SEM_FAILED (-1)
+ #endif
+@@ -2313,6 +2315,7 @@
+       AC_TRY_RUN([
+ #include <sys/types.h>
+ #include <pthread.h>
++#include <stdlib.h>
+         int main()
+         {
+             pthread_mutex_t mutex;
+@@ -2442,7 +2445,9 @@
+ #endif
+ #include <fcntl.h>
+ #include <errno.h>
+-
++#ifdef HAVE_STDLIB_H
++#include <stdlib.h>
++#endif
+ int fd;
+ struct flock proc_mutex_lock_it = {0};
+ const char *fname = "conftest.fcntl";
+--- apr-1.7.0/build/apr_network.m4	2020/10/29 20:23:11	1882980
++++ apr-1.7.0/build/apr_network.m4	2020/10/29 20:32:54	1882981
+@@ -154,6 +154,9 @@
+ #ifdef HAVE_NETINET_IN_H
+ #include <netinet/in.h>
+ #endif
++#ifdef HAVE_ARPA_INET_H
++#include <arpa/inet.h>
++#endif
+ #ifdef HAVE_STDLIB_H
+ #include <stdlib.h>
+ #endif


### PR DESCRIPTION
Incorporates the following from upstream:
* https://svn.apache.org/viewvc?view=revision&revision=1882980 (calls to exit() require stdlib.h or else we get -Werror,-Wimplicit-function-declaration)
* https://svn.apache.org/viewvc?view=revision&revision=1882981 (arpa/inet.h is required for inet_addr)

To be applied in https://github.com/Homebrew/homebrew-core/pull/68915