### PR TITLE
jhead: update patch for 3.06.0.1

### DIFF
--- a/jhead/3.06.0.1.patch
+++ b/jhead/3.06.0.1.patch
@@ -1,0 +1,34 @@
+--- a/makefile	2021-04-14 12:02:45.000000000 +0000
++++ b/makefile	2021-09-21 19:51:21.000000000 +0000
+@@ -1,13 +1,17 @@
+ #--------------------------------
+ # jhead makefile for Unix
+ #--------------------------------
++PREFIX=$(DESTDIR)/usr/local
++BINDIR=$(PREFIX)/bin
++DOCDIR=$(PREFIX)/share/doc/jhead
++MANDIR=$(PREFIX)/share/man/man1
+ OBJ=obj
+ SRC=.
+-CFLAGS:=$(shell dpkg-buildflags --get CFLAGS)
+-LDFLAGS:=$(shell dpkg-buildflags --get LDFLAGS)
+
+ all: objdir jhead
+
++docs = $(SRC)/usage.html
++
+ objdir:
+ 	@mkdir -p obj
+
+@@ -23,6 +27,8 @@
+ clean:
+ 	rm -f $(objs) jhead
+
+-install:
+-	mkdir -p ${DESTDIR}/usr/bin/
+-	cp jhead ${DESTDIR}/usr/bin/
++install: all
++	install -d $(BINDIR) $(DOCDIR) $(MANDIR)
++	install -m 0755 jhead $(BINDIR)
++	install -m 0644 $(docs) $(DOCDIR)
++	install -m 0644 jhead.1 $(MANDIR)


### PR DESCRIPTION
This updates the existing `jhead` patch for 3.06.0.1 (`makefile` has changes that break the existing patch).