### PR TITLE
nutcracker: add patch to use Homebrew `libyaml`

### DIFF
--- a/nutcracker/use-system-libyaml.patch
+++ b/nutcracker/use-system-libyaml.patch
@@ -1,0 +1,84 @@
+From c82c8d540545c8f0f6535e2e2d8bb661936c2034 Mon Sep 17 00:00:00 2001
+From: Carlo Cabrera <30379873+carlocab@users.noreply.github.com>
+Date: Wed, 21 Jul 2021 17:32:00 +0800
+Subject: [PATCH] Use system libyaml
+
+Adapted from Debian's patch at
+
+    https://sources.debian.org/patches/nutcracker/0.4.1+dfsg-1/use_system_libyaml/
+---
+ Makefile.am     | 2 +-
+ configure.ac    | 7 -------
+ src/Makefile.am | 5 +----
+ 3 files changed, 2 insertions(+), 12 deletions(-)
+
+diff --git a/Makefile.am b/Makefile.am
+index 5869974..237405e 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -2,7 +2,7 @@ MAINTAINERCLEANFILES = Makefile.in aclocal.m4 configure config.h.in config.h.in~
+ 
+ ACLOCAL_AMFLAGS = -I m4
+ 
+-SUBDIRS = contrib src
++SUBDIRS = src
+ 
+ dist_man_MANS = man/nutcracker.8
+ 
+diff --git a/configure.ac b/configure.ac
+index 0f96dba..8634435 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -197,15 +197,8 @@ AS_IF([test "x$disable_stats" = xyes],
+   [AC_DEFINE([HAVE_STATS], [1], [Define to 1 if stats is not disabled])])
+ AC_MSG_RESULT($disable_stats)
+ 
+-# Untar the yaml-0.2.5 in contrib/ before config.status is rerun
+-AC_CONFIG_COMMANDS_PRE([tar xvfz contrib/yaml-0.2.5.tar.gz -C contrib])
+-
+-# Call yaml-0.2.5 ./configure recursively
+-AC_CONFIG_SUBDIRS([contrib/yaml-0.2.5])
+-
+ # Define Makefiles
+ AC_CONFIG_FILES([Makefile
+-                 contrib/Makefile
+                  src/Makefile
+                  src/hashkit/Makefile
+                  src/proto/Makefile
+diff --git a/src/Makefile.am b/src/Makefile.am
+index dd07a25..e32be10 100644
+--- a/src/Makefile.am
++++ b/src/Makefile.am
+@@ -7,7 +7,6 @@ endif
+ AM_CPPFLAGS += -I $(top_srcdir)/src/hashkit
+ AM_CPPFLAGS += -I $(top_srcdir)/src/proto
+ AM_CPPFLAGS += -I $(top_srcdir)/src/event
+-AM_CPPFLAGS += -I $(top_srcdir)/contrib/yaml-0.2.5/include
+ 
+ AM_CFLAGS =
+ # about -fno-strict-aliasing: https://github.com/twitter/twemproxy/issues/276
+@@ -22,7 +21,7 @@ AM_CFLAGS += -Wstrict-prototypes -Wmissing-prototypes -Wredundant-decls -Wmissin
+ AM_CFLAGS += -Wno-format-zero-length
+ 
+ AM_LDFLAGS =
+-AM_LDFLAGS += -lm -lpthread -rdynamic
++AM_LDFLAGS += -lm -lpthread -lyaml -rdynamic
+ if OS_SOLARIS
+ AM_LDFLAGS += -lnsl -lsocket
+ endif
+@@ -58,7 +57,6 @@ nutcracker_SOURCES =			\
+ nutcracker_LDADD = $(top_builddir)/src/hashkit/libhashkit.a
+ nutcracker_LDADD += $(top_builddir)/src/proto/libproto.a
+ nutcracker_LDADD += $(top_builddir)/src/event/libevent.a
+-nutcracker_LDADD += $(top_builddir)/contrib/yaml-0.2.5/src/.libs/libyaml.a
+ 
+ TESTS = test_all
+ bin_PROGRAMS = test_all
+@@ -86,4 +84,3 @@ test_all_SOURCES = test_all.c \
+ test_all_LDADD = $(top_builddir)/src/hashkit/libhashkit.a
+ test_all_LDADD += $(top_builddir)/src/proto/libproto.a
+ test_all_LDADD += $(top_builddir)/src/event/libevent.a
+-test_all_LDADD += $(top_builddir)/contrib/yaml-0.2.5/src/.libs/libyaml.a
+-- 
+2.32.0
+


### PR DESCRIPTION
This should help resolve a CI failure seen in
Homebrew/homebrew-core#78294.

While we're here, I should mention that it looks like `nutcracker`
vendors a bunch of other things, which might be why all the other
distros are still on an older version at the moment.

That isn't causing us problems at the moment, however, so let's focus on
fixing the things that are.