### PR TITLE
llvm@9: patch clang driver for Big Sur

### DIFF
--- a/llvm@9/llvm@9.patch
+++ b/llvm@9/llvm@9.patch
@@ -1,0 +1,58 @@
+--- a/tools/clang/lib/Driver/ToolChains/Darwin.cpp
++++ b/tools/clang/lib/Driver/ToolChains/Darwin.cpp
+@@ -1964,21 +1964,42 @@
+
+   switch (Type) {
+   case ToolChain::CST_Libcxx: {
+-    // On Darwin, libc++ is installed alongside the compiler in
+-    // include/c++/v1, so get from '<install>/bin' to '<install>/include/c++/v1'.
+-    {
+-      llvm::SmallString<128> P = llvm::StringRef(getDriver().getInstalledDir());
+-      // Note that P can be relative, so we have to '..' and not parent_path.
+-      llvm::sys::path::append(P, "..", "include", "c++", "v1");
+-      addSystemInclude(DriverArgs, CC1Args, P);
+-    }
+-    // Also add <sysroot>/usr/include/c++/v1 unless -nostdinc is used,
+-    // to match the legacy behavior in CC1.
+-    if (!DriverArgs.hasArg(options::OPT_nostdinc)) {
+-      llvm::SmallString<128> P = Sysroot;
+-      llvm::sys::path::append(P, "usr", "include", "c++", "v1");
+-      addSystemInclude(DriverArgs, CC1Args, P);
++    // On Darwin, libc++ can be installed in one of the following two places:
++    // 1. Alongside the compiler in         <install>/include/c++/v1
++    // 2. In a SDK (or a custom sysroot) in <sysroot>/usr/include/c++/v1
++    //
++    // The precendence of paths is as listed above, i.e. we take the first path
++    // that exists. Also note that we never include libc++ twice -- we take the
++    // first path that exists and don't send the other paths to CC1 (otherwise
++    // include_next could break).
++
++    // Check for (1)
++    // Get from '<install>/bin' to '<install>/include/c++/v1'.
++    // Note that InstallBin can be relative, so we use '..' instead of
++    // parent_path.
++    llvm::SmallString<128> InstallBin =
++        llvm::StringRef(getDriver().getInstalledDir()); // <install>/bin
++    llvm::sys::path::append(InstallBin, "..", "include", "c++", "v1");
++    if (getVFS().exists(InstallBin)) {
++      addSystemInclude(DriverArgs, CC1Args, InstallBin);
++      return;
++    } else if (DriverArgs.hasArg(options::OPT_v)) {
++      llvm::errs() << "ignoring nonexistent directory \"" << InstallBin
++                   << "\"\n";
+     }
++
++    // Otherwise, check for (2)
++    llvm::SmallString<128> SysrootUsr = Sysroot;
++    llvm::sys::path::append(SysrootUsr, "usr", "include", "c++", "v1");
++    if (getVFS().exists(SysrootUsr)) {
++      addSystemInclude(DriverArgs, CC1Args, SysrootUsr);
++      return;
++    } else if (DriverArgs.hasArg(options::OPT_v)) {
++      llvm::errs() << "ignoring nonexistent directory \"" << SysrootUsr
++                   << "\"\n";
++    }
++
++    // Otherwise, don't add any path.
+     break;
+   }


### PR DESCRIPTION
This patch was backported from https://github.com/llvm/llvm-project/commit/a3a24316087d0e1b4db0b8fee19cdee8b7968032 to LLVM 9 by MacPorts: https://github.com/macports/macports-ports/blob/master/lang/llvm-9.0/files/patch-clang-fix-include-next-sysroot-cpp-headers.diff.