### PR TITLE
gitlab-runner: patch for 14.6.0

### DIFF
--- a/gitlab-runner/14_6_0.patch
+++ b/gitlab-runner/14_6_0.patch
@@ -1,0 +1,64 @@
+diff --git a/main.go b/main.go
+index 9f2b76ffd..6fa0b60fd 100644
+--- a/main.go
++++ b/main.go
+@@ -9,7 +9,6 @@ import (
+ 
+ 	"gitlab.com/gitlab-org/gitlab-runner/common"
+ 	cli_helpers "gitlab.com/gitlab-org/gitlab-runner/helpers/cli"
+-	issue_28732_patch "gitlab.com/gitlab-org/gitlab-runner/helpers/patches/issue_28732"
+ 	"gitlab.com/gitlab-org/gitlab-runner/log"
+ 
+ 	_ "gitlab.com/gitlab-org/gitlab-runner/cache/azure"
+@@ -40,7 +39,6 @@ func main() {
+ 		}
+ 	}()
+ 
+-	issue_28732_patch.AssertFixPresent()
+ 
+ 	app := cli.NewApp()
+ 	app.Name = filepath.Base(os.Args[0])
+diff --git a/scripts/patch_go_env b/scripts/patch_go_env
+index d7bfb51c5..a9bf588e2 100755
+--- a/scripts/patch_go_env
++++ b/scripts/patch_go_env
+@@ -1,39 +1 @@
+ #!/bin/bash
+-
+-set -eo pipefail
+-
+-echo "Fixing FD-0 bug..."
+-eval $(go env)
+-
+-patch -p1 -N -d "$GOROOT" <<EOF
+---- a/src/syscall/exec_unix.go.bak	2021-12-07 22:27:19.480273436 +0000
+-+++ b/src/syscall/exec_unix.go	2021-12-07 22:53:37.878003817 +0000
+-@@ -194,7 +194,7 @@
+-
+- 	// Allocate child status pipe close on exec.
+- 	if err = forkExecPipe(p[:]); err != nil {
+--		goto error
+-+		goto error2
+- 	}
+-
+- 	// Kick off child.
+-@@ -234,6 +234,7 @@
+- 		Close(p[0])
+- 		Close(p[1])
+- 	}
+-+error2:
+- 	ForkLock.Unlock()
+- 	return 0, err
+- }
+-@@ -249,6 +250,10 @@
+- 	return pid, 0, err
+- }
+-
+-+// Dummy function to test fd-0 bug
+-+func Issue28732Fix() {
+-+}
+-+
+- // Implemented in runtime package.
+- func runtime_BeforeExec()
+- func runtime_AfterExec()
+-EOF


### PR DESCRIPTION
Remove custom gitlab patch for CVE-2021-44717, as go is already patched against this CVE.

Required for the https://github.com/Homebrew/homebrew-core/pull/92651.