### PR TITLE
Patch for omniorb to correct the flat-namespace error in brew audit.

### DIFF
--- a/omniorb/omniorb_2.4.2.patch
+++ b/omniorb/omniorb_2.4.2.patch
@@ -1,0 +1,17 @@
+diff -ru a/mk/beforeauto.mk.in b/mk/beforeauto.mk.in
+--- a/mk/beforeauto.mk.in	2018-05-09 01:57:00.000000000 +0900
++++ b/mk/beforeauto.mk.in	2021-11-06 23:12:10.000000000 +0900
+@@ -1096,10 +1096,9 @@
+ SharedLibraryLibNameTemplate = lib$$1$$2.$(SHAREDLIB_SUFFIX)
+ SharedLibraryPlatformLinkFlagsTemplate = -dynamiclib \
+                                          -install_name $(INSTALLLIBDIR)/$(SharedLibraryFullNameTemplate) \
+-                                         -flat_namespace \
+-                                         -undefined suppress
+-PythonLibraryPlatformLinkFlagsTemplate = -bundle -flat_namespace \
+-                                         -undefined suppress
++                                          -undefined dynamic_lookup
++PythonLibraryPlatformLinkFlagsTemplate = -bundle \
++                                          -undefined dynamic_lookup
+ PythonSHAREDLIB_SUFFIX = so
+ 
+ 

--- a/omniorb/omniorb_2.4.2.patch
+++ b/omniorb/omniorb_2.4.2.patch
@@ -1,17 +1,20 @@
+Only in b/mk: afterauto.mk
+Only in b/mk: beforeauto.mk
 diff -ru a/mk/beforeauto.mk.in b/mk/beforeauto.mk.in
 --- a/mk/beforeauto.mk.in	2018-05-09 01:57:00.000000000 +0900
-+++ b/mk/beforeauto.mk.in	2021-11-06 23:12:10.000000000 +0900
-@@ -1096,10 +1096,9 @@
++++ b/mk/beforeauto.mk.in	2021-11-10 09:41:14.000000000 +0900
+@@ -1095,11 +1095,9 @@
+ SharedLibrarySoNameTemplate = lib$$1$$2.$$3.$(SHAREDLIB_SUFFIX)
  SharedLibraryLibNameTemplate = lib$$1$$2.$(SHAREDLIB_SUFFIX)
  SharedLibraryPlatformLinkFlagsTemplate = -dynamiclib \
-                                          -install_name $(INSTALLLIBDIR)/$(SharedLibraryFullNameTemplate) \
+-                                         -install_name $(INSTALLLIBDIR)/$(SharedLibraryFullNameTemplate) \
 -                                         -flat_namespace \
 -                                         -undefined suppress
 -PythonLibraryPlatformLinkFlagsTemplate = -bundle -flat_namespace \
 -                                         -undefined suppress
-+                                          -undefined dynamic_lookup
++                                         -install_name $(INSTALLLIBDIR)/$(SharedLibraryFullNameTemplate)
 +PythonLibraryPlatformLinkFlagsTemplate = -bundle \
-+                                          -undefined dynamic_lookup
++                                         -undefined dynamic_lookup
  PythonSHAREDLIB_SUFFIX = so
  
  

--- a/omniorb/omniorb_2.4.2.patch
+++ b/omniorb/omniorb_2.4.2.patch
@@ -1,5 +1,3 @@
-Only in b/mk: afterauto.mk
-Only in b/mk: beforeauto.mk
 diff -ru a/mk/beforeauto.mk.in b/mk/beforeauto.mk.in
 --- a/mk/beforeauto.mk.in	2018-05-09 01:57:00.000000000 +0900
 +++ b/mk/beforeauto.mk.in	2021-11-10 09:41:14.000000000 +0900


### PR DESCRIPTION
The current omniorb's formula returns the flat-namespace error when checked by "brew audit." 
This patch modifies omniORB-2.4.2's makefile to remove "-flat-namespace" option and avoid the flat-namespace errors.
This pull request is related to the PR: https://github.com/Homebrew/homebrew-core/pull/87515
