### PR TITLE
Add pygit2 patch

### DIFF
--- a/pygit2/libgit2-1.2.0.patch
+++ b/pygit2/libgit2-1.2.0.patch
@@ -1,0 +1,100 @@
+From dcde9eff5950492ab0d2565a07fd18d765332a96 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?J=2E=20David=20Ib=C3=A1=C3=B1ez?= <jdavid.ibp@gmail.com>
+Date: Thu, 16 Sep 2021 11:19:04 +0200
+Subject: [PATCH] Upgrade to libgit2 1.2
+
+Closes #1089
+---
+ Makefile                         |  2 +-
+ build.sh                         | 14 +++++++-------
+ pygit2/decl/remote.h             |  2 ++
+ src/types.h                      |  4 ++--
+ 10 files changed, 29 insertions(+), 25 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index aa463bb1654f8049f0d5ca6142d5442a2695b34e..05115cdb984eee1b011ff0b092ce850f154d0379 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1,7 +1,7 @@
+ .PHONY: build html
+
+ build:
+-	LIBSSH2_VERSION=1.9.0 LIBGIT2_VERSION=1.1.0 sh build.sh
++	LIBSSH2_VERSION=1.9.0 LIBGIT2_VERSION=1.2.0 sh build.sh
+
+ html:
+ 	cd docs && find . -name "*rst" | entr make html
+diff --git a/build.sh b/build.sh
+index a24fa02fa10d377352f4a859e03510f7ba493bcc..18320996600bad04bca1931e2027f6bb5716e1c2 100644
+--- a/build.sh
++++ b/build.sh
+@@ -23,19 +23,19 @@
+ #
+ #   sh build.sh
+ #
+-# Build libgit2 1.1.0 (will use libssh2 if available), then build pygit2
++# Build libgit2 1.2.0 (will use libssh2 if available), then build pygit2
+ # inplace:
+ #
+-#   LIBGIT2_VERSION=1.1.0 sh build.sh
++#   LIBGIT2_VERSION=1.2.0 sh build.sh
+ #
+-# Build libssh2 1.9.0 and libgit2 1.1.0, then build pygit2 inplace:
++# Build libssh2 1.9.0 and libgit2 1.2.0, then build pygit2 inplace:
+ #
+-#   LIBSSH2_VERSION=1.9.0 LIBGIT2_VERSION=1.1.0 sh build.sh
++#   LIBSSH2_VERSION=1.9.0 LIBGIT2_VERSION=1.2.0 sh build.sh
+ #
+-# Tell where libssh2 is installed, build libgit2 1.1.0, then build pygit2
++# Tell where libssh2 is installed, build libgit2 1.2.0, then build pygit2
+ # inplace:
+ #
+-#   LIBSSH2_PREFIX=/usr/local LIBGIT2_VERSION=1.1.0 sh build.sh
++#   LIBSSH2_PREFIX=/usr/local LIBGIT2_VERSION=1.2.0 sh build.sh
+ #
+ # Build inplace and run the tests:
+ #
+@@ -95,7 +95,7 @@ fi
+ # Install libgit2
+ if [ -n "$LIBGIT2_VERSION" ]; then
+     FILENAME=libgit2-$LIBGIT2_VERSION
+-    wget https://github.com/libgit2/libgit2/releases/download/v$LIBGIT2_VERSION/$FILENAME.tar.gz -N
++    wget https://github.com/libgit2/libgit2/archive/refs/tags/v$LIBGIT2_VERSION.tar.gz -N -O $FILENAME.tar.gz
+     tar xf $FILENAME.tar.gz
+     cd $FILENAME
+     CMAKE_PREFIX_PATH=$OPENSSL_PREFIX:$LIBSSH2_PREFIX cmake . \
+diff --git a/pygit2/decl/remote.h b/pygit2/decl/remote.h
+index ff84371c3e1ce81a7e9914d4d4592638f41376bb..4e912c065cd6eaf19ef6d0304b0fd8f646edbff4 100644
+--- a/pygit2/decl/remote.h
++++ b/pygit2/decl/remote.h
+@@ -23,6 +23,7 @@ typedef struct {
+
+ typedef int (*git_push_negotiation)(const git_push_update **updates, size_t len, void *payload);
+ typedef int (*git_push_update_reference_cb)(const char *refname, const char *status, void *data);
++typedef int (*git_remote_ready_cb)(git_remote *remote, int direction, void *payload);
+ typedef int (*git_url_resolve_cb)(git_buf *url_resolved, const char *url, int direction, void *payload);
+
+ struct git_remote_callbacks {
+@@ -38,6 +39,7 @@ struct git_remote_callbacks {
+ 	git_push_update_reference_cb push_update_reference;
+ 	git_push_negotiation push_negotiation;
+ 	git_transport_cb transport;
++	git_remote_ready_cb remote_ready;
+ 	void *payload;
+ 	git_url_resolve_cb resolve_url;
+ };
+diff --git a/src/types.h b/src/types.h
+index ff967b81f76688f8f0958638d99a06f7bbacb99c..89ad3a00149a1326c3edfa20d2d69d629cb1d2a2 100644
+--- a/src/types.h
++++ b/src/types.h
+@@ -32,8 +32,8 @@
+ #include <Python.h>
+ #include <git2.h>
+
+-#if !(LIBGIT2_VER_MAJOR == 1 && LIBGIT2_VER_MINOR == 1)
+-#error You need a compatible libgit2 version (1.1.x)
++#if !(LIBGIT2_VER_MAJOR == 1 && LIBGIT2_VER_MINOR == 2)
++#error You need a compatible libgit2 version (1.2.x)
+ #endif
+
+ /*


### PR DESCRIPTION
This allows the `pygit2` resource used in various formulae to build with
libgit2 1.2.0. This amends libgit2/pygit2@dcde9eff5950492ab0d2565a07fd18d765332a96
so that it applies to the PyPI tarball.

Supports Homebrew/hombrew-core#84518.