### PR TITLE
pssh: add patch for python3

### DIFF
--- a/pssh/python3.patch
+++ b/pssh/python3.patch
@@ -1,0 +1,157 @@
+From 6de2210d45aefd764407d1c6e8283118f4a123ed Mon Sep 17 00:00:00 2001
+From: Alexander Bayandin <a.bayandin@gmail.com>
+Date: Tue, 11 May 2021 17:31:38 +0100
+Subject: [PATCH 1/1] Fixes for python3
+
+Combined from https://aur.archlinux.org/packages/python-pssh/
+
+- https://bugs.archlinux.org/task/28626
+- https://bugs.archlinux.org/task/41255
+- https://bugs.archlinux.org/task/46571
+- https://bugs.archlinux.org/task/51533
+- fix to allow relative paths
+---
+ bin/prsync                | 4 ----
+ bin/pscp                  | 6 +-----
+ bin/pslurp                | 5 +----
+ bin/pssh                  | 5 ++++-
+ psshlib/askpass_server.py | 2 +-
+ psshlib/cli.py            | 3 ++-
+ psshlib/manager.py        | 2 ++
+ 7 files changed, 11 insertions(+), 16 deletions(-)
+
+diff --git a/bin/prsync b/bin/prsync
+index 84130af..354e225 100755
+--- a/bin/prsync
++++ b/bin/prsync
+@@ -7,7 +7,6 @@
+ """Parallel rsync to the set of nodes in hosts.txt.
+ 
+ For each node, we essentially do a rsync -rv -e ssh local user@host:remote.
+-Note that remote must be an absolute path.
+ """
+ 
+ import os
+@@ -110,9 +109,6 @@ if __name__ == "__main__":
+     opts, args = parse_args()
+     local = args[0]
+     remote = args[1]
+-    if not re.match("^/", remote):
+-        print("Remote path %s must be an absolute path" % remote)
+-        sys.exit(3)
+     try:
+         hosts = psshutil.read_host_files(opts.host_files,
+             default_user=opts.user)
+diff --git a/bin/pscp b/bin/pscp
+index 5b89b70..75bf449 100755
+--- a/bin/pscp
++++ b/bin/pscp
+@@ -7,8 +7,7 @@
+ """Parallel scp to the set of nodes in hosts.txt.
+ 
+ For each node, we essentially do a scp [-r] local user@host:remote.  This
+-program also uses the -q (quiet) and -C (compression) options.  Note that
+-remote must be an absolute path.
++program also uses the -q (quiet) and -C (compression) options.
+ """
+ 
+ import os
+@@ -92,9 +91,6 @@ if __name__ == "__main__":
+     opts, args = parse_args()
+     localargs = args[0:-1]
+     remote = args[-1]
+-    if not re.match("^/", remote):
+-        print("Remote path %s must be an absolute path" % remote)
+-        sys.exit(3)
+     try:
+         hosts = psshutil.read_host_files(opts.host_files,
+             default_user=opts.user)
+diff --git a/bin/pslurp b/bin/pslurp
+index c7dece6..8a73124 100755
+--- a/bin/pslurp
++++ b/bin/pslurp
+@@ -8,7 +8,7 @@
+ 
+ For each node, we essentially do a scp [-r] user@host:remote
+ outdir/<node>/local.  This program also uses the -q (quiet) and -C
+-(compression) options.  Note that remote must be an absolute path.
++(compression) options.
+ """
+ 
+ import os
+@@ -113,9 +113,6 @@ if __name__ == "__main__":
+     opts, args = parse_args()
+     remote = args[0]
+     local = args[1]
+-    if not re.match("^/", remote):
+-        print("Remote path %s must be an absolute path" % remote)
+-        sys.exit(3)
+     try:
+         hosts = psshutil.read_host_files(opts.host_files,
+             default_user=opts.user)
+diff --git a/bin/pssh b/bin/pssh
+index 5b6c2a5..4648c10 100755
+--- a/bin/pssh
++++ b/bin/pssh
+@@ -65,7 +65,10 @@ def do_pssh(hosts, cmdline, opts):
+     if opts.errdir and not os.path.exists(opts.errdir):
+         os.makedirs(opts.errdir)
+     if opts.send_input:
+-        stdin = sys.stdin.read()
++        if hasattr(sys.stdin, 'buffer'):
++            stdin = sys.stdin.buffer.read()
++        else:
++            stdin = sys.stdin.read()
+     else:
+         stdin = None
+     manager = Manager(opts)
+diff --git a/psshlib/askpass_server.py b/psshlib/askpass_server.py
+index 4293164..3a2b0e5 100644
+--- a/psshlib/askpass_server.py
++++ b/psshlib/askpass_server.py
+@@ -69,7 +69,7 @@ class PasswordServer(object):
+         buffer = self.buffermap[fd]
+         conn = self.socketmap[fd]
+         try:
+-            bytes_written = conn.send(buffer)
++            bytes_written = conn.send(buffer.encode())
+         except socket.error:
+             _, e, _ = sys.exc_info()
+             number = e.args[0]
+diff --git a/psshlib/cli.py b/psshlib/cli.py
+index c14b309..c342cde 100644
+--- a/psshlib/cli.py
++++ b/psshlib/cli.py
+@@ -6,7 +6,8 @@ import os
+ import shlex
+ import sys
+ import textwrap
+-import version
++
++from psshlib import version
+ 
+ _DEFAULT_PARALLELISM = 32
+ _DEFAULT_TIMEOUT     = 0 # "infinity" by default
+diff --git a/psshlib/manager.py b/psshlib/manager.py
+index 9b5686d..5d61d88 100644
+--- a/psshlib/manager.py
++++ b/psshlib/manager.py
+@@ -2,6 +2,7 @@
+ 
+ from errno import EINTR
+ import os
++import fcntl
+ import select
+ import signal
+ import sys
+@@ -209,6 +210,7 @@ class IOMap(object):
+ 
+         # Setup the wakeup file descriptor to avoid hanging on lost signals.
+         wakeup_readfd, wakeup_writefd = os.pipe()
++        fcntl.fcntl(wakeup_writefd, fcntl.F_SETFL, os.O_NONBLOCK)
+         self.register_read(wakeup_readfd, self.wakeup_handler)
+         # TODO: remove test when we stop supporting Python <2.5
+         if hasattr(signal, 'set_wakeup_fd'):
+-- 
+2.31.1
+


### PR DESCRIPTION
Combined from https://aur.archlinux.org/packages/python-pssh/

- https://bugs.archlinux.org/task/28626
- https://bugs.archlinux.org/task/41255
- https://bugs.archlinux.org/task/46571
- https://bugs.archlinux.org/task/51533
- fix to allow relative paths