### PR TITLE
llvm: add patch to fix lldb build

### DIFF
--- a/llvm/lldb.patch
+++ b/llvm/lldb.patch
@@ -1,0 +1,126 @@
+diff --git a/lldb/source/Plugins/Platform/MacOSX/PlatformAppleTVSimulator.h b/lldb/source/Plugins/Platform/MacOSX/PlatformAppleTVSimulator.h
+--- a/lldb/source/Plugins/Platform/MacOSX/PlatformAppleTVSimulator.h
++++ b/lldb/source/Plugins/Platform/MacOSX/PlatformAppleTVSimulator.h
+@@ -55,7 +55,7 @@
+   GetSharedModule(const lldb_private::ModuleSpec &module_spec,
+                   lldb_private::Process *process, lldb::ModuleSP &module_sp,
+                   const lldb_private::FileSpecList *module_search_paths_ptr,
+-                  lldb::ModuleSP *old_module_sp_ptr,
++                  llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules,
+                   bool *did_create_ptr) override;
+ 
+   uint32_t
+diff --git a/lldb/source/Plugins/Platform/MacOSX/PlatformAppleTVSimulator.cpp b/lldb/source/Plugins/Platform/MacOSX/PlatformAppleTVSimulator.cpp
+--- a/lldb/source/Plugins/Platform/MacOSX/PlatformAppleTVSimulator.cpp
++++ b/lldb/source/Plugins/Platform/MacOSX/PlatformAppleTVSimulator.cpp
+@@ -282,7 +282,7 @@
+ Status PlatformAppleTVSimulator::GetSharedModule(
+     const ModuleSpec &module_spec, lldb_private::Process *process,
+     ModuleSP &module_sp, const FileSpecList *module_search_paths_ptr,
+-    ModuleSP *old_module_sp_ptr, bool *did_create_ptr) {
++    llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules, bool *did_create_ptr) {
+   // For AppleTV, the SDK files are all cached locally on the host system. So
+   // first we ask for the file in the cached SDK, then we attempt to get a
+   // shared module for the right architecture with the right UUID.
+@@ -296,9 +296,9 @@
+                               module_search_paths_ptr);
+   } else {
+     const bool always_create = false;
+-    error = ModuleList::GetSharedModule(
+-        module_spec, module_sp, module_search_paths_ptr, old_module_sp_ptr,
+-        did_create_ptr, always_create);
++    error = ModuleList::GetSharedModule(module_spec, module_sp,
++                                        module_search_paths_ptr, old_modules,
++                                        did_create_ptr, always_create);
+   }
+   if (module_sp)
+     module_sp->SetPlatformFileSpec(platform_file);
+diff --git a/lldb/source/Plugins/Platform/MacOSX/PlatformAppleWatchSimulator.h b/lldb/source/Plugins/Platform/MacOSX/PlatformAppleWatchSimulator.h
+--- a/lldb/source/Plugins/Platform/MacOSX/PlatformAppleWatchSimulator.h
++++ b/lldb/source/Plugins/Platform/MacOSX/PlatformAppleWatchSimulator.h
+@@ -55,7 +55,7 @@
+   GetSharedModule(const lldb_private::ModuleSpec &module_spec,
+                   lldb_private::Process *process, lldb::ModuleSP &module_sp,
+                   const lldb_private::FileSpecList *module_search_paths_ptr,
+-                  lldb::ModuleSP *old_module_sp_ptr,
++                  llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules,
+                   bool *did_create_ptr) override;
+ 
+   uint32_t
+diff --git a/lldb/source/Plugins/Platform/MacOSX/PlatformAppleWatchSimulator.cpp b/lldb/source/Plugins/Platform/MacOSX/PlatformAppleWatchSimulator.cpp
+--- a/lldb/source/Plugins/Platform/MacOSX/PlatformAppleWatchSimulator.cpp
++++ b/lldb/source/Plugins/Platform/MacOSX/PlatformAppleWatchSimulator.cpp
+@@ -283,7 +283,7 @@
+ Status PlatformAppleWatchSimulator::GetSharedModule(
+     const ModuleSpec &module_spec, lldb_private::Process *process,
+     ModuleSP &module_sp, const FileSpecList *module_search_paths_ptr,
+-    ModuleSP *old_module_sp_ptr, bool *did_create_ptr) {
++    llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules, bool *did_create_ptr) {
+   // For AppleWatch, the SDK files are all cached locally on the host system.
+   // So first we ask for the file in the cached SDK, then we attempt to get a
+   // shared module for the right architecture with the right UUID.
+@@ -297,9 +297,9 @@
+                               module_search_paths_ptr);
+   } else {
+     const bool always_create = false;
+-    error = ModuleList::GetSharedModule(
+-        module_spec, module_sp, module_search_paths_ptr, old_module_sp_ptr,
+-        did_create_ptr, always_create);
++    error = ModuleList::GetSharedModule(module_spec, module_sp,
++                                        module_search_paths_ptr, old_modules,
++                                        did_create_ptr, always_create);
+   }
+   if (module_sp)
+     module_sp->SetPlatformFileSpec(platform_file);
+diff --git a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinKernel.cpp b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinKernel.cpp
+--- a/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinKernel.cpp
++++ b/lldb/source/Plugins/Platform/MacOSX/PlatformDarwinKernel.cpp
+@@ -730,7 +730,7 @@
+     // framework on macOS systems, a chance.
+     error = PlatformDarwin::GetSharedModule(module_spec, process, module_sp,
+                                             module_search_paths_ptr,
+-                                            old_module_sp_ptr, did_create_ptr);
++                                            old_modules, did_create_ptr);
+     if (error.Success() && module_sp.get()) {
+       return error;
+     }
+diff --git a/lldb/source/Plugins/Platform/MacOSX/PlatformiOSSimulator.h b/lldb/source/Plugins/Platform/MacOSX/PlatformiOSSimulator.h
+--- a/lldb/source/Plugins/Platform/MacOSX/PlatformiOSSimulator.h
++++ b/lldb/source/Plugins/Platform/MacOSX/PlatformiOSSimulator.h
+@@ -57,7 +57,7 @@
+   GetSharedModule(const lldb_private::ModuleSpec &module_spec,
+                   lldb_private::Process *process, lldb::ModuleSP &module_sp,
+                   const lldb_private::FileSpecList *module_search_paths_ptr,
+-                  lldb::ModuleSP *old_module_sp_ptr,
++                  llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules,
+                   bool *did_create_ptr) override;
+ 
+   uint32_t
+diff --git a/lldb/source/Plugins/Platform/MacOSX/PlatformiOSSimulator.cpp b/lldb/source/Plugins/Platform/MacOSX/PlatformiOSSimulator.cpp
+--- a/lldb/source/Plugins/Platform/MacOSX/PlatformiOSSimulator.cpp
++++ b/lldb/source/Plugins/Platform/MacOSX/PlatformiOSSimulator.cpp
+@@ -286,8 +286,8 @@
+ 
+ Status PlatformiOSSimulator::GetSharedModule(
+     const ModuleSpec &module_spec, Process *process, ModuleSP &module_sp,
+-    const FileSpecList *module_search_paths_ptr, ModuleSP *old_module_sp_ptr,
+-    bool *did_create_ptr) {
++    const FileSpecList *module_search_paths_ptr,
++    llvm::SmallVectorImpl<lldb::ModuleSP> *old_modules, bool *did_create_ptr) {
+   // For iOS, the SDK files are all cached locally on the host system. So first
+   // we ask for the file in the cached SDK, then we attempt to get a shared
+   // module for the right architecture with the right UUID.
+@@ -301,9 +301,9 @@
+                               module_search_paths_ptr);
+   } else {
+     const bool always_create = false;
+-    error = ModuleList::GetSharedModule(
+-        module_spec, module_sp, module_search_paths_ptr, old_module_sp_ptr,
+-        did_create_ptr, always_create);
++    error = ModuleList::GetSharedModule(module_spec, module_sp,
++                                        module_search_paths_ptr, old_modules,
++                                        did_create_ptr, always_create);
+   }
+   if (module_sp)
+     module_sp->SetPlatformFileSpec(platform_file);
+


### PR DESCRIPTION
Patch taken from https://reviews.llvm.org/D95683, but the diff URL on
Phabricator is not stable.

See also https://github.com/Homebrew/homebrew-core/pull/70091.