### PR TITLE
libgsm: add patches for building shared library

### DIFF
--- a/libgsm/libgsm_shared_linux.patch
+++ b/libgsm/libgsm_shared_linux.patch
@@ -1,0 +1,68 @@
+--- a/Makefile
++++ b/Makefile
+@@ -96,7 +96,7 @@ TOAST_INSTALL_MAN = $(TOAST_INSTALL_ROOT
+ #  Other tools
+ 
+ SHELL		= /bin/sh
+-LN		= ln
++LN		= ln -s
+ BASENAME 	= basename
+ AR		= ar
+ ARFLAGS		= cr
+@@ -140,6 +140,7 @@ LFLAGS	= $(LDFLAGS) $(LDINC)
+ # Targets
+ 
+ LIBGSM	= $(LIB)/libgsm.a
++LIBGSMSO= $(LIB)/libgsm.so
+ 
+ TOAST	= $(BIN)/toast
+ UNTOAST	= $(BIN)/untoast
+@@ -279,7 +280,7 @@ TOAST_INSTALL_TARGETS =	\
+ 
+ # Target rules
+ 
+-all:		$(LIBGSM) $(TOAST) $(TCAT) $(UNTOAST)
++all:		$(LIBGSM) $(LIBGSMSO) $(TOAST) $(TCAT) $(UNTOAST)
+ 		@-echo $(ROOT): Done.
+ 
+ tst:		$(TST)/lin2cod $(TST)/cod2lin $(TOAST) $(TST)/test-result
+@@ -299,6 +300,11 @@ install:	toastinstall gsminstall
+ 
+ # The basic API: libgsm
+ 
++$(LIBGSMSO):	$(LIB) $(GSM_OBJECTS)
++		$(LD) $(LDFLAGS) -o $@.@@SOVERSION@@ -shared -Xlinker -soname -Xlinker libgsm.so.1 $(GSM_OBJECTS) -lc
++		ln -fs libgsm.so.@@SOVERSION@@ lib/libgsm.so.1
++		ln -fs libgsm.so.@@SOVERSION@@ lib/libgsm.so
++
+ $(LIBGSM):	$(LIB) $(GSM_OBJECTS)
+ 		-rm $(RMFLAGS) $(LIBGSM)
+ 		$(AR) $(ARFLAGS) $(LIBGSM) $(GSM_OBJECTS)
+@@ -308,15 +314,15 @@ $(LIBGSM):	$(LIB) $(GSM_OBJECTS)
+ # Toast, Untoast and Tcat -- the compress-like frontends to gsm.
+ 
+ $(TOAST):	$(BIN) $(TOAST_OBJECTS) $(LIBGSM)
+-		$(LD) $(LFLAGS) -o $(TOAST) $(TOAST_OBJECTS) $(LIBGSM) $(LDLIB)
++		$(LD) $(LFLAGS) -o $(TOAST) $(TOAST_OBJECTS) $(LIBGSMSO) $(LDLIB)
+ 
+ $(UNTOAST):	$(BIN) $(TOAST)
+ 		-rm $(RMFLAGS) $(UNTOAST)
+-		$(LN) $(TOAST) $(UNTOAST)
++		$(LN) toast $(UNTOAST)
+ 
+ $(TCAT):	$(BIN) $(TOAST)
+ 		-rm $(RMFLAGS) $(TCAT)
+-		$(LN) $(TOAST) $(TCAT)
++		$(LN) toast $(TCAT)
+ 
+ 
+ # The local bin and lib directories
+@@ -426,7 +432,9 @@ semi-clean:
+ 
+ clean:	semi-clean
+ 		-rm $(RMFLAGS) $(LIBGSM) $(ADDTST)/add		\
+-			$(TOAST) $(TCAT) $(UNTOAST)	\
++			$(LIBGSMSO) $(LIB)/libgsm.so.@@SOVERSION@@	\
++			$(LIB)libgsm.so.1			\
++			$(TOAST) $(TCAT) $(UNTOAST)		\
+ 			$(ROOT)/gsm-1.0.tar.Z

--- a/libgsm/libgsm_shared_mac.patch
+++ b/libgsm/libgsm_shared_mac.patch
@@ -1,0 +1,68 @@
+--- Makefile
++++ Makefile
+@@ -96,7 +96,7 @@
+ #  Other tools
+
+ SHELL		= /bin/sh
+-LN		= ln
++LN		= ln -s
+ BASENAME 	= basename
+ AR		= ar
+ ARFLAGS		= cr
+@@ -140,6 +140,7 @@
+ # Targets
+
+ LIBGSM	= $(LIB)/libgsm.a
++LIBGSMSO= $(LIB)/libgsm.@@SOVERSION@@.dylib
+
+ TOAST	= $(BIN)/toast
+ UNTOAST	= $(BIN)/untoast
+@@ -279,7 +280,7 @@
+
+ # Target rules
+
+-all:		$(LIBGSM) $(TOAST) $(TCAT) $(UNTOAST)
++all:		$(LIBGSM) $(LIBGSMSO) $(TOAST) $(TCAT) $(UNTOAST)
+ 		@-echo $(ROOT): Done.
+
+ tst:		$(TST)/lin2cod $(TST)/cod2lin $(TOAST) $(TST)/test-result
+@@ -299,6 +300,11 @@
+
+ # The basic API: libgsm
+
++$(LIBGSMSO):	$(LIB) $(GSM_OBJECTS)
++		$(LD) -o $(LIBGSMSO) -dynamiclib -Wl,-compatibility_version,1,-current_version,@@SOVERSION@@,-install_name,$(LIBGSMSO) $(GSM_OBJECTS) -lc
++		ln -fs libgsm.@@SOVERSION@@.dylib lib/libgsm.1.dylib
++		ln -fs libgsm.@@SOVERSION@@.dylib lib/libgsm.dylib
++
+ $(LIBGSM):	$(LIB) $(GSM_OBJECTS)
+ 		-rm $(RMFLAGS) $(LIBGSM)
+ 		$(AR) $(ARFLAGS) $(LIBGSM) $(GSM_OBJECTS)
+@@ -308,15 +314,15 @@
+ # Toast, Untoast and Tcat -- the compress-like frontends to gsm.
+
+ $(TOAST):	$(BIN) $(TOAST_OBJECTS) $(LIBGSM)
+-		$(LD) $(LFLAGS) -o $(TOAST) $(TOAST_OBJECTS) $(LIBGSM) $(LDLIB)
++		$(LD) $(LFLAGS) -o $(TOAST) $(TOAST_OBJECTS) $(LIBGSMSO) $(LDLIB)
+
+ $(UNTOAST):	$(BIN) $(TOAST)
+ 		-rm $(RMFLAGS) $(UNTOAST)
+-		$(LN) $(TOAST) $(UNTOAST)
++		$(LN) toast $(UNTOAST)
+
+ $(TCAT):	$(BIN) $(TOAST)
+ 		-rm $(RMFLAGS) $(TCAT)
+-		$(LN) $(TOAST) $(TCAT)
++		$(LN) toast $(TCAT)
+
+
+ # The local bin and lib directories
+@@ -426,7 +432,9 @@
+
+ clean:	semi-clean
+ 		-rm $(RMFLAGS) $(LIBGSM) $(ADDTST)/add		\
+-			$(TOAST) $(TCAT) $(UNTOAST)	\
++			$(LIBGSMSO) $(LIB)/libgsm.1.dylib	\
++			$(LIB)/libgsm.dylib			\
++			$(TOAST) $(TCAT) $(UNTOAST)		\
+ 			$(ROOT)/gsm-1.0.tar.Z


### PR DESCRIPTION
These patches were originally hosted in other git repos.  They hardcode the library version, which now out of date.  In these versions, the placeholder SOVERSION is used instead, which will be replaced the current version in the formula with `inreplace`.