### PR TITLE
openjdk@11: update aarch64 patch for 11.0.10

### DIFF
--- a/openjdk@11/aarch64.diff
+++ b/openjdk@11/aarch64.diff
@@ -9087,17 +9087,6 @@ diff -Npur jdk11u-jdk-11.0.9-ga/src/hotspot/share/runtime/sharedRuntime.cpp jdk1
    address entry_point = moop->from_compiled_entry_no_trampoline();
  
    // It's possible that deoptimization can occur at a call site which hasn't
-@@ -2811,8 +2814,8 @@ void AdapterHandlerLibrary::create_nativ
-     BufferBlob*  buf = buffer_blob(); // the temporary code buffer in CodeCache
-     if (buf != NULL) {
-       CodeBuffer buffer(buf);
--      double locs_buf[20];
--      buffer.insts()->initialize_shared_locs((relocInfo*)locs_buf, sizeof(locs_buf) / sizeof(relocInfo));
-+      struct { double data[20]; } locs_buf;
-+      buffer.insts()->initialize_shared_locs((relocInfo*)&locs_buf, sizeof(locs_buf) / sizeof(relocInfo));
-       MacroAssembler _masm(&buffer);
- 
-       // Fill in the signature array, for the calling-convention call.
 diff -Npur jdk11u-jdk-11.0.9-ga/src/hotspot/share/runtime/signature.hpp jdk11u-jdk-11.0.9-ga-patched/src/hotspot/share/runtime/signature.hpp
 --- jdk11u-jdk-11.0.9-ga/src/hotspot/share/runtime/signature.hpp	2020-09-11 18:12:45.000000000 +0200
 +++ jdk11u-jdk-11.0.9-ga-patched/src/hotspot/share/runtime/signature.hpp	2021-01-16 15:56:28.000000000 +0100
@@ -9792,16 +9781,9 @@ diff -Npur jdk11u-jdk-11.0.9-ga/src/hotspot/share/runtime/vm_version.cpp jdk11u-
 -  return _parallel_worker_threads;
 -}
 diff -Npur jdk11u-jdk-11.0.9-ga/src/hotspot/share/runtime/vm_version.hpp jdk11u-jdk-11.0.9-ga-patched/src/hotspot/share/runtime/vm_version.hpp
---- jdk11u-jdk-11.0.9-ga/src/hotspot/share/runtime/vm_version.hpp	2020-09-11 18:12:45.000000000 +0200
-+++ jdk11u-jdk-11.0.9-ga-patched/src/hotspot/share/runtime/vm_version.hpp	2021-01-16 15:56:28.000000000 +0100
-@@ -1,5 +1,5 @@
- /*
-- * Copyright (c) 1997, 2016, Oracle and/or its affiliates. All rights reserved.
-+ * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
-  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
-  *
-  * This code is free software; you can redistribute it and/or modify it
-@@ -22,169 +22,10 @@
+--- jdk11u-jdk-11.0.9-ga/src/hotspot/share/runtime/vm_version.hpp      2020-09-11 18:12:45.000000000 +0200
++++ jdk11u-jdk-11.0.9-ga-patched/src/hotspot/share/runtime/vm_version.hpp      2021-01-16 15:56:28.000000000 +0100
+@@ -22,170 +22,10 @@
   *
   */
  
@@ -9818,6 +9800,7 @@ diff -Npur jdk11u-jdk-11.0.9-ga/src/hotspot/share/runtime/vm_version.hpp jdk11u-
 -  KVM,
 -  VMWare,
 -  HyperV,
+-  HyperVRole,
 -  PowerVM, // on AIX or Linux ppc64(le)
 -  PowerFullPartitionMode, // on Linux ppc64(le)
 -  PowerKVM
@@ -9967,9 +9950,10 @@ diff -Npur jdk11u-jdk-11.0.9-ga/src/hotspot/share/runtime/vm_version.hpp jdk11u-
 -
 -  static bool print_matching_lines_from_file(const char* filename, outputStream* st, const char* keywords_to_match[]);
 -};
+-
 +#ifndef SHARE_RUNTIME_VM_VERSION_HPP
 +#define SHARE_RUNTIME_VM_VERSION_HPP
- 
++
 +#include "utilities/macros.hpp"  // for CPU_HEADER() macro.
  #include CPU_HEADER(vm_version)
  
@@ -10087,25 +10071,6 @@ diff -Npur jdk11u-jdk-11.0.9-ga/src/java.desktop/macosx/native/libawt_lwawt/awt/
  }
  
  @implementation AWTView
-diff -Npur jdk11u-jdk-11.0.9-ga/src/java.desktop/macosx/native/libawt_lwawt/awt/CSystemColors.m jdk11u-jdk-11.0.9-ga-patched/src/java.desktop/macosx/native/libawt_lwawt/awt/CSystemColors.m
---- jdk11u-jdk-11.0.9-ga/src/java.desktop/macosx/native/libawt_lwawt/awt/CSystemColors.m	2020-09-11 18:12:45.000000000 +0200
-+++ jdk11u-jdk-11.0.9-ga-patched/src/java.desktop/macosx/native/libawt_lwawt/awt/CSystemColors.m	2021-01-16 15:56:28.000000000 +0100
-@@ -1,5 +1,5 @@
- /*
-- * Copyright (c) 2011, 2012, Oracle and/or its affiliates. All rights reserved.
-+ * Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
-  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
-  *
-  * This code is free software; you can redistribute it and/or modify it
-@@ -126,7 +126,7 @@ static JNF_STATIC_MEMBER_CACHE(jm_system
- + (NSColor*)getColor:(NSUInteger)colorIndex useAppleColor:(BOOL)useAppleColor {
-     NSColor* result = nil;
- 
--    if (colorIndex < (useAppleColor) ? sun_lwawt_macosx_LWCToolkit_NUM_APPLE_COLORS : java_awt_SystemColor_NUM_COLORS) {
-+    if (colorIndex < ((useAppleColor) ? sun_lwawt_macosx_LWCToolkit_NUM_APPLE_COLORS : java_awt_SystemColor_NUM_COLORS)) {
-         result = (useAppleColor ? appleColors : sColors)[colorIndex];
-     }
-     else {
 diff -Npur jdk11u-jdk-11.0.9-ga/src/java.desktop/macosx/native/libawt_lwawt/awt/OSVersion.h jdk11u-jdk-11.0.9-ga-patched/src/java.desktop/macosx/native/libawt_lwawt/awt/OSVersion.h
 --- jdk11u-jdk-11.0.9-ga/src/java.desktop/macosx/native/libawt_lwawt/awt/OSVersion.h	2020-09-11 18:12:45.000000000 +0200
 +++ jdk11u-jdk-11.0.9-ga-patched/src/java.desktop/macosx/native/libawt_lwawt/awt/OSVersion.h	1970-01-01 01:00:00.000000000 +0100
@@ -11004,229 +10969,3 @@ diff -Npur jdk11u-jdk-11.0.9-ga/src/jdk.hotspot.agent/share/classes/sun/jvm/hots
 +    return debugger.getThreadForIdentifierAddress(threadIdAddr, uniqueThreadIdAddr);
 +  }
 +}
-diff -Npur jdk11u-jdk-11.0.9-ga/test/hotspot/gtest/code/test_vtableStub.cpp jdk11u-jdk-11.0.9-ga-patched/test/hotspot/gtest/code/test_vtableStub.cpp
---- jdk11u-jdk-11.0.9-ga/test/hotspot/gtest/code/test_vtableStub.cpp	2020-09-11 18:12:45.000000000 +0200
-+++ jdk11u-jdk-11.0.9-ga-patched/test/hotspot/gtest/code/test_vtableStub.cpp	2021-01-16 15:56:38.000000000 +0100
-@@ -30,6 +30,7 @@
- TEST_VM(code, vtableStubs) {
-   // Should be in VM to use locks
-   ThreadInVMfromNative ThreadInVMfromNative(JavaThread::current());
-+  Thread::WXWriteFromExecSetter wx_exec;
- 
-   VtableStubs::find_vtable_stub(0); // min vtable index
-   for (int i = 0; i < 15; i++) {
-@@ -42,6 +43,7 @@ TEST_VM(code, vtableStubs) {
- TEST_VM(code, itableStubs) {
-   // Should be in VM to use locks
-   ThreadInVMfromNative ThreadInVMfromNative(JavaThread::current());
-+  Thread::WXWriteFromExecSetter wx_exec;
- 
-   VtableStubs::find_itable_stub(0); // min itable index
-   for (int i = 0; i < 15; i++) {
-diff -Npur jdk11u-jdk-11.0.9-ga/test/hotspot/gtest/gc/shared/test_oopStorage.cpp jdk11u-jdk-11.0.9-ga-patched/test/hotspot/gtest/gc/shared/test_oopStorage.cpp
---- jdk11u-jdk-11.0.9-ga/test/hotspot/gtest/gc/shared/test_oopStorage.cpp	2020-09-11 18:12:45.000000000 +0200
-+++ jdk11u-jdk-11.0.9-ga-patched/test/hotspot/gtest/gc/shared/test_oopStorage.cpp	2021-01-16 15:56:38.000000000 +0100
-@@ -147,6 +147,9 @@ static bool process_deferred_updates(Oop
- }
- 
- static void release_entry(OopStorage& storage, oop* entry, bool process_deferred = true) {
-+  // missing transition to vm state
-+  Thread::WXWriteFromExecSetter wx_write;
-+
-   *entry = NULL;
-   storage.release(entry);
-   if (process_deferred) {
-@@ -497,11 +500,17 @@ public:
-       QuickSort::sort(to_release, nrelease, PointerCompare(), false);
-     }
- 
--    _storage.release(to_release, nrelease);
--    EXPECT_EQ(_max_entries - nrelease, _storage.allocation_count());
-+    {
-+      // missing transition to vm state
-+      Thread::WXWriteFromExecSetter wx_write;
-+      _storage.release(to_release, nrelease);
-+      EXPECT_EQ(_max_entries - nrelease, _storage.allocation_count());
-+    }
- 
-     for (size_t i = 0; i < nrelease; ++i) {
-       release_entry(_storage, _entries[2 * i + 1], false);
-+      // missing transition to vm state
-+      Thread::WXWriteFromExecSetter wx_write;
-       EXPECT_EQ(_max_entries - nrelease - (i + 1), _storage.allocation_count());
-     }
-     EXPECT_TRUE(process_deferred_updates(_storage));
-@@ -529,6 +538,8 @@ TEST_VM_F(OopStorageTest, invalid_pointe
-   {
-     char* mem = NEW_C_HEAP_ARRAY(char, 1000, mtInternal);
-     oop* ptr = reinterpret_cast<oop*>(align_down(mem + 250, sizeof(oop)));
-+    // missing transition to vm state
-+    Thread::WXWriteFromExecSetter wx_write;
-     // Predicate returns false for some malloc'ed block.
-     EXPECT_EQ(OopStorage::INVALID_ENTRY, _storage.allocation_status(ptr));
-     FREE_C_HEAP_ARRAY(char, mem);
-@@ -537,6 +548,8 @@ TEST_VM_F(OopStorageTest, invalid_pointe
-   {
-     oop obj;
-     oop* ptr = &obj;
-+    // missing transition to vm state
-+    Thread::WXWriteFromExecSetter wx_write;
-     // Predicate returns false for some "random" location.
-     EXPECT_EQ(OopStorage::INVALID_ENTRY, _storage.allocation_status(ptr));
-   }
-@@ -1077,11 +1090,16 @@ TEST_VM_F(OopStorageTestWithAllocation, 
-   oop* garbage = reinterpret_cast<oop*>(1024 * 1024);
-   release_entry(_storage, released);
- 
--  EXPECT_EQ(OopStorage::ALLOCATED_ENTRY, _storage.allocation_status(retained));
--  EXPECT_EQ(OopStorage::UNALLOCATED_ENTRY, _storage.allocation_status(released));
-+  {
-+    // missing transition to vm state
-+    Thread::WXWriteFromExecSetter wx_write;
-+
-+    EXPECT_EQ(OopStorage::ALLOCATED_ENTRY, _storage.allocation_status(retained));
-+    EXPECT_EQ(OopStorage::UNALLOCATED_ENTRY, _storage.allocation_status(released));
- #ifndef DISABLE_GARBAGE_ALLOCATION_STATUS_TESTS
--  EXPECT_EQ(OopStorage::INVALID_ENTRY, _storage.allocation_status(garbage));
-+    EXPECT_EQ(OopStorage::INVALID_ENTRY, _storage.allocation_status(garbage));
- #endif
-+  }
- 
-   for (size_t i = 0; i < _max_entries; ++i) {
-     if ((_entries[i] != retained) && (_entries[i] != released)) {
-@@ -1092,14 +1110,20 @@ TEST_VM_F(OopStorageTestWithAllocation, 
- 
-   {
-     ThreadInVMfromNative invm(JavaThread::current());
-+    Thread::WXWriteFromExecSetter wx_write;
-     VM_DeleteBlocksAtSafepoint op(&_storage);
-     VMThread::execute(&op);
-   }
--  EXPECT_EQ(OopStorage::ALLOCATED_ENTRY, _storage.allocation_status(retained));
-+
-+  {
-+    // missing transition to vm state
-+    Thread::WXWriteFromExecSetter wx_write;
-+    EXPECT_EQ(OopStorage::ALLOCATED_ENTRY, _storage.allocation_status(retained));
- #ifndef DISABLE_GARBAGE_ALLOCATION_STATUS_TESTS
--  EXPECT_EQ(OopStorage::INVALID_ENTRY, _storage.allocation_status(released));
--  EXPECT_EQ(OopStorage::INVALID_ENTRY, _storage.allocation_status(garbage));
-+    EXPECT_EQ(OopStorage::INVALID_ENTRY, _storage.allocation_status(released));
-+    EXPECT_EQ(OopStorage::INVALID_ENTRY, _storage.allocation_status(garbage));
- #endif // DISABLE_GARBAGE_ALLOCATION_STATUS_TESTS
-+  }
- }
- 
- TEST_VM_F(OopStorageTest, usage_info) {
-diff -Npur jdk11u-jdk-11.0.9-ga/test/hotspot/gtest/gc/shared/test_oopStorage_parperf.cpp jdk11u-jdk-11.0.9-ga-patched/test/hotspot/gtest/gc/shared/test_oopStorage_parperf.cpp
---- jdk11u-jdk-11.0.9-ga/test/hotspot/gtest/gc/shared/test_oopStorage_parperf.cpp	2020-09-11 18:12:45.000000000 +0200
-+++ jdk11u-jdk-11.0.9-ga-patched/test/hotspot/gtest/gc/shared/test_oopStorage_parperf.cpp	2021-01-16 15:56:38.000000000 +0100
-@@ -112,6 +112,8 @@ OopStorageParIterPerf::OopStorageParIter
- }
- 
- OopStorageParIterPerf::~OopStorageParIterPerf() {
-+  // missing transition to vm state
-+  Thread::WXWriteFromExecSetter wx_write;
-   _storage.release(_entries, ARRAY_SIZE(_entries));
- }
- 
-diff -Npur jdk11u-jdk-11.0.9-ga/test/hotspot/gtest/runtime/test_os.cpp jdk11u-jdk-11.0.9-ga-patched/test/hotspot/gtest/runtime/test_os.cpp
---- jdk11u-jdk-11.0.9-ga/test/hotspot/gtest/runtime/test_os.cpp	2020-09-11 18:12:45.000000000 +0200
-+++ jdk11u-jdk-11.0.9-ga-patched/test/hotspot/gtest/runtime/test_os.cpp	2021-01-16 15:56:38.000000000 +0100
-@@ -157,6 +157,10 @@ static void do_test_print_hex_dump(addre
-   char buf[256];
-   buf[0] = '\0';
-   stringStream ss(buf, sizeof(buf));
-+
-+  // missing transition to vm state
-+  Thread::WXWriteFromExecSetter wx_write;
-+
-   os::print_hex_dump(&ss, addr, addr + len, unitsize);
- //  tty->print_cr("expected: %s", expected);
- //  tty->print_cr("result: %s", buf);
-diff -Npur jdk11u-jdk-11.0.9-ga/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java jdk11u-jdk-11.0.9-ga-patched/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java
---- jdk11u-jdk-11.0.9-ga/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java	2020-09-11 18:12:45.000000000 +0200
-+++ jdk11u-jdk-11.0.9-ga-patched/test/hotspot/jtreg/runtime/CompressedOops/CompressedClassPointers.java	2021-01-16 15:56:38.000000000 +0100
-@@ -25,7 +25,7 @@
-  * @test
-  * @bug 8024927
-  * @summary Testing address of compressed class pointer space as best as possible.
-- * @requires vm.bits == 64 & vm.opt.final.UseCompressedOops == true & os.family != "windows"
-+ * @requires vm.bits == 64 & vm.opt.final.UseCompressedOops == true & os.family != "windows" & !(os.family == "mac" & os.arch=="aarch64")
-  * @library /test/lib
-  * @modules java.base/jdk.internal.misc
-  *          java.management
-diff -Npur jdk11u-jdk-11.0.9-ga/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/extension/EX03/ex03t001/ex03t001.c jdk11u-jdk-11.0.9-ga-patched/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/extension/EX03/ex03t001/ex03t001.c
---- jdk11u-jdk-11.0.9-ga/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/extension/EX03/ex03t001/ex03t001.c	2020-09-11 18:12:45.000000000 +0200
-+++ jdk11u-jdk-11.0.9-ga-patched/test/hotspot/jtreg/vmTestbase/nsk/jvmti/scenarios/extension/EX03/ex03t001/ex03t001.c	2021-01-16 15:56:38.000000000 +0100
-@@ -43,13 +43,22 @@ static jrawMonitorID eventMon;
- /* ============================================================================= */
- 
- static void JNICALL
--ClassUnload(jvmtiEnv* jvmti_env, JNIEnv *jni_env, jthread thread, jclass class, ...) {
-+ClassUnload(jvmtiEnv* jvmti_env, ...) {
-     /*
-      * With the CMS GC the event can be posted on
-      * a ConcurrentGC thread that is not a JavaThread.
-      * In this case the thread argument can be NULL, so that,
-      * we should not expect the thread argument to be non-NULL.
-      */
-+    JNIEnv *jni_env = NULL;
-+    va_list ap;
-+
-+    va_start(ap, jvmti_env);
-+    jni_env = va_arg(ap, JNIEnv *);
-+    jthread thread = va_arg(ap, jthread);
-+    jclass class = va_arg(ap, jclass);
-+    va_end(ap);
-+
-     if (class == NULL) {
-         nsk_jvmti_setFailStatus();
-         NSK_COMPLAIN0("ClassUnload: 'class' input parameter is NULL.\n");
-diff -Npur jdk11u-jdk-11.0.9-ga/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/ArgumentHandler.java jdk11u-jdk-11.0.9-ga-patched/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/ArgumentHandler.java
---- jdk11u-jdk-11.0.9-ga/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/ArgumentHandler.java	2020-09-11 18:12:45.000000000 +0200
-+++ jdk11u-jdk-11.0.9-ga-patched/test/hotspot/jtreg/vmTestbase/nsk/share/jdi/ArgumentHandler.java	2021-01-16 15:56:38.000000000 +0100
-@@ -538,6 +538,8 @@ class CheckedFeatures {
-         {"linux-s390x",     "com.sun.jdi.SharedMemoryAttach"},
-         {"macosx-amd64",    "com.sun.jdi.SharedMemoryAttach"},
-         {"mac-x64",         "com.sun.jdi.SharedMemoryAttach"},
-+        {"macosx-aarch64",  "com.sun.jdi.SharedMemoryAttach"},
-+        {"mac-aarch64",     "com.sun.jdi.SharedMemoryAttach"},
-         {"aix-ppc64",       "com.sun.jdi.SharedMemoryAttach"},
- 
-             // listening connectors
-@@ -568,6 +570,8 @@ class CheckedFeatures {
-         {"linux-s390x",     "com.sun.jdi.SharedMemoryListen"},
-         {"macosx-amd64",    "com.sun.jdi.SharedMemoryListen"},
-         {"mac-x64",         "com.sun.jdi.SharedMemoryListen"},
-+        {"macosx-aarch64",  "com.sun.jdi.SharedMemoryListen"},
-+        {"mac-aarch64",     "com.sun.jdi.SharedMemoryListen"},
-         {"aix-ppc64",       "com.sun.jdi.SharedMemoryListen"},
- 
-             // launching connectors
-@@ -647,8 +651,14 @@ class CheckedFeatures {
-         {"macosx-amd64",     "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
-         {"macosx-amd64",     "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
- 
--        {"mac-x64",         "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
--        {"mac-x64",         "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
-+        {"mac-x64",          "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
-+        {"mac-x64",          "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
-+
-+        {"macosx-aarch64",   "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
-+        {"macosx-aarch64",   "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
-+
-+        {"mac-aarch64",      "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
-+        {"mac-aarch64",      "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
- 
-         {"aix-ppc64",       "com.sun.jdi.CommandLineLaunch", "dt_shmem"},
-         {"aix-ppc64",       "com.sun.jdi.RawCommandLineLaunch", "dt_shmem"},
-@@ -672,6 +682,8 @@ class CheckedFeatures {
-         {"linux-s390x",     "dt_shmem"},
-         {"macosx-amd64",    "dt_shmem"},
-         {"mac-x64",         "dt_shmem"},
-+        {"macosx-aarch64",  "dt_shmem"},
-+        {"mac-aarch64",     "dt_shmem"},
-         {"aix-ppc64",       "dt_shmem"},
-     };
- }


### PR DESCRIPTION
This PR updates patch for openjdk@11 for Apple Silicon (https://github.com/Homebrew/formula-patches/commit/906561d59f9c9197acb44e5246f4adb71fef5bab) to make it compatible with [openjdk@11 11.0.10](https://github.com/Homebrew/homebrew-core/pull/69396):

- Remove patch for xcode 12 (it was applied by upstream)
- Update patch `src/hotspot/share/runtime/vm_version.hpp`
- Remove patch for `test/` directory — it has conflicts with upstream, I believe we don't really need it, so, just left upstream version of `test/`

<details>
<summary> The patch doesn't apply cleanly, but it applies (with some offsets) </summary>
<p>

```
==> Applying aarch64.diff
patch -g 0 -f -p1 -i /private/tmp/openjdk-11--patch-20210122-76032-1tn43xz/aarch64.diff
patching file make/autoconf/flags.m4
patching file make/autoconf/hotspot.m4
patching file make/autoconf/platform.m4
patching file make/autoconf/toolchain.m4
patching file make/common/NativeCompilation.gmk
patching file make/hotspot/lib/CompileJvm.gmk
patching file make/lib/Lib-jdk.hotspot.agent.gmk
patching file make/test/JtregNativeJdk.gmk
patching file src/hotspot/cpu/aarch64/aarch64.ad
patching file src/hotspot/cpu/aarch64/aarch64_ad.m4
patching file src/hotspot/cpu/aarch64/assembler_aarch64.cpp
Hunk #2 succeeded at 132 (offset -2 lines).
Hunk #3 succeeded at 1223 (offset -3 lines).
Hunk #4 succeeded at 1262 (offset -3 lines).
Hunk #5 succeeded at 1271 (offset -3 lines).
Hunk #6 succeeded at 1282 (offset -3 lines).
Hunk #7 succeeded at 1431 (offset -3 lines).
patching file src/hotspot/cpu/aarch64/assembler_aarch64.hpp
patching file src/hotspot/cpu/aarch64/c1_Defs_aarch64.hpp
patching file src/hotspot/cpu/aarch64/c1_FrameMap_aarch64.cpp
patching file src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.cpp
patching file src/hotspot/cpu/aarch64/frame_aarch64.cpp
patching file src/hotspot/cpu/aarch64/gc/shared/barrierSetAssembler_aarch64.cpp
patching file src/hotspot/cpu/aarch64/immediate_aarch64.cpp
patching file src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
patching file src/hotspot/cpu/aarch64/interpreterRT_aarch64.cpp
patching file src/hotspot/cpu/aarch64/interpreterRT_aarch64.hpp
patching file src/hotspot/cpu/aarch64/jniFastGetField_aarch64.cpp
patching file src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
Hunk #28 succeeded at 5766 (offset -4 lines).
patching file src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
patching file src/hotspot/cpu/aarch64/macroAssembler_aarch64_log.cpp
patching file src/hotspot/cpu/aarch64/macroAssembler_aarch64_trig.cpp
patching file src/hotspot/cpu/aarch64/nativeInst_aarch64.cpp
patching file src/hotspot/cpu/aarch64/register_aarch64.hpp
patching file src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
patching file src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
patching file src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
patching file src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
patching file src/hotspot/cpu/aarch64/vm_version_aarch64.hpp
patching file src/hotspot/cpu/aarch64/vm_version_ext_aarch64.hpp
patching file src/hotspot/cpu/arm/register_arm.hpp
patching file src/hotspot/cpu/arm/vm_version_arm.hpp
patching file src/hotspot/cpu/arm/vm_version_arm_32.cpp
patching file src/hotspot/cpu/arm/vm_version_ext_arm.hpp
patching file src/hotspot/cpu/ppc/vm_version_ext_ppc.hpp
patching file src/hotspot/cpu/ppc/vm_version_ppc.cpp
patching file src/hotspot/cpu/ppc/vm_version_ppc.hpp
patching file src/hotspot/cpu/s390/register_s390.hpp
patching file src/hotspot/cpu/s390/vm_version_ext_s390.hpp
patching file src/hotspot/cpu/s390/vm_version_s390.cpp
patching file src/hotspot/cpu/s390/vm_version_s390.hpp
patching file src/hotspot/cpu/sparc/vm_version_ext_sparc.hpp
patching file src/hotspot/cpu/sparc/vm_version_sparc.cpp
patching file src/hotspot/cpu/sparc/vm_version_sparc.hpp
patching file src/hotspot/cpu/x86/assembler_x86.hpp
patching file src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
patching file src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
patching file src/hotspot/cpu/x86/vm_version_ext_x86.hpp
patching file src/hotspot/cpu/x86/vm_version_x86.cpp
patching file src/hotspot/cpu/x86/vm_version_x86.hpp
patching file src/hotspot/cpu/zero/register_zero.hpp
patching file src/hotspot/cpu/zero/vm_version_ext_zero.hpp
patching file src/hotspot/cpu/zero/vm_version_zero.cpp
patching file src/hotspot/cpu/zero/vm_version_zero.hpp
patching file src/hotspot/os/aix/os_aix.cpp
patching file src/hotspot/os/bsd/os_bsd.cpp
patching file src/hotspot/os/bsd/os_perf_bsd.cpp
patching file src/hotspot/os/linux/os_linux.cpp
patching file src/hotspot/os/solaris/os_solaris.cpp
patching file src/hotspot/os/windows/os_perf_windows.cpp
patching file src/hotspot/os/windows/os_windows.cpp
Hunk #1 succeeded at 3103 (offset -2 lines).
Hunk #2 succeeded at 3309 (offset -2 lines).
Hunk #3 succeeded at 3328 (offset -2 lines).
patching file src/hotspot/os_cpu/aix_ppc/os_aix_ppc.hpp
patching file src/hotspot/os_cpu/bsd_aarch64/atomic_bsd_aarch64.hpp
patching file src/hotspot/os_cpu/bsd_aarch64/bytes_bsd_aarch64.inline.hpp
patching file src/hotspot/os_cpu/bsd_aarch64/copy_bsd_aarch64.inline.hpp
patching file src/hotspot/os_cpu/bsd_aarch64/copy_bsd_aarch64.s
patching file src/hotspot/os_cpu/bsd_aarch64/globals_bsd_aarch64.hpp
patching file src/hotspot/os_cpu/bsd_aarch64/orderAccess_bsd_aarch64.hpp
patching file src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.cpp
patching file src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.hpp
patching file src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.inline.hpp
patching file src/hotspot/os_cpu/bsd_aarch64/prefetch_bsd_aarch64.inline.hpp
patching file src/hotspot/os_cpu/bsd_aarch64/thread_bsd_aarch64.cpp
patching file src/hotspot/os_cpu/bsd_aarch64/thread_bsd_aarch64.hpp
patching file src/hotspot/os_cpu/bsd_aarch64/vmStructs_bsd_aarch64.hpp
patching file src/hotspot/os_cpu/bsd_aarch64/vm_version_bsd_aarch64.cpp
patching file src/hotspot/os_cpu/bsd_x86/os_bsd_x86.hpp
Hunk #1 succeeded at 37 (offset 1 line).
patching file src/hotspot/os_cpu/bsd_x86/vm_version_bsd_x86.cpp
patching file src/hotspot/os_cpu/bsd_zero/os_bsd_zero.hpp
patching file src/hotspot/os_cpu/bsd_zero/vm_version_bsd_zero.cpp
patching file src/hotspot/os_cpu/linux_aarch64/atomic_linux_aarch64.hpp
patching file src/hotspot/os_cpu/linux_aarch64/orderAccess_linux_aarch64.hpp
patching file src/hotspot/os_cpu/linux_aarch64/os_linux_aarch64.hpp
patching file src/hotspot/os_cpu/linux_aarch64/vm_version_linux_aarch64.cpp
patching file src/hotspot/os_cpu/linux_arm/atomic_linux_arm.hpp
patching file src/hotspot/os_cpu/linux_arm/orderAccess_linux_arm.hpp
patching file src/hotspot/os_cpu/linux_arm/os_linux_arm.hpp
patching file src/hotspot/os_cpu/linux_arm/vm_version_linux_arm_32.cpp
patching file src/hotspot/os_cpu/linux_ppc/os_linux_ppc.hpp
patching file src/hotspot/os_cpu/linux_s390/atomic_linux_s390.hpp
patching file src/hotspot/os_cpu/linux_s390/orderAccess_linux_s390.hpp
patching file src/hotspot/os_cpu/linux_s390/os_linux_s390.hpp
patching file src/hotspot/os_cpu/linux_sparc/vm_version_linux_sparc.cpp
patching file src/hotspot/os_cpu/linux_x86/os_linux_x86.hpp
Hunk #1 succeeded at 50 (offset 1 line).
patching file src/hotspot/os_cpu/linux_x86/vm_version_linux_x86.cpp
patching file src/hotspot/os_cpu/linux_zero/os_linux_zero.hpp
patching file src/hotspot/os_cpu/linux_zero/vm_version_linux_zero.cpp
patching file src/hotspot/os_cpu/solaris_sparc/os_solaris_sparc.hpp
patching file src/hotspot/os_cpu/solaris_sparc/vm_version_solaris_sparc.cpp
patching file src/hotspot/os_cpu/solaris_x86/os_solaris_x86.hpp
patching file src/hotspot/os_cpu/solaris_x86/vm_version_solaris_x86.cpp
patching file src/hotspot/os_cpu/windows_x86/os_windows_x86.hpp
Hunk #1 succeeded at 71 (offset 1 line).
patching file src/hotspot/os_cpu/windows_x86/vm_version_windows_x86.cpp
patching file src/hotspot/share/ci/ciUtilities.inline.hpp
patching file src/hotspot/share/classfile/classLoader.cpp
patching file src/hotspot/share/classfile/javaClasses.cpp
patching file src/hotspot/share/classfile/verifier.cpp
Hunk #1 succeeded at 292 (offset 7 lines).
patching file src/hotspot/share/compiler/compileBroker.cpp
Hunk #1 succeeded at 1674 (offset 1 line).
Hunk #2 succeeded at 1977 (offset 1 line).
Hunk #3 succeeded at 2160 (offset 1 line).
patching file src/hotspot/share/gc/g1/g1PageBasedVirtualSpace.cpp
patching file src/hotspot/share/gc/parallel/psCardTable.cpp
patching file src/hotspot/share/gc/parallel/psVirtualspace.cpp
patching file src/hotspot/share/gc/shared/cardTable.cpp
patching file src/hotspot/share/gc/shared/oopStorage.cpp
patching file src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
Hunk #1 succeeded at 1317 (offset 18 lines).
Hunk #2 succeeded at 2387 (offset 18 lines).
patching file src/hotspot/share/gc/shenandoah/shenandoahHeapRegion.cpp
patching file src/hotspot/share/interpreter/oopMapCache.cpp
patching file src/hotspot/share/jfr/instrumentation/jfrJvmtiAgent.cpp
patching file src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
patching file src/hotspot/share/jvmci/jvmciEnv.hpp
patching file src/hotspot/share/jvmci/jvmciRuntime.cpp
Hunk #1 succeeded at 759 (offset -50 lines).
patching file src/hotspot/share/memory/virtualspace.cpp
patching file src/hotspot/share/opto/runtime.cpp
patching file src/hotspot/share/prims/jni.cpp
Hunk #1 succeeded at 4017 (offset 10 lines).
Hunk #2 succeeded at 4114 (offset 10 lines).
Hunk #3 succeeded at 4175 (offset 10 lines).
Hunk #4 succeeded at 4250 (offset 10 lines).
Hunk #5 succeeded at 4308 (offset 10 lines).
patching file src/hotspot/share/prims/jniCheck.cpp
patching file src/hotspot/share/prims/jvm.cpp
Hunk #1 succeeded at 3449 (offset 10 lines).
patching file src/hotspot/share/prims/jvmtiEnter.xsl
patching file src/hotspot/share/prims/jvmtiEnv.cpp
patching file src/hotspot/share/prims/jvmtiExport.cpp
Hunk #1 succeeded at 82 (offset 1 line).
Hunk #2 succeeded at 99 (offset 1 line).
Hunk #3 succeeded at 391 (offset 1 line).
patching file src/hotspot/share/prims/jvmtiExtensions.cpp
patching file src/hotspot/share/prims/jvmtiImpl.cpp
Hunk #1 succeeded at 83 (offset 1 line).
patching file src/hotspot/share/prims/methodHandles.cpp
patching file src/hotspot/share/prims/nativeLookup.cpp
patching file src/hotspot/share/prims/perf.cpp
patching file src/hotspot/share/prims/unsafe.cpp
patching file src/hotspot/share/prims/whitebox.cpp
patching file src/hotspot/share/runtime/abstract_vm_version.cpp
patching file src/hotspot/share/runtime/abstract_vm_version.hpp
patching file src/hotspot/share/runtime/deoptimization.cpp
Hunk #1 succeeded at 2069 (offset 3 lines).
patching file src/hotspot/share/runtime/interfaceSupport.inline.hpp
patching file src/hotspot/share/runtime/javaCalls.cpp
patching file src/hotspot/share/runtime/objectMonitor.cpp
patching file src/hotspot/share/runtime/os.cpp
Hunk #2 succeeded at 1715 (offset 3 lines).
Hunk #3 succeeded at 1726 (offset 3 lines).
Hunk #4 succeeded at 1796 (offset 3 lines).
patching file src/hotspot/share/runtime/os.hpp
patching file src/hotspot/share/runtime/safepoint.cpp
patching file src/hotspot/share/runtime/sharedRuntime.cpp
patching file src/hotspot/share/runtime/signature.hpp
patching file src/hotspot/share/runtime/stubRoutines.cpp
patching file src/hotspot/share/runtime/stubRoutines.hpp
patching file src/hotspot/share/runtime/stubRoutines.inline.hpp
patching file src/hotspot/share/runtime/thread.cpp
Hunk #1 succeeded at 316 (offset 1 line).
Hunk #2 succeeded at 371 (offset 1 line).
Hunk #3 succeeded at 2534 (offset 2 lines).
Hunk #4 succeeded at 2555 (offset 2 lines).
Hunk #5 succeeded at 2622 (offset 2 lines).
Hunk #6 succeeded at 3679 (offset 6 lines).
Hunk #7 succeeded at 3784 (offset 6 lines).
Hunk #8 succeeded at 4209 (offset 11 lines).
Hunk #9 succeeded at 4229 (offset 11 lines).
patching file src/hotspot/share/runtime/thread.hpp
Hunk #1 succeeded at 752 (offset 1 line).
patching file src/hotspot/share/runtime/vm_version.cpp
patching file src/hotspot/share/runtime/vm_version.hpp
patching file src/hotspot/share/services/diagnosticCommand.cpp
patching file src/hotspot/share/utilities/globalDefinitions_gcc.hpp
patching file src/hotspot/share/utilities/nativeCallStack.cpp
patching file src/hotspot/share/utilities/vmError.cpp
patching file src/java.base/macosx/native/libjava/java_props_macosx.c
patching file src/java.base/macosx/native/libjli/java_md_macosx.c
patching file src/java.desktop/macosx/native/libawt_lwawt/awt/AWTView.m
Hunk #2 succeeded at 55 (offset 3 lines).
patching file src/java.desktop/macosx/native/libawt_lwawt/awt/OSVersion.h
patching file src/java.desktop/macosx/native/libawt_lwawt/awt/OSVersion.m
patching file src/java.security.jgss/share/native/libj2gss/gssapi.h
Hunk #2 succeeded at 694 (offset 13 lines).
patching file src/jdk.hotspot.agent/macosx/native/libsaproc/MacosxDebuggerLocal.m
patching file src/jdk.hotspot.agent/macosx/native/libsaproc/libproc_impl.h
patching file src/jdk.hotspot.agent/macosx/native/libsaproc/ps_core.c
patching file src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HotSpotAgent.java
patching file src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/asm/Disassembler.java
patching file src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/bsd/BsdCDebugger.java
patching file src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/bsd/BsdThreadContextFactory.java
patching file src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/bsd/aarch64/BsdAARCH64CFrame.java
patching file src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/bsd/aarch64/BsdAARCH64ThreadContext.java
patching file src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Threads.java
patching file src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/bsd_aarch64/BsdAARCH64JavaThreadPDAccess.java
```

</p>
</details>

