### PR TITLE
bdw-gc: add multithreading patch

### DIFF
--- a/bdw-gc/crystal-mt.patch
+++ b/bdw-gc/crystal-mt.patch
@@ -1,0 +1,208 @@
+From 06762091efa6c05f27bd91af227afbc5b5334de9 Mon Sep 17 00:00:00 2001
+From: Carlo Cabrera <30379873+carlocab@users.noreply.github.com>
+Date: Wed, 29 Sep 2021 16:24:25 +0800
+Subject: [PATCH] Backport multithreading patch to 8.0.6
+
+This is a backport of ivmai/bdwgc@5668de71107022a316ee967162bc16c10754b9ce
+so that it applies to the v8.0.6 tag.
+
+The commit is applied with no changes, except for the changes to
+`win32_threads.c`. The changes to this file are not relevant for our
+purposes, and the original commit no longer applies.
+
+This patch can be removed in v8.2.0.
+---
+ include/gc.h      | 24 ++++++++++++++++++++
+ misc.c            | 24 ++++++++++++++++++++
+ pthread_support.c | 56 +++++++++++++++++++++++++++++++++++++++++++++++
+ tests/test.c      | 16 ++++++++++++++
+ 4 files changed, 120 insertions(+)
+
+diff --git a/include/gc.h b/include/gc.h
+index 2de5792..70e7fe7 100644
+--- a/include/gc.h
++++ b/include/gc.h
+@@ -1566,6 +1566,30 @@ GC_API void * GC_CALL GC_call_with_gc_active(GC_fn_type /* fn */,
+ GC_API int GC_CALL GC_get_stack_base(struct GC_stack_base *)
+                                                         GC_ATTR_NONNULL(1);
+ 
++/* Fill in the GC_stack_base structure with the cold end (bottom) of    */
++/* the stack of the current thread (or coroutine).                      */
++/* Unlike GC_get_stack_base, it retrieves the value stored in the       */
++/* collector (which is initially set by the collector upon the thread   */
++/* is started or registered manually but it could be later updated by   */
++/* client using GC_set_stackbottom).  Returns the GC-internal non-NULL  */
++/* handle of the thread which could be passed to GC_set_stackbottom     */
++/* later.  It is assumed that the collector is already initialized and  */
++/* the thread is registered.  Acquires the GC lock to avoid data races. */
++GC_API void * GC_CALL GC_get_my_stackbottom(struct GC_stack_base *)
++                                                        GC_ATTR_NONNULL(1);
++
++/* Set the cool end of the user (coroutine) stack of the specified      */
++/* thread.  The GC thread handle is either the one returned by          */
++/* GC_get_my_stackbottom or NULL (the latter designates the current     */
++/* thread).  The caller should hold the GC lock (e.g. using             */
++/* GC_call_with_alloc_lock).  Also, the function could be used for      */
++/* setting GC_stackbottom value (the bottom of the primordial thread)   */
++/* before the collector is initialized (the GC lock is not needed to be */
++/* acquired in this case).                                              */
++GC_API void GC_CALL GC_set_stackbottom(void * /* gc_thread_handle */,
++                                       const struct GC_stack_base *)
++                                                        GC_ATTR_NONNULL(2);
++
+ /* The following routines are primarily intended for use with a         */
+ /* preprocessor which inserts calls to check C pointer arithmetic.      */
+ /* They indicate failure by invoking the corresponding _print_proc.     */
+diff --git a/misc.c b/misc.c
+index 0869e01..217a2d5 100644
+--- a/misc.c
++++ b/misc.c
+@@ -2216,6 +2216,30 @@ STATIC void GC_do_blocking_inner(ptr_t data, void * context GC_ATTR_UNUSED)
+     GC_blocked_sp = NULL;
+ }
+ 
++  GC_API void GC_CALL GC_set_stackbottom(void *gc_thread_handle,
++                                         const struct GC_stack_base *sb)
++  {
++    GC_ASSERT(sb -> mem_base != NULL);
++    GC_ASSERT(NULL == gc_thread_handle || &GC_stackbottom == gc_thread_handle);
++    GC_ASSERT(NULL == GC_blocked_sp
++              && NULL == GC_traced_stack_sect); /* for now */
++    (void)gc_thread_handle;
++
++    GC_stackbottom = (char *)sb->mem_base;
++#   ifdef IA64
++      GC_register_stackbottom = (ptr_t)sb->reg_base;
++#   endif
++  }
++
++  GC_API void * GC_CALL GC_get_my_stackbottom(struct GC_stack_base *sb)
++  {
++    GC_ASSERT(GC_is_initialized);
++    sb -> mem_base = GC_stackbottom;
++#   ifdef IA64
++      sb -> reg_base = GC_register_stackbottom;
++#   endif
++    return &GC_stackbottom; /* gc_thread_handle */
++  }
+ #endif /* !THREADS */
+ 
+ GC_API void * GC_CALL GC_do_blocking(GC_fn_type fn, void * client_data)
+diff --git a/pthread_support.c b/pthread_support.c
+index 4891b3a..11b9d03 100644
+--- a/pthread_support.c
++++ b/pthread_support.c
+@@ -1436,6 +1436,62 @@ GC_INNER void GC_do_blocking_inner(ptr_t data, void * context GC_ATTR_UNUSED)
+     UNLOCK();
+ }
+ 
++GC_API void GC_CALL GC_set_stackbottom(void *gc_thread_handle,
++                                       const struct GC_stack_base *sb)
++{
++    GC_thread t = (GC_thread)gc_thread_handle;
++
++    GC_ASSERT(sb -> mem_base != NULL);
++    if (!EXPECT(GC_is_initialized, TRUE)) {
++        GC_ASSERT(NULL == t);
++    } else {
++        GC_ASSERT(I_HOLD_LOCK());
++        if (NULL == t) /* current thread? */
++            t = GC_lookup_thread(pthread_self());
++        GC_ASSERT((t -> flags & FINISHED) == 0);
++        GC_ASSERT(!(t -> thread_blocked)
++                  && NULL == t -> traced_stack_sect); /* for now */
++
++        if ((t -> flags & MAIN_THREAD) == 0) {
++            t -> stack_end = (ptr_t)sb->mem_base;
++#           ifdef IA64
++                t -> backing_store_end = (ptr_t)sb->reg_base;
++#           endif
++            return;
++        }
++        /* Otherwise alter the stack bottom of the primordial thread.   */
++    }
++
++    GC_stackbottom = (char*)sb->mem_base;
++#   ifdef IA64
++        GC_register_stackbottom = (ptr_t)sb->reg_base;
++#   endif
++}
++
++GC_API void * GC_CALL GC_get_my_stackbottom(struct GC_stack_base *sb)
++{
++    pthread_t self = pthread_self();
++    GC_thread me;
++    DCL_LOCK_STATE;
++
++    LOCK();
++    me = GC_lookup_thread(self);
++    /* The thread is assumed to be registered.  */
++    if ((me -> flags & MAIN_THREAD) == 0) {
++        sb -> mem_base = me -> stack_end;
++#       ifdef IA64
++            sb -> reg_base = me -> backing_store_end;
++#       endif
++    } else {
++        sb -> mem_base = GC_stackbottom;
++#       ifdef IA64
++            sb -> reg_base = GC_register_stackbottom;
++#       endif
++    }
++    UNLOCK();
++    return (void *)me; /* gc_thread_handle */
++}
++
+ /* GC_call_with_gc_active() has the opposite to GC_do_blocking()        */
+ /* functionality.  It might be called from a user function invoked by   */
+ /* GC_do_blocking() to temporarily back allow calling any GC function   */
+diff --git a/tests/test.c b/tests/test.c
+index 8e2e3a6..b5fe25d 100644
+--- a/tests/test.c
++++ b/tests/test.c
+@@ -1309,6 +1309,18 @@ void * GC_CALLBACK inc_int_counter(void *pcounter)
+  return NULL;
+ }
+ 
++struct thr_hndl_sb_s {
++  void *gc_thread_handle;
++  struct GC_stack_base sb;
++};
++
++void * GC_CALLBACK set_stackbottom(void *cd)
++{
++  GC_set_stackbottom(((struct thr_hndl_sb_s *)cd)->gc_thread_handle,
++                     &((struct thr_hndl_sb_s *)cd)->sb);
++  return NULL;
++}
++
+ #ifndef MIN_WORDS
+ # define MIN_WORDS 2
+ #endif
+@@ -1329,6 +1341,7 @@ void run_one_test(void)
+       pid_t pid;
+       int wstatus;
+ #   endif
++    struct thr_hndl_sb_s thr_hndl_sb;
+ 
+     GC_FREE(0);
+ #   ifdef THREADS
+@@ -1473,6 +1486,7 @@ void run_one_test(void)
+              GC_FREE(GC_MALLOC_IGNORE_OFF_PAGE(2));
+            }
+          }
++    thr_hndl_sb.gc_thread_handle = GC_get_my_stackbottom(&thr_hndl_sb.sb);
+ #   ifdef GC_GCJ_SUPPORT
+       GC_REGISTER_DISPLACEMENT(sizeof(struct fake_vtable *));
+       GC_init_gcj_malloc(0, (void *)(GC_word)fake_gcj_mark_proc);
+@@ -1534,6 +1548,8 @@ void run_one_test(void)
+           exit(0);
+         }
+ #   endif
++    (void)GC_call_with_alloc_lock(set_stackbottom, &thr_hndl_sb);
++
+     /* Repeated list reversal test. */
+ #   ifndef NO_CLOCK
+         GET_TIME(start_time);
+-- 
+2.33.0
+


### PR DESCRIPTION
This is a backport of ivmai/bdwgc@5668de71107022a316ee967162bc16c10754b9ce
so that it applies to the v8.0.6 tag.

The commit is applied with no changes, except for the changes to
`win32_threads.c`. The changes to this file are not relevant for our
purposes, and the original commit no longer applies.

This patch can be removed in v8.2.0.