### PR TITLE
autogen: add guile 3.0 and flat namespace patches

### DIFF
--- a/autogen/allow-guile-3.0.diff
+++ b/autogen/allow-guile-3.0.diff
@@ -1,0 +1,48 @@
+Index: autogen-5.18.16/agen5/guile-iface.h
+===================================================================
+--- autogen-5.18.16.orig/agen5/guile-iface.h
++++ autogen-5.18.16/agen5/guile-iface.h
+@@ -9,16 +9,13 @@
+ # error AutoGen does not work with this version of Guile
+   choke me.
+ 
+-#elif GUILE_VERSION < 203000
++#else
+ # define AG_SCM_IS_PROC(_p)           scm_is_true( scm_procedure_p(_p))
+ # define AG_SCM_LIST_P(_l)            scm_is_true( scm_list_p(_l))
+ # define AG_SCM_PAIR_P(_p)            scm_is_true( scm_pair_p(_p))
+ # define AG_SCM_TO_LONG(_v)           scm_to_long(_v)
+ # define AG_SCM_TO_ULONG(_v)          ((unsigned long)scm_to_ulong(_v))
+ 
+-#else
+-# error unknown GUILE_VERSION
+-  choke me.
+ #endif
+ 
+ #endif /* MUTATING_GUILE_IFACE_H_GUARD */
+Index: autogen-5.18.16/configure
+===================================================================
+--- autogen-5.18.16.orig/configure
++++ autogen-5.18.16/configure
+@@ -14798,7 +14798,7 @@ $as_echo "no" >&6; }
+ 		PKG_CONFIG=""
+ 	fi
+ fi
+-  _guile_versions_to_search="2.2 2.0 1.8"
++  _guile_versions_to_search="3.0 2.2 2.0 1.8"
+   if test -n "$GUILE_EFFECTIVE_VERSION"; then
+     _guile_tmp=""
+     for v in $_guile_versions_to_search; do
+Index: autogen-5.18.16/config/guile.m4
+===================================================================
+--- autogen-5.18.16.orig/config/guile.m4
++++ autogen-5.18.16/config/guile.m4
+@@ -61,7 +61,7 @@
+ #
+ AC_DEFUN([GUILE_PKG],
+  [PKG_PROG_PKG_CONFIG
+-  _guile_versions_to_search="m4_default([$1], [2.2 2.0 1.8])"
++  _guile_versions_to_search="m4_default([$1], [3.0 2.2 2.0 1.8])"
+   if test -n "$GUILE_EFFECTIVE_VERSION"; then
+     _guile_tmp=""
+     for v in $_guile_versions_to_search; do

--- a/autogen/flat-namespace.diff
+++ b/autogen/flat-namespace.diff
@@ -1,0 +1,25 @@
+diff --git a/config/libtool.m4 b/config/libtool.m4
+index e86a682..c1c342f 100644
+--- a/config/libtool.m4
++++ b/config/libtool.m4
+@@ -1067,16 +1067,11 @@ _LT_EOF
+       _lt_dar_allow_undefined='$wl-undefined ${wl}suppress' ;;
+     darwin1.*)
+       _lt_dar_allow_undefined='$wl-flat_namespace $wl-undefined ${wl}suppress' ;;
+-    darwin*) # darwin 5.x on
+-      # if running on 10.5 or later, the deployment target defaults
+-      # to the OS version, if on x86, and 10.4, the deployment
+-      # target defaults to 10.4. Don't you love it?
+-      case ${MACOSX_DEPLOYMENT_TARGET-10.0},$host in
+-	10.0,*86*-darwin8*|10.0,*-darwin[[91]]*)
+-	  _lt_dar_allow_undefined='$wl-undefined ${wl}dynamic_lookup' ;;
+-	10.[[012]][[,.]]*)
++    darwin*)
++      case ${MACOSX_DEPLOYMENT_TARGET},$host in
++	10.[[012]],*|,*powerpc*)
+ 	  _lt_dar_allow_undefined='$wl-flat_namespace $wl-undefined ${wl}suppress' ;;
+-	10.*)
++	*)
+ 	  _lt_dar_allow_undefined='$wl-undefined ${wl}dynamic_lookup' ;;
+       esac
+     ;;


### PR DESCRIPTION
Fix -flat_namespace being used on Big Sur and later.
Fix guile detection, see https://sourceforge.net/p/autogen/bugs/196/

The guile patch is almost the same as the 2.2 patch that was already in this repo.
Upstream said that they will disable that version check completely.