### PR TITLE
exiv2: add `std::unique_ptr` patch

### DIFF
--- a/exiv2/unique_ptr.patch
+++ b/exiv2/unique_ptr.patch
@@ -1,0 +1,5141 @@
+diff --git a/cmake/compilerFlags.cmake b/cmake/compilerFlags.cmake
+index 68fd8f0..2011d18 100644
+--- a/cmake/compilerFlags.cmake
++++ b/cmake/compilerFlags.cmake
+@@ -1,6 +1,10 @@
+ # These flags applies to exiv2lib, the applications, and to the xmp code
+ include(CheckCXXCompilerFlag)
+ 
++set(CMAKE_CXX_STANDARD 11)
++set(CMAKE_CXX_STANDARD_REQUIRED ON)
++set(CMAKE_CXX_EXTENSIONS OFF)
++
+ if ( MINGW OR UNIX OR MSYS ) # MINGW, Linux, APPLE, CYGWIN
+     if (${CMAKE_CXX_COMPILER_ID} STREQUAL GNU)
+         set(COMPILER_IS_GCC ON)
+diff --git a/cmake/compilerFlagsExiv2.cmake b/cmake/compilerFlagsExiv2.cmake
+index d364b69..0926a29 100644
+--- a/cmake/compilerFlagsExiv2.cmake
++++ b/cmake/compilerFlagsExiv2.cmake
+@@ -4,7 +4,7 @@ include(CheckCXXCompilerFlag)
+ 
+ if (COMPILER_IS_GCC OR COMPILER_IS_CLANG) # MINGW, Linux, APPLE, CYGWIN
+     if ( EXIV2_TEAM_WARNINGS_AS_ERRORS )
+-        add_compile_options(-Werror -Wno-error=deprecated-declarations)
++        add_compile_options(-Werror)
+         check_cxx_compiler_flag(-Wno-error=deprecated-copy DEPRECATED_COPY)
+         if ( DEPRECATED_COPY) 
+             add_compile_options(-Wno-error=deprecated-copy)
+diff --git a/cmake/printSummary.cmake b/cmake/printSummary.cmake
+index 2f3e1fc..e708f35 100644
+--- a/cmake/printSummary.cmake
++++ b/cmake/printSummary.cmake
+@@ -38,8 +38,8 @@ message( STATUS "RelWithDebInfo:    ${CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO}" )
+ message( STATUS "MinSizeRel:        ${CMAKE_EXE_LINKER_FLAGS_MINSIZEREL}" )
+ message( STATUS "" )
+ message( STATUS "Compiler Options")
+-OptionOutput( "Warnings as errors:                 " EXIV2_WARNINGS_AS_ERRORS        )
+-OptionOutput( "Use extra compiler warning flags:   " EXIV2_EXTRA_WARNINGS            )
++OptionOutput( "Warnings as errors:                 " EXIV2_TEAM_WARNINGS_AS_ERRORS        )
++OptionOutput( "Use extra compiler warning flags:   " EXIV2_TEAM_EXTRA_WARNINGS            )
+ message( STATUS "" )
+ 
+ message( STATUS "------------------------------------------------------------------" )
+diff --git a/contrib/organize/organize.cpp b/contrib/organize/organize.cpp
+index a176a6b..86076d2 100644
+--- a/contrib/organize/organize.cpp
++++ b/contrib/organize/organize.cpp
+@@ -244,7 +244,7 @@ std::string build_dest(const fs::path &source_file)
+ {
+     std::string dest;
+ 
+-    Exiv2::Image::AutoPtr image;
++    Exiv2::Image::UniquePtr image;
+     try {
+         image = Exiv2::ImageFactory::open(source_file.string());
+         image->readMetadata();
+diff --git a/fuzz/fuzz-read-print-write.cpp b/fuzz/fuzz-read-print-write.cpp
+index 037ae9d..c88f6e3 100644
+--- a/fuzz/fuzz-read-print-write.cpp
++++ b/fuzz/fuzz-read-print-write.cpp
+@@ -16,7 +16,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t * data, size_t size) {
+ 
+   try {
+     Exiv2::DataBuf data_copy(data, size);
+-    Exiv2::Image::AutoPtr image =
++    Exiv2::Image::UniquePtr image =
+       Exiv2::ImageFactory::open(data_copy.pData_, size);
+     assert(image.get() != 0);
+ 
+diff --git a/include/exiv2/asfvideo.hpp b/include/exiv2/asfvideo.hpp
+index 50ddb9e..a5b2282 100644
+--- a/include/exiv2/asfvideo.hpp
++++ b/include/exiv2/asfvideo.hpp
+@@ -62,7 +62,7 @@ namespace Exiv2 {
+               instance after it is passed to this method. Use the Image::io()
+               method to get a temporary reference.
+          */
+-        AsfVideo(BasicIo::AutoPtr io);
++        AsfVideo(BasicIo::UniquePtr io);
+         //@}
+ 
+         //! @name Manipulators
+@@ -169,7 +169,7 @@ namespace Exiv2 {
+           Caller owns the returned object and the auto-pointer ensures that
+           it will be deleted.
+      */
+-    EXIV2LIB_DEPRECATED_EXPORT Image::AutoPtr newAsfInstance(BasicIo::AutoPtr io, bool create);
++    EXIV2LIB_DEPRECATED_EXPORT Image::UniquePtr newAsfInstance(BasicIo::UniquePtr io, bool create);
+ 
+     //! Check if the file iIo is a Windows Asf Video.
+     EXIV2LIB_DEPRECATED_EXPORT bool isAsfType(BasicIo& iIo, bool advance);
+diff --git a/include/exiv2/basicio.hpp b/include/exiv2/basicio.hpp
+index e2a0ce4..17f0e89 100644
+--- a/include/exiv2/basicio.hpp
++++ b/include/exiv2/basicio.hpp
+@@ -30,7 +30,7 @@
+ #include "types.hpp"
+ 
+ // + standard includes
+-#include <memory>       // for std::auto_ptr
++#include <memory>
+ 
+ // The way to handle data from stdin or data uri path. If EXV_XPATH_MEMIO = 1,
+ // it uses MemIo. Otherwises, it uses FileIo.
+@@ -55,7 +55,7 @@ namespace Exiv2 {
+     class EXIV2API BasicIo {
+     public:
+         //! BasicIo auto_ptr type
+-        typedef std::auto_ptr<BasicIo> AutoPtr;
++        typedef std::unique_ptr<BasicIo> UniquePtr;
+ 
+         //! Seek starting positions
+         enum Position { beg, cur, end };
+@@ -521,7 +521,7 @@ namespace Exiv2 {
+ 
+         // Pimpl idiom
+         class Impl;
+-        std::auto_ptr<Impl> p_;
++        std::unique_ptr<Impl> p_;
+ 
+     }; // class FileIo
+ 
+@@ -721,7 +721,7 @@ namespace Exiv2 {
+ 
+         // Pimpl idiom
+         class Impl;
+-        std::auto_ptr<Impl> p_;
++        std::unique_ptr<Impl> p_;
+ 
+     }; // class MemIo
+ 
+diff --git a/include/exiv2/bmffimage.hpp b/include/exiv2/bmffimage.hpp
+index 9db1065..e28c169 100644
+--- a/include/exiv2/bmffimage.hpp
++++ b/include/exiv2/bmffimage.hpp
+@@ -80,7 +80,7 @@ namespace Exiv2
+           @param create Specifies if an existing image should be read (false)
+               or if a new file should be created (true).
+          */
+-        BmffImage(BasicIo::AutoPtr io, bool create);
++        BmffImage(BasicIo::UniquePtr io, bool create);
+         //@}
+ 
+         //@{
+@@ -193,7 +193,7 @@ namespace Exiv2
+              Caller owns the returned object and the auto-pointer ensures that
+              it will be deleted.
+      */
+-    EXIV2API Image::AutoPtr newBmffInstance(BasicIo::AutoPtr io, bool create);
++    EXIV2API Image::UniquePtr newBmffInstance(BasicIo::UniquePtr io, bool create);
+ 
+     //! Check if the file iIo is a BMFF image.
+     EXIV2API bool isBmffType(BasicIo& iIo, bool advance);
+diff --git a/include/exiv2/bmpimage.hpp b/include/exiv2/bmpimage.hpp
+index aa8c7f7..8ae8385 100644
+--- a/include/exiv2/bmpimage.hpp
++++ b/include/exiv2/bmpimage.hpp
+@@ -73,7 +73,7 @@ namespace Exiv2 {
+               instance after it is passed to this method.  Use the Image::io()
+               method to get a temporary reference.
+          */
+-        explicit BmpImage(BasicIo::AutoPtr io);
++        explicit BmpImage(BasicIo::UniquePtr io);
+         //@}
+ 
+         //! @name Manipulators
+@@ -118,7 +118,7 @@ namespace Exiv2 {
+              Caller owns the returned object and the auto-pointer ensures that
+              it will be deleted.
+      */
+-    EXIV2API Image::AutoPtr newBmpInstance(BasicIo::AutoPtr io, bool create);
++    EXIV2API Image::UniquePtr newBmpInstance(BasicIo::UniquePtr io, bool create);
+ 
+     //! Check if the file iIo is a Windows Bitmap image.
+     EXIV2API bool isBmpType(BasicIo& iIo, bool advance);
+diff --git a/include/exiv2/cr2image.hpp b/include/exiv2/cr2image.hpp
+index dd19430..34379ef 100644
+--- a/include/exiv2/cr2image.hpp
++++ b/include/exiv2/cr2image.hpp
+@@ -68,7 +68,7 @@ namespace Exiv2 {
+           @param create Specifies if an existing image should be read (false)
+               or if a new file should be created (true).
+          */
+-        Cr2Image(BasicIo::AutoPtr io, bool create);
++        Cr2Image(BasicIo::UniquePtr io, bool create);
+         //@}
+ 
+         //! @name Manipulators
+@@ -152,7 +152,7 @@ namespace Exiv2 {
+              Caller owns the returned object and the auto-pointer ensures that
+              it will be deleted.
+      */
+-    EXIV2API Image::AutoPtr newCr2Instance(BasicIo::AutoPtr io, bool create);
++    EXIV2API Image::UniquePtr newCr2Instance(BasicIo::UniquePtr io, bool create);
+ 
+     //! Check if the file iIo is a CR2 image.
+     EXIV2API bool isCr2Type(BasicIo& iIo, bool advance);
+diff --git a/include/exiv2/crwimage.hpp b/include/exiv2/crwimage.hpp
+index aab0f82..202bb1a 100644
+--- a/include/exiv2/crwimage.hpp
++++ b/include/exiv2/crwimage.hpp
+@@ -75,7 +75,7 @@ namespace Exiv2 {
+           @param create Specifies if an existing image should be read (false)
+               or if a new file should be created (true).
+          */
+-        CrwImage(BasicIo::AutoPtr io, bool create);
++        CrwImage(BasicIo::UniquePtr io, bool create);
+         //@}
+ 
+         //! @name Manipulators
+@@ -161,7 +161,7 @@ namespace Exiv2 {
+              Caller owns the returned object and the auto-pointer ensures that
+              it will be deleted.
+      */
+-    EXIV2API Image::AutoPtr newCrwInstance(BasicIo::AutoPtr io, bool create);
++    EXIV2API Image::UniquePtr newCrwInstance(BasicIo::UniquePtr io, bool create);
+ 
+     //! Check if the file iIo is a CRW image.
+     EXIV2API bool isCrwType(BasicIo& iIo, bool advance);
+diff --git a/include/exiv2/datasets.hpp b/include/exiv2/datasets.hpp
+index 0e7c4a4..52b1c91 100644
+--- a/include/exiv2/datasets.hpp
++++ b/include/exiv2/datasets.hpp
+@@ -275,7 +275,7 @@ namespace Exiv2 {
+     class EXIV2API IptcKey : public Key {
+     public:
+         //! Shortcut for an %IptcKey auto pointer.
+-        typedef std::auto_ptr<IptcKey> AutoPtr;
++        typedef std::unique_ptr<IptcKey> UniquePtr;
+ 
+         //! @name Creators
+         //@{
+@@ -320,7 +320,7 @@ namespace Exiv2 {
+         virtual std::string tagName() const;
+         virtual std::string tagLabel() const;
+         virtual uint16_t tag() const;
+-        AutoPtr clone() const;
++        UniquePtr clone() const;
+         //! Return the name of the record
+         std::string recordName() const;
+         //! Return the record id
+diff --git a/include/exiv2/epsimage.hpp b/include/exiv2/epsimage.hpp
+index 54d26e7..1317b60 100644
+--- a/include/exiv2/epsimage.hpp
++++ b/include/exiv2/epsimage.hpp
+@@ -74,7 +74,7 @@ namespace Exiv2
+           @param create Specifies if an existing image should be read (false)
+               or if a new file should be created (true).
+          */
+-        EpsImage(BasicIo::AutoPtr io, bool create);
++        EpsImage(BasicIo::UniquePtr io, bool create);
+         //@}
+ 
+         //! @name Manipulators
+@@ -114,7 +114,7 @@ namespace Exiv2
+              Caller owns the returned object and the auto-pointer ensures that
+              it will be deleted.
+      */
+-    EXIV2LIB_DEPRECATED_EXPORT Image::AutoPtr newEpsInstance(BasicIo::AutoPtr io, bool create);
++    EXIV2LIB_DEPRECATED_EXPORT Image::UniquePtr newEpsInstance(BasicIo::UniquePtr io, bool create);
+ 
+     //! Check if the file iIo is a EPS image.
+     EXIV2LIB_DEPRECATED_EXPORT bool isEpsType(BasicIo& iIo, bool advance);
+diff --git a/include/exiv2/exif.hpp b/include/exiv2/exif.hpp
+index 2a70efe..d439a5e 100644
+--- a/include/exiv2/exif.hpp
++++ b/include/exiv2/exif.hpp
+@@ -192,7 +192,7 @@ namespace Exiv2 {
+         long toLong(long n =0) const;
+         float toFloat(long n =0) const;
+         Rational toRational(long n =0) const;
+-        Value::AutoPtr getValue() const;
++        Value::UniquePtr getValue() const;
+         const Value& value() const;
+         //! Return the size of the data area.
+         long sizeDataArea() const;
+@@ -213,8 +213,8 @@ namespace Exiv2 {
+ 
+     private:
+         // DATA
+-        ExifKey::AutoPtr key_;                  //!< Key
+-        Value::AutoPtr   value_;                //!< Value
++        ExifKey::UniquePtr key_;                  //!< Key
++        Value::UniquePtr   value_;                //!< Value
+ 
+     }; // class Exifdatum
+ 
+diff --git a/include/exiv2/gifimage.hpp b/include/exiv2/gifimage.hpp
+index 828be6d..2ab8a77 100644
+--- a/include/exiv2/gifimage.hpp
++++ b/include/exiv2/gifimage.hpp
+@@ -66,7 +66,7 @@ namespace Exiv2 {
+               instance after it is passed to this method.  Use the Image::io()
+               method to get a temporary reference.
+          */
+-        explicit GifImage(BasicIo::AutoPtr io);
++        explicit GifImage(BasicIo::UniquePtr io);
+         //@}
+ 
+         //! @name Manipulators
+@@ -111,7 +111,7 @@ namespace Exiv2 {
+              Caller owns the returned object and the auto-pointer ensures that
+              it will be deleted.
+      */
+-    EXIV2API Image::AutoPtr newGifInstance(BasicIo::AutoPtr io, bool create);
++    EXIV2API Image::UniquePtr newGifInstance(BasicIo::UniquePtr io, bool create);
+ 
+     //! Check if the file iIo is a GIF image.
+     EXIV2API bool isGifType(BasicIo& iIo, bool advance);
+diff --git a/include/exiv2/image.hpp b/include/exiv2/image.hpp
+index 7000c51..0e8db07 100644
+--- a/include/exiv2/image.hpp
++++ b/include/exiv2/image.hpp
+@@ -78,7 +78,7 @@ namespace Exiv2 {
+     class EXIV2API Image {
+     public:
+         //! Image auto_ptr type
+-        typedef std::auto_ptr<Image> AutoPtr;
++        typedef std::unique_ptr<Image> UniquePtr;
+ 
+         //! @name Creators
+         //@{
+@@ -89,7 +89,7 @@ namespace Exiv2 {
+          */
+         Image(int              imageType,
+               uint16_t         supportedMetadata,
+-              BasicIo::AutoPtr io);
++              BasicIo::UniquePtr io);
+         //! Virtual Destructor
+         virtual ~Image();
+         //@}
+@@ -481,7 +481,7 @@ namespace Exiv2 {
+ 
+     protected:
+         // DATA
+-        BasicIo::AutoPtr  io_;                //!< Image data IO pointer
++        BasicIo::UniquePtr  io_;                //!< Image data IO pointer
+         ExifData          exifData_;          //!< Exif data container
+         IptcData          iptcData_;          //!< IPTC data container
+         XmpData           xmpData_;           //!< XMP data container
+@@ -519,7 +519,7 @@ namespace Exiv2 {
+     }; // class Image
+ 
+     //! Type for function pointer that creates new Image instances
+-    typedef Image::AutoPtr (*NewInstanceFct)(BasicIo::AutoPtr io, bool create);
++    typedef Image::UniquePtr (*NewInstanceFct)(BasicIo::UniquePtr io, bool create);
+     //! Type for function pointer that checks image types
+     typedef bool (*IsThisTypeFct)(BasicIo& iIo, bool advance);
+ 
+@@ -545,13 +545,13 @@ namespace Exiv2 {
+           @throw Error If the file is not found or it is unable to connect to the server to
+                 read the remote file.
+          */
+-        static BasicIo::AutoPtr createIo(const std::string& path, bool useCurl = true);
++        static BasicIo::UniquePtr createIo(const std::string& path, bool useCurl = true);
+ #ifdef EXV_UNICODE_PATH
+         /*!
+           @brief Like createIo() but accepts a unicode path in an std::wstring.
+           @note This function is only available on Windows.
+          */
+-        static BasicIo::AutoPtr createIo(const std::wstring& wpath, bool useCurl = true);
++        static BasicIo::UniquePtr createIo(const std::wstring& wpath, bool useCurl = true);
+ #endif
+         /*!
+           @brief Create an Image subclass of the appropriate type by reading
+@@ -566,13 +566,13 @@ namespace Exiv2 {
+           @throw Error If opening the file fails or it contains data of an
+               unknown image type.
+          */
+-        static Image::AutoPtr open(const std::string& path, bool useCurl = true);
++        static Image::UniquePtr open(const std::string& path, bool useCurl = true);
+ #ifdef EXV_UNICODE_PATH
+         /*!
+           @brief Like open() but accepts a unicode path in an std::wstring.
+           @note This function is only available on Windows.
+          */
+-        static Image::AutoPtr open(const std::wstring& wpath, bool useCurl = true);
++        static Image::UniquePtr open(const std::wstring& wpath, bool useCurl = true);
+ #endif
+         /*!
+           @brief Create an Image subclass of the appropriate type by reading
+@@ -585,7 +585,7 @@ namespace Exiv2 {
+               matches that of the data buffer.
+           @throw Error If the memory contains data of an unknown image type.
+          */
+-        static Image::AutoPtr open(const byte* data, long size);
++        static Image::UniquePtr open(const byte* data, long size);
+         /*!
+           @brief Create an Image subclass of the appropriate type by reading
+               the provided BasicIo instance. %Image type is derived from the
+@@ -603,7 +603,7 @@ namespace Exiv2 {
+               determined, the pointer is 0.
+           @throw Error If opening the BasicIo fails
+          */
+-        static Image::AutoPtr open(BasicIo::AutoPtr io);
++        static Image::UniquePtr open(BasicIo::UniquePtr io);
+         /*!
+           @brief Create an Image subclass of the requested type by creating a
+               new image file. If the file already exists, it will be overwritten.
+@@ -613,13 +613,13 @@ namespace Exiv2 {
+               type.
+           @throw Error If the image type is not supported.
+          */
+-        static Image::AutoPtr create(int type, const std::string& path);
++        static Image::UniquePtr create(int type, const std::string& path);
+ #ifdef EXV_UNICODE_PATH
+         /*!
+           @brief Like create() but accepts a unicode path in an std::wstring.
+           @note This function is only available on Windows.
+          */
+-        static Image::AutoPtr create(int type, const std::wstring& wpath);
++        static Image::UniquePtr create(int type, const std::wstring& wpath);
+ #endif
+         /*!
+           @brief Create an Image subclass of the requested type by creating a
+@@ -629,7 +629,7 @@ namespace Exiv2 {
+               type.
+           @throw Error If the image type is not supported
+          */
+-        static Image::AutoPtr create(int type);
++        static Image::UniquePtr create(int type);
+         /*!
+           @brief Create an Image subclass of the requested type by writing a
+               new image to a BasicIo instance. If the BasicIo instance already
+@@ -644,7 +644,7 @@ namespace Exiv2 {
+           @return An auto-pointer that owns an Image instance of the requested
+               type. If the image type is not supported, the pointer is 0.
+          */
+-        static Image::AutoPtr create(int type, BasicIo::AutoPtr io);
++        static Image::UniquePtr create(int type, BasicIo::UniquePtr io);
+         /*!
+           @brief Returns the image type of the provided file.
+           @param path %Image file. The contents of the file are tested to
+diff --git a/include/exiv2/iptc.hpp b/include/exiv2/iptc.hpp
+index c0226c9..bdc2401 100644
+--- a/include/exiv2/iptc.hpp
++++ b/include/exiv2/iptc.hpp
+@@ -142,14 +142,14 @@ namespace Exiv2 {
+         long toLong(long n =0) const;
+         float toFloat(long n =0) const;
+         Rational toRational(long n =0) const;
+-        Value::AutoPtr getValue() const;
++        Value::UniquePtr getValue() const;
+         const Value& value() const;
+         //@}
+ 
+     private:
+         // DATA
+-        IptcKey::AutoPtr key_;                  //!< Key
+-        Value::AutoPtr   value_;                //!< Value
++        IptcKey::UniquePtr key_;                  //!< Key
++        Value::UniquePtr   value_;                //!< Value
+ 
+     }; // class Iptcdatum
+ 
+diff --git a/include/exiv2/jp2image.hpp b/include/exiv2/jp2image.hpp
+index fcc6082..4c8bec2 100644
+--- a/include/exiv2/jp2image.hpp
++++ b/include/exiv2/jp2image.hpp
+@@ -66,7 +66,7 @@ namespace Exiv2
+           @param create Specifies if an existing image should be read (false)
+               or if a new file should be created (true).
+          */
+-        Jp2Image(BasicIo::AutoPtr io, bool create);
++        Jp2Image(BasicIo::UniquePtr io, bool create);
+         //@}
+ 
+         //! @name Manipulators
+@@ -130,7 +130,7 @@ namespace Exiv2
+              Caller owns the returned object and the auto-pointer ensures that
+              it will be deleted.
+      */
+-    EXIV2API Image::AutoPtr newJp2Instance(BasicIo::AutoPtr io, bool create);
++    EXIV2API Image::UniquePtr newJp2Instance(BasicIo::UniquePtr io, bool create);
+ 
+     //! Check if the file iIo is a JPEG-2000 image.
+     EXIV2API bool isJp2Type(BasicIo& iIo, bool advance);
+diff --git a/include/exiv2/jpgimage.hpp b/include/exiv2/jpgimage.hpp
+index 6ca4784..96e5eb7 100644
+--- a/include/exiv2/jpgimage.hpp
++++ b/include/exiv2/jpgimage.hpp
+@@ -167,7 +167,7 @@ namespace Exiv2 {
+           @param dataSize Size of initData in bytes.
+          */
+         JpegBase(int              type,
+-                 BasicIo::AutoPtr io,
++                 BasicIo::UniquePtr io,
+                  bool             create,
+                  const byte       initData[],
+                  long             dataSize);
+@@ -306,7 +306,7 @@ namespace Exiv2 {
+           @param create Specifies if an existing image should be read (false)
+               or if a new file should be created (true).
+          */
+-        JpegImage(BasicIo::AutoPtr io, bool create);
++        JpegImage(BasicIo::UniquePtr io, bool create);
+         //@}
+         //! @name Accessors
+         //@{
+@@ -367,7 +367,7 @@ namespace Exiv2 {
+           @param create Specifies if an existing image should be read (false)
+                  or if a new file should be created (true).
+          */
+-        ExvImage(BasicIo::AutoPtr io, bool create);
++        ExvImage(BasicIo::UniquePtr io, bool create);
+         //@}
+         //! @name Accessors
+         //@{
+@@ -409,7 +409,7 @@ namespace Exiv2 {
+              Caller owns the returned object and the auto-pointer ensures that
+              it will be deleted.
+      */
+-    EXIV2API Image::AutoPtr newJpegInstance(BasicIo::AutoPtr io, bool create);
++    EXIV2API Image::UniquePtr newJpegInstance(BasicIo::UniquePtr io, bool create);
+     //! Check if the file iIo is a JPEG image.
+     EXIV2API bool isJpegType(BasicIo& iIo, bool advance);
+     /*!
+@@ -417,7 +417,7 @@ namespace Exiv2 {
+              Caller owns the returned object and the auto-pointer ensures that
+              it will be deleted.
+      */
+-    EXIV2API Image::AutoPtr newExvInstance(BasicIo::AutoPtr io, bool create);
++    EXIV2API Image::UniquePtr newExvInstance(BasicIo::UniquePtr io, bool create);
+     //! Check if the file iIo is an EXV file
+     EXIV2API bool isExvType(BasicIo& iIo, bool advance);
+ 
+diff --git a/include/exiv2/matroskavideo.hpp b/include/exiv2/matroskavideo.hpp
+index d83b7e8..7c2bad7 100644
+--- a/include/exiv2/matroskavideo.hpp
++++ b/include/exiv2/matroskavideo.hpp
+@@ -68,7 +68,7 @@ namespace Exiv2 {
+               instance after it is passed to this method. Use the Image::io()
+               method to get a temporary reference.
+          */
+-        MatroskaVideo(BasicIo::AutoPtr io);
++        MatroskaVideo(BasicIo::UniquePtr io);
+         //@}
+ 
+         //! @name Manipulators
+@@ -138,7 +138,7 @@ namespace Exiv2 {
+           Caller owns the returned object and the auto-pointer ensures that
+           it will be deleted.
+      */
+-    EXIV2LIB_DEPRECATED_EXPORT Image::AutoPtr newMkvInstance(BasicIo::AutoPtr io, bool create);
++    EXIV2LIB_DEPRECATED_EXPORT Image::UniquePtr newMkvInstance(BasicIo::UniquePtr io, bool create);
+ 
+     //! Check if the file iIo is a Matroska Video.
+     EXIV2LIB_DEPRECATED_EXPORT bool isMkvType(BasicIo& iIo, bool advance);
+diff --git a/include/exiv2/metadatum.hpp b/include/exiv2/metadatum.hpp
+index 036812e..467bbea 100644
+--- a/include/exiv2/metadatum.hpp
++++ b/include/exiv2/metadatum.hpp
+@@ -44,7 +44,7 @@ namespace Exiv2 {
+     class EXIV2API Key {
+     public:
+         //! Shortcut for a %Key auto pointer.
+-        typedef std::auto_ptr<Key> AutoPtr;
++        typedef std::unique_ptr<Key> UniquePtr;
+ 
+         //! @name Creators
+         //@{
+@@ -76,7 +76,7 @@ namespace Exiv2 {
+                  The caller owns this copy and the auto-pointer ensures that it
+                  will be deleted.
+          */
+-        AutoPtr clone() const;
++        UniquePtr clone() const;
+         /*!
+           @brief Write the key to an output stream. You do not usually have
+                  to use this function; it is used for the implementation of
+@@ -251,7 +251,7 @@ namespace Exiv2 {
+           @return An auto-pointer containing a pointer to a copy (clone) of the
+                   value, 0 if the value is not set.
+          */
+-        virtual Value::AutoPtr getValue() const =0;
++        virtual Value::UniquePtr getValue() const =0;
+         /*!
+           @brief Return a constant reference to the value.
+ 
+diff --git a/include/exiv2/mrwimage.hpp b/include/exiv2/mrwimage.hpp
+index 4ed7082..43623ba 100644
+--- a/include/exiv2/mrwimage.hpp
++++ b/include/exiv2/mrwimage.hpp
+@@ -61,7 +61,7 @@ namespace Exiv2 {
+           @param create Specifies if an existing image should be read (false)
+               or if a new file should be created (true).
+          */
+-        MrwImage(BasicIo::AutoPtr io, bool create);
++        MrwImage(BasicIo::UniquePtr io, bool create);
+         //@}
+ 
+         //! @name Manipulators
+@@ -117,7 +117,7 @@ namespace Exiv2 {
+              Caller owns the returned object and the auto-pointer ensures that
+              it will be deleted.
+      */
+-    EXIV2API Image::AutoPtr newMrwInstance(BasicIo::AutoPtr io, bool create);
++    EXIV2API Image::UniquePtr newMrwInstance(BasicIo::UniquePtr io, bool create);
+ 
+     //! Check if the file iIo is a MRW image.
+     EXIV2API bool isMrwType(BasicIo& iIo, bool advance);
+diff --git a/include/exiv2/orfimage.hpp b/include/exiv2/orfimage.hpp
+index 299ee63..1a2d169 100644
+--- a/include/exiv2/orfimage.hpp
++++ b/include/exiv2/orfimage.hpp
+@@ -61,7 +61,7 @@ namespace Exiv2 {
+           @param create Specifies if an existing image should be read (false)
+               or if a new file should be created (true).
+          */
+-        OrfImage(BasicIo::AutoPtr io, bool create);
++        OrfImage(BasicIo::UniquePtr io, bool create);
+         //@}
+ 
+         //! @name Manipulators
+@@ -138,7 +138,7 @@ namespace Exiv2 {
+              Caller owns the returned object and the auto-pointer ensures that
+              it will be deleted.
+      */
+-    EXIV2API Image::AutoPtr newOrfInstance(BasicIo::AutoPtr io, bool create);
++    EXIV2API Image::UniquePtr newOrfInstance(BasicIo::UniquePtr io, bool create);
+ 
+     //! Check if the file iIo is an ORF image.
+     EXIV2API bool isOrfType(BasicIo& iIo, bool advance);
+diff --git a/include/exiv2/pgfimage.hpp b/include/exiv2/pgfimage.hpp
+index dfdd8f3..6b8f33e 100644
+--- a/include/exiv2/pgfimage.hpp
++++ b/include/exiv2/pgfimage.hpp
+@@ -63,7 +63,7 @@ namespace Exiv2
+           @param create Specifies if an existing image should be read (false)
+               or if a new file should be created (true).
+          */
+-        PgfImage(BasicIo::AutoPtr io, bool create);
++        PgfImage(BasicIo::UniquePtr io, bool create);
+         //@}
+ 
+         //! @name Manipulators
+@@ -113,7 +113,7 @@ namespace Exiv2
+              Caller owns the returned object and the auto-pointer ensures that
+              it will be deleted.
+      */
+-    EXIV2API Image::AutoPtr newPgfInstance(BasicIo::AutoPtr io, bool create);
++    EXIV2API Image::UniquePtr newPgfInstance(BasicIo::UniquePtr io, bool create);
+ 
+     //! Check if the file iIo is a PGF image.
+     EXIV2API bool isPgfType(BasicIo& iIo, bool advance);
+diff --git a/include/exiv2/pngimage.hpp b/include/exiv2/pngimage.hpp
+index 78c9108..728bcc2 100644
+--- a/include/exiv2/pngimage.hpp
++++ b/include/exiv2/pngimage.hpp
+@@ -63,7 +63,7 @@ namespace Exiv2
+           @param create Specifies if an existing image should be read (false)
+               or if a new file should be created (true).
+          */
+-        PngImage(BasicIo::AutoPtr io, bool create);
++        PngImage(BasicIo::UniquePtr io, bool create);
+         //@}
+ 
+         //! @name Manipulators
+@@ -116,7 +116,7 @@ namespace Exiv2
+              Caller owns the returned object and the auto-pointer ensures that
+              it will be deleted.
+      */
+-    EXIV2API Image::AutoPtr newPngInstance(BasicIo::AutoPtr io, bool create);
++    EXIV2API Image::UniquePtr newPngInstance(BasicIo::UniquePtr io, bool create);
+ 
+     //! Check if the file iIo is a PNG image.
+     EXIV2API bool isPngType(BasicIo& iIo, bool advance);
+diff --git a/include/exiv2/properties.hpp b/include/exiv2/properties.hpp
+index f56b0c2..cfcf6a6 100644
+--- a/include/exiv2/properties.hpp
++++ b/include/exiv2/properties.hpp
+@@ -231,7 +231,7 @@ namespace Exiv2 {
+     {
+     public:
+         //! Shortcut for an %XmpKey auto pointer.
+-        typedef std::auto_ptr<XmpKey> AutoPtr;
++        typedef std::unique_ptr<XmpKey> UniquePtr;
+ 
+         //! @name Creators
+         //@{
+@@ -280,7 +280,7 @@ namespace Exiv2 {
+         //! Properties don't have a tag number. Return 0.
+         virtual uint16_t tag() const;
+ 
+-        AutoPtr clone() const;
++        UniquePtr clone() const;
+ 
+         // Todo: Should this be removed? What about tagLabel then?
+         //! Return the schema namespace for the prefix of the key
+@@ -294,7 +294,7 @@ namespace Exiv2 {
+     private:
+         // Pimpl idiom
+         struct Impl;
+-        std::auto_ptr<Impl> p_;
++        std::unique_ptr<Impl> p_;
+ 
+     };  // class XmpKey
+ 
+diff --git a/include/exiv2/psdimage.hpp b/include/exiv2/psdimage.hpp
+index 242e4b4..9cb4b27 100644
+--- a/include/exiv2/psdimage.hpp
++++ b/include/exiv2/psdimage.hpp
+@@ -65,7 +65,7 @@ namespace Exiv2 {
+               instance after it is passed to this method.  Use the Image::io()
+               method to get a temporary reference.
+          */
+-        explicit PsdImage(BasicIo::AutoPtr io);
++        explicit PsdImage(BasicIo::UniquePtr io);
+         //@}
+ 
+         //! @name Manipulators
+@@ -127,7 +127,7 @@ namespace Exiv2 {
+              Caller owns the returned object and the auto-pointer ensures that
+              it will be deleted.
+      */
+-    EXIV2API Image::AutoPtr newPsdInstance(BasicIo::AutoPtr io, bool create);
++    EXIV2API Image::UniquePtr newPsdInstance(BasicIo::UniquePtr io, bool create);
+ 
+     //! Check if the file iIo is a Photoshop image.
+     EXIV2API bool isPsdType(BasicIo& iIo, bool advance);
+diff --git a/include/exiv2/quicktimevideo.hpp b/include/exiv2/quicktimevideo.hpp
+index fe0e129..7b91c38 100644
+--- a/include/exiv2/quicktimevideo.hpp
++++ b/include/exiv2/quicktimevideo.hpp
+@@ -58,7 +58,7 @@ namespace Exiv2 {
+               instance after it is passed to this method. Use the Image::io()
+               method to get a temporary reference.
+          */
+-        QuickTimeVideo(BasicIo::AutoPtr io);
++        QuickTimeVideo(BasicIo::UniquePtr io);
+         //@}
+ 
+         //! @name Manipulators
+@@ -235,7 +235,7 @@ namespace Exiv2 {
+           Caller owns the returned object and the auto-pointer ensures that
+           it will be deleted.
+      */
+-    EXIV2LIB_DEPRECATED_EXPORT Image::AutoPtr newQTimeInstance(BasicIo::AutoPtr io, bool create);
++    EXIV2LIB_DEPRECATED_EXPORT Image::UniquePtr newQTimeInstance(BasicIo::UniquePtr io, bool create);
+ 
+     //! Check if the file iIo is a Quick Time Video.
+     EXIV2LIB_DEPRECATED_EXPORT bool isQTimeType(BasicIo& iIo, bool advance);
+diff --git a/include/exiv2/rafimage.hpp b/include/exiv2/rafimage.hpp
+index 207fe7e..6e60cb9 100644
+--- a/include/exiv2/rafimage.hpp
++++ b/include/exiv2/rafimage.hpp
+@@ -66,7 +66,7 @@ namespace Exiv2 {
+           @param create Specifies if an existing image should be read (false)
+               or if a new file should be created (true).
+          */
+-        RafImage(BasicIo::AutoPtr io, bool create);
++        RafImage(BasicIo::UniquePtr io, bool create);
+         //@}
+ 
+         //! @name Manipulators
+@@ -123,7 +123,7 @@ namespace Exiv2 {
+              Caller owns the returned object and the auto-pointer ensures that
+              it will be deleted.
+      */
+-    EXIV2API Image::AutoPtr newRafInstance(BasicIo::AutoPtr io, bool create);
++    EXIV2API Image::UniquePtr newRafInstance(BasicIo::UniquePtr io, bool create);
+ 
+     //! Check if the file iIo is a RAF image.
+     EXIV2API bool isRafType(BasicIo& iIo, bool advance);
+diff --git a/include/exiv2/riffvideo.hpp b/include/exiv2/riffvideo.hpp
+index 0b323b9..47f2347 100644
+--- a/include/exiv2/riffvideo.hpp
++++ b/include/exiv2/riffvideo.hpp
+@@ -58,7 +58,7 @@ namespace Exiv2 {
+               instance after it is passed to this method. Use the Image::io()
+               method to get a temporary reference.
+          */
+-        RiffVideo(BasicIo::AutoPtr io);
++        RiffVideo(BasicIo::UniquePtr io);
+         //@}
+ 
+         //! @name Manipulators
+@@ -203,7 +203,7 @@ namespace Exiv2 {
+           Caller owns the returned object and the auto-pointer ensures that
+           it will be deleted.
+      */
+-    EXIV2LIB_DEPRECATED_EXPORT Image::AutoPtr newRiffInstance(BasicIo::AutoPtr io, bool create);
++    EXIV2LIB_DEPRECATED_EXPORT Image::UniquePtr newRiffInstance(BasicIo::UniquePtr io, bool create);
+ 
+     //! Check if the file iIo is a Riff Video.
+     EXIV2LIB_DEPRECATED_EXPORT bool isRiffType(BasicIo& iIo, bool advance);
+diff --git a/include/exiv2/rw2image.hpp b/include/exiv2/rw2image.hpp
+index 9da395e..1799988 100644
+--- a/include/exiv2/rw2image.hpp
++++ b/include/exiv2/rw2image.hpp
+@@ -59,7 +59,7 @@ namespace Exiv2 {
+               instance after it is passed to this method.  Use the Image::io()
+               method to get a temporary reference.
+          */
+-        explicit Rw2Image(BasicIo::AutoPtr io);
++        explicit Rw2Image(BasicIo::UniquePtr io);
+         //@}
+ 
+         //! @name Manipulators
+@@ -138,7 +138,7 @@ namespace Exiv2 {
+              Caller owns the returned object and the auto-pointer ensures that
+              it will be deleted.
+      */
+-    EXIV2API Image::AutoPtr newRw2Instance(BasicIo::AutoPtr io, bool create);
++    EXIV2API Image::UniquePtr newRw2Instance(BasicIo::UniquePtr io, bool create);
+ 
+     //! Check if the file iIo is a RW2 image.
+     EXIV2API bool isRw2Type(BasicIo& iIo, bool advance);
+diff --git a/include/exiv2/tags.hpp b/include/exiv2/tags.hpp
+index f6a63a3..1b3b307 100644
+--- a/include/exiv2/tags.hpp
++++ b/include/exiv2/tags.hpp
+@@ -140,7 +140,7 @@ namespace Exiv2 {
+     class EXIV2API ExifKey : public Key {
+     public:
+         //! Shortcut for an %ExifKey auto pointer.
+-        typedef std::auto_ptr<ExifKey> AutoPtr;
++        typedef std::unique_ptr<ExifKey> UniquePtr;
+ 
+         //! @name Creators
+         //@{
+@@ -202,7 +202,7 @@ namespace Exiv2 {
+         //! Return the default type id for this tag.
+         TypeId defaultTypeId() const;       // Todo: should be in the base class
+ 
+-        AutoPtr clone() const;
++        UniquePtr clone() const;
+         //! Return the index (unique id of this key within the original Exif data, 0 if not set)
+         int idx() const;
+         //@}
+@@ -214,7 +214,7 @@ namespace Exiv2 {
+     private:
+         // Pimpl idiom
+         struct Impl;
+-        std::auto_ptr<Impl> p_;
++        std::unique_ptr<Impl> p_;
+ 
+     }; // class ExifKey
+ 
+diff --git a/include/exiv2/tgaimage.hpp b/include/exiv2/tgaimage.hpp
+index 04b1d38..6a22858 100644
+--- a/include/exiv2/tgaimage.hpp
++++ b/include/exiv2/tgaimage.hpp
+@@ -66,7 +66,7 @@ namespace Exiv2 {
+               instance after it is passed to this method.  Use the Image::io()
+               method to get a temporary reference.
+          */
+-        explicit TgaImage(BasicIo::AutoPtr io);
++        explicit TgaImage(BasicIo::UniquePtr io);
+         //@}
+ 
+         //! @name Manipulators
+@@ -111,7 +111,7 @@ namespace Exiv2 {
+              Caller owns the returned object and the auto-pointer ensures that
+              it will be deleted.
+      */
+-    EXIV2API Image::AutoPtr newTgaInstance(BasicIo::AutoPtr io, bool create);
++    EXIV2API Image::UniquePtr newTgaInstance(BasicIo::UniquePtr io, bool create);
+ 
+     //! Check if the file iIo is a Targa v2 image.
+     EXIV2API bool isTgaType(BasicIo& iIo, bool advance);
+diff --git a/include/exiv2/tiffimage.hpp b/include/exiv2/tiffimage.hpp
+index c251806..1e618d4 100644
+--- a/include/exiv2/tiffimage.hpp
++++ b/include/exiv2/tiffimage.hpp
+@@ -68,7 +68,7 @@ namespace Exiv2 {
+           @param create Specifies if an existing image should be read (false)
+               or if a new file should be created (true).
+          */
+-        TiffImage(BasicIo::AutoPtr io, bool create);
++        TiffImage(BasicIo::UniquePtr io, bool create);
+         //@}
+ 
+         //! @name Manipulators
+@@ -204,7 +204,7 @@ namespace Exiv2 {
+              Caller owns the returned object and the auto-pointer ensures that
+              it will be deleted.
+      */
+-    EXIV2API Image::AutoPtr newTiffInstance(BasicIo::AutoPtr io, bool create);
++    EXIV2API Image::UniquePtr newTiffInstance(BasicIo::UniquePtr io, bool create);
+ 
+     //! Check if the file iIo is a TIFF image.
+     EXIV2API bool isTiffType(BasicIo& iIo, bool advance);
+diff --git a/include/exiv2/types.hpp b/include/exiv2/types.hpp
+index 11f13c3..09cbd4d 100644
+--- a/include/exiv2/types.hpp
++++ b/include/exiv2/types.hpp
+@@ -174,7 +174,7 @@ namespace Exiv2 {
+ 
+     /*!
+       @brief Auxiliary type to enable copies and assignments, similar to
+-             std::auto_ptr_ref. See http://www.josuttis.com/libbook/auto_ptr.html
++             std::unique_ptr_ref. See http://www.josuttis.com/libbook/auto_ptr.html
+              for a discussion.
+      */
+     struct EXIV2API DataBufRef {
+@@ -202,7 +202,7 @@ namespace Exiv2 {
+         DataBuf(const byte* pData, long size);
+         /*!
+           @brief Copy constructor. Transfers the buffer to the newly created
+-                 object similar to std::auto_ptr, i.e., the original object is
++                 object similar to std::unique_ptr, i.e., the original object is
+                  modified.
+          */
+         DataBuf(DataBuf& rhs);
+@@ -214,7 +214,7 @@ namespace Exiv2 {
+         //@{
+         /*!
+           @brief Assignment operator. Transfers the buffer and releases the
+-                 buffer at the original object similar to std::auto_ptr, i.e.,
++                 buffer at the original object similar to std::unique_ptr, i.e.,
+                  the original object is modified.
+          */
+         DataBuf& operator=(DataBuf& rhs);
+@@ -244,7 +244,7 @@ namespace Exiv2 {
+           @name Conversions
+ 
+           Special conversions with auxiliary type to enable copies
+-          and assignments, similar to those used for std::auto_ptr.
++          and assignments, similar to those used for std::unique_ptr.
+           See http://www.josuttis.com/libbook/auto_ptr.html for a discussion.
+          */
+         //@{
+diff --git a/include/exiv2/value.hpp b/include/exiv2/value.hpp
+index 3ec1af5..9dc4d39 100644
+--- a/include/exiv2/value.hpp
++++ b/include/exiv2/value.hpp
+@@ -51,7 +51,7 @@ namespace Exiv2 {
+     class EXIV2API Value {
+     public:
+         //! Shortcut for a %Value auto pointer.
+-        typedef std::auto_ptr<Value> AutoPtr;
++        typedef std::unique_ptr<Value> UniquePtr;
+ 
+         //! @name Creators
+         //@{
+@@ -107,7 +107,7 @@ namespace Exiv2 {
+                  The caller owns this copy and the auto-pointer ensures that
+                  it will be deleted.
+          */
+-        AutoPtr clone() const { return AutoPtr(clone_()); }
++        UniquePtr clone() const { return UniquePtr(clone_()); }
+         /*!
+           @brief Write value to a data buffer.
+ 
+@@ -224,7 +224,7 @@ namespace Exiv2 {
+           @return Auto-pointer to the newly created Value. The caller owns this
+                   copy and the auto-pointer ensures that it will be deleted.
+          */
+-        static AutoPtr create(TypeId typeId);
++        static UniquePtr create(TypeId typeId);
+ 
+     protected:
+         /*!
+@@ -253,7 +253,7 @@ namespace Exiv2 {
+     class EXIV2API DataValue : public Value {
+     public:
+         //! Shortcut for a %DataValue auto pointer.
+-        typedef std::auto_ptr<DataValue> AutoPtr;
++        typedef std::unique_ptr<DataValue> UniquePtr;
+ 
+         explicit DataValue(TypeId typeId =undefined);
+ 
+@@ -286,7 +286,7 @@ namespace Exiv2 {
+ 
+         //! @name Accessors
+         //@{
+-        AutoPtr clone() const { return AutoPtr(clone_()); }
++        UniquePtr clone() const { return UniquePtr(clone_()); }
+         /*!
+           @brief Write value to a character data buffer.
+ 
+@@ -335,7 +335,7 @@ namespace Exiv2 {
+     class EXIV2API StringValueBase : public Value {
+     public:
+         //! Shortcut for a %StringValueBase auto pointer.
+-        typedef std::auto_ptr<StringValueBase> AutoPtr;
++        typedef std::unique_ptr<StringValueBase> UniquePtr;
+ 
+         //! @name Creators
+         //@{
+@@ -372,7 +372,7 @@ namespace Exiv2 {
+ 
+         //! @name Accessors
+         //@{
+-        AutoPtr clone() const { return AutoPtr(clone_()); }
++        UniquePtr clone() const { return UniquePtr(clone_()); }
+         /*!
+           @brief Write value to a character data buffer.
+ 
+@@ -417,7 +417,7 @@ namespace Exiv2 {
+     class EXIV2API StringValue : public StringValueBase {
+     public:
+         //! Shortcut for a %StringValue auto pointer.
+-        typedef std::auto_ptr<StringValue> AutoPtr;
++        typedef std::unique_ptr<StringValue> UniquePtr;
+ 
+         //! @name Creators
+         //@{
+@@ -431,7 +431,7 @@ namespace Exiv2 {
+ 
+         //! @name Accessors
+         //@{
+-        AutoPtr clone() const { return AutoPtr(clone_()); }
++        UniquePtr clone() const { return UniquePtr(clone_()); }
+         //@}
+ 
+     private:
+@@ -449,7 +449,7 @@ namespace Exiv2 {
+     class EXIV2API AsciiValue : public StringValueBase {
+     public:
+         //! Shortcut for a %AsciiValue auto pointer.
+-        typedef std::auto_ptr<AsciiValue> AutoPtr;
++        typedef std::unique_ptr<AsciiValue> UniquePtr;
+ 
+         //! @name Creators
+         //@{
+@@ -474,7 +474,7 @@ namespace Exiv2 {
+ 
+         //! @name Accessors
+         //@{
+-        AutoPtr clone() const { return AutoPtr(clone_()); }
++        UniquePtr clone() const { return UniquePtr(clone_()); }
+         /*!
+           @brief Write the ASCII value up to the the first '\\0' character to an
+                  output stream.  Any further characters are ignored and not
+@@ -537,7 +537,7 @@ namespace Exiv2 {
+         }; // class CharsetInfo
+ 
+         //! Shortcut for a %CommentValue auto pointer.
+-        typedef std::auto_ptr<CommentValue> AutoPtr;
++        typedef std::unique_ptr<CommentValue> UniquePtr;
+ 
+         //! @name Creators
+         //@{
+@@ -572,7 +572,7 @@ namespace Exiv2 {
+ 
+         //! @name Accessors
+         //@{
+-        AutoPtr clone() const { return AutoPtr(clone_()); }
++        UniquePtr clone() const { return UniquePtr(clone_()); }
+         long copy(byte* buf, ByteOrder byteOrder) const;
+         /*!
+           @brief Write the comment in a format which can be read by
+@@ -624,7 +624,7 @@ namespace Exiv2 {
+     class EXIV2API XmpValue : public Value {
+     public:
+         //! Shortcut for a %XmpValue auto pointer.
+-        typedef std::auto_ptr<XmpValue> AutoPtr;
++        typedef std::unique_ptr<XmpValue> UniquePtr;
+ 
+         //! XMP array types.
+         enum XmpArrayType { xaNone, xaAlt, xaBag, xaSeq };
+@@ -715,7 +715,7 @@ namespace Exiv2 {
+     class EXIV2API XmpTextValue : public XmpValue {
+     public:
+         //! Shortcut for a %XmpTextValue auto pointer.
+-        typedef std::auto_ptr<XmpTextValue> AutoPtr;
++        typedef std::unique_ptr<XmpTextValue> UniquePtr;
+ 
+         //! @name Creators
+         //@{
+@@ -748,7 +748,7 @@ namespace Exiv2 {
+ 
+         //! @name Accessors
+         //@{
+-        AutoPtr clone() const;
++        UniquePtr clone() const;
+         long size() const;
+         virtual long count() const;
+         /*!
+@@ -797,7 +797,7 @@ namespace Exiv2 {
+     class EXIV2API XmpArrayValue : public XmpValue {
+     public:
+         //! Shortcut for a %XmpArrayValue auto pointer.
+-        typedef std::auto_ptr<XmpArrayValue> AutoPtr;
++        typedef std::unique_ptr<XmpArrayValue> UniquePtr;
+ 
+         //! @name Creators
+         //@{
+@@ -823,7 +823,7 @@ namespace Exiv2 {
+ 
+         //! @name Accessors
+         //@{
+-        AutoPtr clone() const;
++        UniquePtr clone() const;
+         virtual long count() const;
+         /*!
+           @brief Return the <EM>n</EM>-th component of the value as a string.
+@@ -890,7 +890,7 @@ namespace Exiv2 {
+     class EXIV2API LangAltValue : public XmpValue {
+     public:
+         //! Shortcut for a %LangAltValue auto pointer.
+-        typedef std::auto_ptr<LangAltValue> AutoPtr;
++        typedef std::unique_ptr<LangAltValue> UniquePtr;
+ 
+         //! @name Creators
+         //@{
+@@ -925,7 +925,7 @@ namespace Exiv2 {
+ 
+         //! @name Accessors
+         //@{
+-        AutoPtr clone() const;
++        UniquePtr clone() const;
+         virtual long count() const;
+         /*!
+           @brief Return the text value associated with the default language
+@@ -978,7 +978,7 @@ namespace Exiv2 {
+     class EXIV2API DateValue : public Value {
+     public:
+         //! Shortcut for a %DateValue auto pointer.
+-        typedef std::auto_ptr<DateValue> AutoPtr;
++        typedef std::unique_ptr<DateValue> UniquePtr;
+ 
+         //! @name Creators
+         //@{
+@@ -1031,7 +1031,7 @@ namespace Exiv2 {
+ 
+         //! @name Accessors
+         //@{
+-        AutoPtr clone() const { return AutoPtr(clone_()); }
++        UniquePtr clone() const { return UniquePtr(clone_()); }
+         /*!
+           @brief Write value to a character data buffer.
+ 
+@@ -1079,7 +1079,7 @@ namespace Exiv2 {
+     class EXIV2API TimeValue : public Value {
+     public:
+         //! Shortcut for a %TimeValue auto pointer.
+-        typedef std::auto_ptr<TimeValue> AutoPtr;
++        typedef std::unique_ptr<TimeValue> UniquePtr;
+ 
+         //! @name Creators
+         //@{
+@@ -1138,7 +1138,7 @@ namespace Exiv2 {
+ 
+         //! @name Accessors
+         //@{
+-        AutoPtr clone() const { return AutoPtr(clone_()); }
++        UniquePtr clone() const { return UniquePtr(clone_()); }
+         /*!
+           @brief Write value to a character data buffer.
+ 
+@@ -1235,7 +1235,7 @@ namespace Exiv2 {
+     class ValueType : public Value {
+     public:
+         //! Shortcut for a %ValueType\<T\> auto pointer.
+-        typedef std::auto_ptr<ValueType<T> > AutoPtr;
++        typedef std::unique_ptr<ValueType<T> > UniquePtr;
+ 
+         //! @name Creators
+         //@{
+@@ -1275,7 +1275,7 @@ namespace Exiv2 {
+ 
+         //! @name Accessors
+         //@{
+-        AutoPtr clone() const { return AutoPtr(clone_()); }
++        UniquePtr clone() const { return UniquePtr(clone_()); }
+         virtual long copy(byte* buf, ByteOrder byteOrder) const;
+         virtual long count() const;
+         virtual long size() const;
+@@ -1521,7 +1521,10 @@ namespace Exiv2 {
+ 
+     template<typename T>
+     ValueType<T>::ValueType(const ValueType<T>& rhs)
+-        : Value(rhs), value_(rhs.value_), pDataArea_(0), sizeDataArea_(0)
++        : Value(rhs)
++        , value_(rhs.value_)
++        , pDataArea_(nullptr)
++        , sizeDataArea_(0)
+     {
+         if (rhs.sizeDataArea_ > 0) {
+             pDataArea_ = new byte[rhs.sizeDataArea_];
+diff --git a/include/exiv2/webpimage.hpp b/include/exiv2/webpimage.hpp
+index 4edccbe..17437f4 100644
+--- a/include/exiv2/webpimage.hpp
++++ b/include/exiv2/webpimage.hpp
+@@ -57,7 +57,7 @@ namespace Exiv2 {
+               instance after it is passed to this method. Use the Image::io()
+               method to get a temporary reference.
+          */
+-        WebPImage(BasicIo::AutoPtr io);
++        WebPImage(BasicIo::UniquePtr io);
+         //@}
+ 
+         //! @name Manipulators
+@@ -126,7 +126,7 @@ namespace Exiv2 {
+           Caller owns the returned object and the auto-pointer ensures that
+           it will be deleted.
+      */
+-    EXIV2API Image::AutoPtr newWebPInstance(BasicIo::AutoPtr io, bool create);
++    EXIV2API Image::UniquePtr newWebPInstance(BasicIo::UniquePtr io, bool create);
+ 
+     //! Check if the file iIo is a WebP Video.
+     EXIV2API bool isWebPType(BasicIo& iIo, bool advance);
+diff --git a/include/exiv2/xmp_exiv2.hpp b/include/exiv2/xmp_exiv2.hpp
+index 8934ebe..6cb3620 100644
+--- a/include/exiv2/xmp_exiv2.hpp
++++ b/include/exiv2/xmp_exiv2.hpp
+@@ -139,14 +139,14 @@ namespace Exiv2 {
+         long toLong(long n =0) const;
+         float toFloat(long n =0) const;
+         Rational toRational(long n =0) const;
+-        Value::AutoPtr getValue() const;
++        Value::UniquePtr getValue() const;
+         const Value& value() const;
+         //@}
+ 
+     private:
+         // Pimpl idiom
+         struct Impl;
+-        std::auto_ptr<Impl> p_;
++        std::unique_ptr<Impl> p_;
+ 
+     }; // class Xmpdatum
+ 
+diff --git a/include/exiv2/xmpsidecar.hpp b/include/exiv2/xmpsidecar.hpp
+index a1be374..b1efb19 100644
+--- a/include/exiv2/xmpsidecar.hpp
++++ b/include/exiv2/xmpsidecar.hpp
+@@ -58,7 +58,7 @@ namespace Exiv2 {
+           @param create Specifies if an existing image should be read (false)
+               or if a new image should be created (true).
+          */
+-        XmpSidecar(BasicIo::AutoPtr io, bool create);
++        XmpSidecar(BasicIo::UniquePtr io, bool create);
+         //@}
+ 
+         //! @name Manipulators
+@@ -100,7 +100,7 @@ namespace Exiv2 {
+              Caller owns the returned object and the auto-pointer ensures that
+              it will be deleted.
+      */
+-    EXIV2API Image::AutoPtr newXmpInstance(BasicIo::AutoPtr io, bool create);
++    EXIV2API Image::UniquePtr newXmpInstance(BasicIo::UniquePtr io, bool create);
+ 
+     //! Check if the file iIo is an XMP sidecar file.
+     EXIV2API bool isXmpType(BasicIo& iIo, bool advance);
+diff --git a/samples/addmoddel.cpp b/samples/addmoddel.cpp
+index 98a112f..7442fa1 100644
+--- a/samples/addmoddel.cpp
++++ b/samples/addmoddel.cpp
+@@ -57,7 +57,7 @@ try {
+     std::cout << "Added a few tags the quick way.\n";
+ 
+     // Create a ASCII string value (note the use of create)
+-    Exiv2::Value::AutoPtr v = Exiv2::Value::create(Exiv2::asciiString);
++    Exiv2::Value::UniquePtr v = Exiv2::Value::create(Exiv2::asciiString);
+     // Set the value to a string
+     v->read("1999:12:31 23:59:59");
+     // Add the value together with its key to the Exif data container
+@@ -66,7 +66,7 @@ try {
+     std::cout << "Added key \"" << key << "\", value \"" << *v << "\"\n";
+ 
+     // Now create a more interesting value (without using the create method)
+-    Exiv2::URationalValue::AutoPtr rv(new Exiv2::URationalValue);
++    Exiv2::URationalValue::UniquePtr rv(new Exiv2::URationalValue);
+     // Set two rational components from a string
+     rv->read("1/2 1/3");
+     // Add more elements through the extended interface of rational value
+@@ -98,7 +98,7 @@ try {
+     // Downcast the Value pointer to its actual type
+     Exiv2::URationalValue* prv = dynamic_cast<Exiv2::URationalValue*>(v.release());
+     if (prv == 0) throw Exiv2::Error(Exiv2::kerErrorMessage, "Downcast failed");
+-    rv = Exiv2::URationalValue::AutoPtr(prv);
++    rv = Exiv2::URationalValue::UniquePtr(prv);
+     // Modify the value directly through the interface of URationalValue
+     rv->value_.at(2) = std::make_pair(88,77);
+     // Copy the modified value back to the metadatum
+@@ -118,7 +118,7 @@ try {
+ 
+     // *************************************************************************
+     // Finally, write the remaining Exif data to the image file
+-    Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(file);
++    Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(file);
+     assert(image.get() != 0);
+ 
+     image->setExifData(exifData);
+diff --git a/samples/convert-test.cpp b/samples/convert-test.cpp
+index 53a2121..51d1318 100644
+--- a/samples/convert-test.cpp
++++ b/samples/convert-test.cpp
+@@ -38,7 +38,7 @@ try {
+         return 1;
+     }
+ 
+-    Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(argv[1]);
++    Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(argv[1]);
+     assert(image.get() != 0);
+     image->readMetadata();
+ 
+diff --git a/samples/easyaccess-test.cpp b/samples/easyaccess-test.cpp
+index dde358a..ecc3993 100644
+--- a/samples/easyaccess-test.cpp
++++ b/samples/easyaccess-test.cpp
+@@ -82,7 +82,7 @@ try {
+         return 1;
+     }
+ 
+-    Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(argv[1]);
++    Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(argv[1]);
+     assert (image.get() != 0);
+     image->readMetadata();
+     Exiv2::ExifData& ed = image->exifData();
+diff --git a/samples/exifcomment.cpp b/samples/exifcomment.cpp
+index adefefe..df7fb0a 100644
+--- a/samples/exifcomment.cpp
++++ b/samples/exifcomment.cpp
+@@ -41,7 +41,7 @@ try {
+         return 1;
+     }
+ 
+-    Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(argv[1]);
++    Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(argv[1]);
+     assert (image.get() != 0);
+     image->readMetadata();
+     Exiv2::ExifData &exifData = image->exifData();
+diff --git a/samples/exifdata-test.cpp b/samples/exifdata-test.cpp
+index 60aa609..a915609 100644
+--- a/samples/exifdata-test.cpp
++++ b/samples/exifdata-test.cpp
+@@ -44,7 +44,7 @@ try {
+     }
+     std::string file(argv[1]);
+ 
+-    Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(file);
++    Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(file);
+     assert (image.get() != 0);
+     image->readMetadata();
+ 
+@@ -117,7 +117,7 @@ catch (Exiv2::AnyError& e) {
+ 
+ void write(const std::string& file, Exiv2::ExifData& ed)
+ {
+-    Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(file);
++    Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(file);
+     assert (image.get() != 0);
+     image->setExifData(ed);
+     image->writeMetadata();
+@@ -125,7 +125,7 @@ void write(const std::string& file, Exiv2::ExifData& ed)
+ 
+ void print(const std::string& file)
+ {
+-    Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(file);
++    Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(file);
+     assert (image.get() != 0);
+     image->readMetadata();
+ 
+diff --git a/samples/exifdata.cpp b/samples/exifdata.cpp
+index 63f6f0e..00985dd 100644
+--- a/samples/exifdata.cpp
++++ b/samples/exifdata.cpp
+@@ -197,7 +197,7 @@ int main(int argc,const char* argv[])
+ 	}
+ 
+ 	if ( !result ) try {
+-		Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(file);
++		Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(file);
+ 		assert(image.get() != 0);
+ 		image->readMetadata();
+ 		Exiv2::ExifData &exifData = image->exifData();
+diff --git a/samples/exifprint.cpp b/samples/exifprint.cpp
+index 5dd2168..6ce2093 100644
+--- a/samples/exifprint.cpp
++++ b/samples/exifprint.cpp
+@@ -88,7 +88,7 @@ try {
+         return 0;
+     }
+ 
+-    Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(file);
++    Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(file);
+     assert(image.get() != 0);
+     image->readMetadata();
+ 
+diff --git a/samples/exifvalue.cpp b/samples/exifvalue.cpp
+index 522efef..15485af 100644
+--- a/samples/exifvalue.cpp
++++ b/samples/exifvalue.cpp
+@@ -42,7 +42,7 @@ int main(int argc, char* const argv[])
+     const char* file = argv[1];
+     const char* key  = argv[2];
+ 
+-    Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(file);
++    Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(file);
+     assert(image.get() != 0);
+     image->readMetadata();
+     Exiv2::ExifData &exifData = image->exifData();
+diff --git a/samples/exiv2json.cpp b/samples/exiv2json.cpp
+index 2dc15f5..c2f17a5 100644
+--- a/samples/exiv2json.cpp
++++ b/samples/exiv2json.cpp
+@@ -302,7 +302,7 @@ int main(int argc, char* const argv[])
+         while      (opt[0] == '-') opt++ ; // skip past leading -'s
+         char        option = opt[0];
+ 
+-        Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(path);
++        Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path);
+         assert(image.get() != 0);
+         image->readMetadata();
+ 
+diff --git a/samples/geotag.cpp b/samples/geotag.cpp
+index dbbfe25..38a6095 100644
+--- a/samples/geotag.cpp
++++ b/samples/geotag.cpp
+@@ -614,7 +614,7 @@ bool readImage(const char* path,Options& /* options */)
+     bool bResult = false ;
+ 
+     try {
+-        Image::AutoPtr image = ImageFactory::open(path);
++        Image::UniquePtr image = ImageFactory::open(path);
+         if ( image.get() ) {
+             image->readMetadata();
+             ExifData &exifData = image->exifData();
+@@ -640,7 +640,7 @@ time_t readImageTime(const std::string& path,std::string* pS=NULL)
+ 
+     do {
+         try {
+-            Image::AutoPtr image = ImageFactory::open(path);
++            Image::UniquePtr image = ImageFactory::open(path);
+             if ( image.get() ) {
+                 image->readMetadata();
+                 ExifData &exifData = image->exifData();
+@@ -921,7 +921,7 @@ int main(int argc,const char* argv[])
+             try {
+                 time_t t       = readImageTime(path,&stamp) ;
+                 Position* pPos = searchTimeDict(gTimeDict,t,Position::deltaMax_);
+-                Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(path);
++                Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path);
+                 if ( image.get() ) {
+                     image->readMetadata();
+                     Exiv2::ExifData& exifData = image->exifData();
+diff --git a/samples/iotest.cpp b/samples/iotest.cpp
+index 7ac45e1..402a620 100644
+--- a/samples/iotest.cpp
++++ b/samples/iotest.cpp
+@@ -69,7 +69,7 @@ int main(int argc, char* const argv[])
+             Exiv2::byte* bytes = blocksize>0 ? new Exiv2::byte[blocksize]: NULL;
+ 
+             // copy fileIn from a remote location.
+-            BasicIo::AutoPtr io = Exiv2::ImageFactory::createIo(fr);
++            BasicIo::UniquePtr io = Exiv2::ImageFactory::createIo(fr);
+             if ( io->open() != 0 ) {
+                 Error(Exiv2::kerFileOpenFailed, io->path(), "rb", strError());
+             }
+diff --git a/samples/iptceasy.cpp b/samples/iptceasy.cpp
+index 2217be1..9363f4b 100644
+--- a/samples/iptceasy.cpp
++++ b/samples/iptceasy.cpp
+@@ -57,7 +57,7 @@ try {
+     std::cout << "Time sent: " << iptcData["Iptc.Envelope.TimeSent"] << "\n";
+ 
+     // Open image file
+-    Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(file);
++    Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(file);
+     assert (image.get() != 0);
+ 
+     // Set IPTC data and write it to the file
+diff --git a/samples/iptcprint.cpp b/samples/iptcprint.cpp
+index 29af8f4..51cc621 100644
+--- a/samples/iptcprint.cpp
++++ b/samples/iptcprint.cpp
+@@ -38,7 +38,7 @@ try {
+         return 1;
+     }
+ 
+-    Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(argv[1]);
++    Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(argv[1]);
+     assert (image.get() != 0);
+     image->readMetadata();
+ 
+diff --git a/samples/iptctest.cpp b/samples/iptctest.cpp
+index 83c6248..5e38980 100644
+--- a/samples/iptctest.cpp
++++ b/samples/iptctest.cpp
+@@ -48,7 +48,7 @@ int main(int argc, char* const argv[])
+             return 1;
+         }
+ 
+-        Image::AutoPtr image = ImageFactory::open(argv[1]);
++        Image::UniquePtr image = ImageFactory::open(argv[1]);
+         assert (image.get() != 0);
+         image->readMetadata();
+ 
+@@ -120,7 +120,7 @@ void processAdd(const std::string& line, int num, IptcData &iptcData)
+         data = data.substr(1, data.size()-2);
+     }
+     TypeId type = IptcDataSets::dataSetType(iptcKey.tag(), iptcKey.record());
+-    Value::AutoPtr value = Value::create(type);
++    Value::UniquePtr value = Value::create(type);
+     value->read(data);
+ 
+     int rc = iptcData.add(iptcKey, value.get());
+@@ -171,7 +171,7 @@ void processModify(const std::string& line, int num, IptcData &iptcData)
+         data = data.substr(1, data.size()-2);
+     }
+     TypeId type = IptcDataSets::dataSetType(iptcKey.tag(), iptcKey.record());
+-    Value::AutoPtr value = Value::create(type);
++    Value::UniquePtr value = Value::create(type);
+     value->read(data);
+ 
+     IptcData::iterator iter = iptcData.findKey(iptcKey);
+diff --git a/samples/largeiptc-test.cpp b/samples/largeiptc-test.cpp
+index a0e494d..8725fd5 100644
+--- a/samples/largeiptc-test.cpp
++++ b/samples/largeiptc-test.cpp
+@@ -53,7 +53,7 @@ int main(int argc, char* const argv[])
+         }
+ 
+         // Read metadata from file
+-        Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(file);
++        Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(file);
+         assert(image.get() != 0);
+         image->readMetadata();
+ 
+diff --git a/samples/metacopy.cpp b/samples/metacopy.cpp
+index a8402d7..3995227 100644
+--- a/samples/metacopy.cpp
++++ b/samples/metacopy.cpp
+@@ -49,15 +49,15 @@ try {
+     }
+ 
+     // Use MemIo to increase test coverage.
+-    Exiv2::BasicIo::AutoPtr fileIo(new Exiv2::FileIo(params.read_));
+-    Exiv2::BasicIo::AutoPtr memIo(new Exiv2::MemIo);
++    Exiv2::BasicIo::UniquePtr fileIo(new Exiv2::FileIo(params.read_));
++    Exiv2::BasicIo::UniquePtr memIo(new Exiv2::MemIo);
+     memIo->transfer(*fileIo);
+ 
+-    Exiv2::Image::AutoPtr readImg = Exiv2::ImageFactory::open(memIo);
++    Exiv2::Image::UniquePtr readImg = Exiv2::ImageFactory::open(std::move(memIo));
+     assert(readImg.get() != 0);
+     readImg->readMetadata();
+ 
+-    Exiv2::Image::AutoPtr writeImg = Exiv2::ImageFactory::open(params.write_);
++    Exiv2::Image::UniquePtr writeImg = Exiv2::ImageFactory::open(params.write_);
+     assert(writeImg.get() != 0);
+     if (params.preserve_) writeImg->readMetadata();
+     if (params.iptc_) {
+diff --git a/samples/mrwthumb.cpp b/samples/mrwthumb.cpp
+index 39dca0e..f29c218 100644
+--- a/samples/mrwthumb.cpp
++++ b/samples/mrwthumb.cpp
+@@ -38,7 +38,7 @@ int main(int argc, char* const argv[])
+             return 1;
+         }
+ 
+-        Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(argv[1]);
++        Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(argv[1]);
+         assert(image.get() != 0);
+         image->readMetadata();
+ 
+diff --git a/samples/mt-test.cpp b/samples/mt-test.cpp
+index 41c3419..624cd0e 100644
+--- a/samples/mt-test.cpp
++++ b/samples/mt-test.cpp
+@@ -53,7 +53,7 @@ void reportExifMetadataCount(int n,const char* argv[])
+ 
+ 	// count the exif metadata in the file
+ 	try {
+-		Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(argv[n]);
++		Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(argv[n]);
+ 		assert(image.get() != 0);
+ 		image->readMetadata();
+ 
+diff --git a/samples/prevtest.cpp b/samples/prevtest.cpp
+index 07ee33c..d4b65f7 100644
+--- a/samples/prevtest.cpp
++++ b/samples/prevtest.cpp
+@@ -39,7 +39,7 @@ try {
+     }
+     std::string filename(argv[1]);
+ 
+-    Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(filename);
++    Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(filename);
+     assert(image.get() != 0);
+     image->readMetadata();
+ 
+diff --git a/samples/remotetest.cpp b/samples/remotetest.cpp
+index 61ce5ba..9078316 100644
+--- a/samples/remotetest.cpp
++++ b/samples/remotetest.cpp
+@@ -58,19 +58,19 @@ try {
+     exifData["Exif.Image.Make"]         = "Canon";                 // AsciiValue
+     exifData["Exif.Canon.OwnerName"]    = "Tuan";                  // UShortValue
+     exifData["Exif.CanonCs.LensType"]   = uint16_t(65535);         // LongValue
+-    Exiv2::Value::AutoPtr v = Exiv2::Value::create(Exiv2::asciiString);
++    Exiv2::Value::UniquePtr v = Exiv2::Value::create(Exiv2::asciiString);
+     v->read("2013:06:09 14:30:30");
+     Exiv2::ExifKey key("Exif.Image.DateTime");
+     exifData.add(key, v.get());
+ 
+-    Exiv2::Image::AutoPtr writeTest = Exiv2::ImageFactory::open(file, useCurlFromExiv2TestApps);
++    Exiv2::Image::UniquePtr writeTest = Exiv2::ImageFactory::open(file, useCurlFromExiv2TestApps);
+     assert(writeTest.get() != 0);
+     writeTest->setExifData(exifData);
+     writeTest->writeMetadata();
+ 
+     // read the result to make sure everything fine
+     std::cout << "Print out the new metadata ...\n";
+-    Exiv2::Image::AutoPtr readTest = Exiv2::ImageFactory::open(file, useCurlFromExiv2TestApps);
++    Exiv2::Image::UniquePtr readTest = Exiv2::ImageFactory::open(file, useCurlFromExiv2TestApps);
+     assert(readTest.get() != 0);
+     readTest->readMetadata();
+     Exiv2::ExifData &exifReadData = readTest->exifData();
+diff --git a/samples/tiff-test.cpp b/samples/tiff-test.cpp
+index b506961..fe9cba5 100644
+--- a/samples/tiff-test.cpp
++++ b/samples/tiff-test.cpp
+@@ -91,7 +91,7 @@ void mini1(const char* path)
+ 
+ void mini9(const char* path)
+ {
+-    TiffImage tiffImage(BasicIo::AutoPtr(new FileIo(path)), false);
++    TiffImage tiffImage(BasicIo::UniquePtr(new FileIo(path)), false);
+     tiffImage.readMetadata();
+ 
+     std::cout << "MIME type:  " << tiffImage.mimeType() << "\n";
+diff --git a/samples/toexv.cpp b/samples/toexv.cpp
+index 290c46b..1c3f15b 100644
+--- a/samples/toexv.cpp
++++ b/samples/toexv.cpp
+@@ -26,7 +26,7 @@
+ #include "utils.hpp"
+ #include "toexv.hpp"
+ 
+-static size_t exifMetadataCount(Exiv2::Image::AutoPtr& image)
++static size_t exifMetadataCount(Exiv2::Image::UniquePtr& image)
+ {
+ 	size_t result = 0 ;
+ 	Exiv2::ExifData&                  exif = image->exifData();
+@@ -51,7 +51,7 @@ int main(int argc, char* const argv[])
+ 		if (params.getopt(argc, argv)) return params.usage();
+ 		if (params.help_             ) return params.help();
+ 
+-		Exiv2::Image::AutoPtr readImage = Exiv2::ImageFactory::open(params.read_);
++		Exiv2::Image::UniquePtr readImage = Exiv2::ImageFactory::open(params.read_);
+ 		assert(readImage.get() != 0);
+ 		readImage->readMetadata();
+ 
+@@ -59,8 +59,8 @@ int main(int argc, char* const argv[])
+ 			std::cout << "exifMetadataCount = " << exifMetadataCount(readImage) << std::endl;
+ 
+ 			// create an in-memory file and write the metadata
+-			Exiv2::BasicIo::AutoPtr memIo   (new Exiv2::MemIo());
+-			Exiv2::Image::AutoPtr   memImage(new Exiv2::ExvImage(memIo,true));
++			Exiv2::BasicIo::UniquePtr memIo   (new Exiv2::MemIo());
++			Exiv2::Image::UniquePtr   memImage(new Exiv2::ExvImage(memIo,true));
+ 			memImage->setMetadata  (*readImage);
+ 			memImage->writeMetadata();
+ 
+@@ -73,8 +73,8 @@ int main(int argc, char* const argv[])
+ 			std::cout << "size = " << size << std::endl;
+ 
+ 			// create an in-memory file with buff and read the metadata into buffImage
+-			Exiv2::BasicIo::AutoPtr buffIo   (new Exiv2::MemIo(buff,size));
+-			Exiv2::Image::AutoPtr   buffImage(new Exiv2::ExvImage(buffIo,false));
++			Exiv2::BasicIo::UniquePtr buffIo   (new Exiv2::MemIo(buff,size));
++			Exiv2::Image::UniquePtr   buffImage(new Exiv2::ExvImage(buffIo,false));
+ 			assert(buffImage.get() != 0);
+ 			buffImage->readMetadata();
+ 
+@@ -82,12 +82,12 @@ int main(int argc, char* const argv[])
+ 
+ 		} else if ( params.write_ != "-" ) {
+ 			// create a file and write the metadata
+-			Exiv2::Image::AutoPtr writeImage = Exiv2::ImageFactory::create(Exiv2::ImageType::exv,params.write_);
++			Exiv2::Image::UniquePtr writeImage = Exiv2::ImageFactory::create(Exiv2::ImageType::exv,params.write_);
+ 			params.copyMetadata(readImage,writeImage);
+ 		} else {
+ 			// create an in-memory file
+-			Exiv2::BasicIo::AutoPtr memIo   (new Exiv2::MemIo());
+-			Exiv2::Image::AutoPtr   memImage(new Exiv2::ExvImage(memIo,true));
++			Exiv2::BasicIo::UniquePtr memIo   (new Exiv2::MemIo());
++			Exiv2::Image::UniquePtr   memImage(new Exiv2::ExvImage(memIo,true));
+ 			params.copyMetadata(readImage,memImage);
+ 
+ 			// read a few bytes from the in-memory file
+@@ -129,7 +129,7 @@ Params::Params( const char* opts)
+ , usage_(false)
+ {}
+ 
+-void Params::copyMetadata(Exiv2::Image::AutoPtr& readImage,Exiv2::Image::AutoPtr& writeImage)
++void Params::copyMetadata(Exiv2::Image::UniquePtr& readImage,Exiv2::Image::UniquePtr& writeImage)
+ {
+ 	if (all_    ) writeImage->setMetadata  (*readImage);
+ 	if (iptc_   ) writeImage->setIptcData  ( readImage->iptcData());
+diff --git a/samples/toexv.hpp b/samples/toexv.hpp
+index 690cf14..8a8a7bc 100644
+--- a/samples/toexv.hpp
++++ b/samples/toexv.hpp
+@@ -68,7 +68,7 @@ public:
+     int help(std::ostream& os =std::cout) const;
+ 
+     //! copy metadata from one image to another.
+-    void copyMetadata(Exiv2::Image::AutoPtr& readImage,Exiv2::Image::AutoPtr& writeImage);
++    void copyMetadata(Exiv2::Image::UniquePtr& readImage,Exiv2::Image::UniquePtr& writeImage);
+ 
+ }; // class Params
+ 
+diff --git a/samples/write-test.cpp b/samples/write-test.cpp
+index f5651b6..df10de6 100644
+--- a/samples/write-test.cpp
++++ b/samples/write-test.cpp
+@@ -170,7 +170,7 @@ void testCase(const std::string& file1,
+     ExifKey ek(key);
+ 
+     //Open first image
+-    Image::AutoPtr image1 = ImageFactory::open(file1);
++    Image::UniquePtr image1 = ImageFactory::open(file1);
+     assert(image1.get() != 0);
+ 
+     // Load existing metadata
+@@ -186,7 +186,7 @@ void testCase(const std::string& file1,
+     pos->setValue(value);
+ 
+     // Open second image
+-    Image::AutoPtr image2 = ImageFactory::open(file2);
++    Image::UniquePtr image2 = ImageFactory::open(file2);
+     assert(image2.get() != 0);
+ 
+     image2->setExifData(image1->exifData());
+diff --git a/samples/write2-test.cpp b/samples/write2-test.cpp
+index 724e473..42c6928 100644
+--- a/samples/write2-test.cpp
++++ b/samples/write2-test.cpp
+@@ -48,19 +48,19 @@ int main(int argc, char* const argv[])
+     Exiv2::ExifData ed1;
+     ed1["Exif.Image.Model"] = "Test 1";
+ 
+-    Exiv2::Value::AutoPtr v1 = Exiv2::Value::create(Exiv2::unsignedShort);
++    Exiv2::Value::UniquePtr v1 = Exiv2::Value::create(Exiv2::unsignedShort);
+     v1->read("160 161 162 163");
+     ed1.add(Exiv2::ExifKey("Exif.Image.SamplesPerPixel"), v1.get());
+ 
+-    Exiv2::Value::AutoPtr v2 = Exiv2::Value::create(Exiv2::signedLong);
++    Exiv2::Value::UniquePtr v2 = Exiv2::Value::create(Exiv2::signedLong);
+     v2->read("-2 -1 0 1");
+     ed1.add(Exiv2::ExifKey("Exif.Image.XResolution"), v2.get());
+ 
+-    Exiv2::Value::AutoPtr v3 = Exiv2::Value::create(Exiv2::signedRational);
++    Exiv2::Value::UniquePtr v3 = Exiv2::Value::create(Exiv2::signedRational);
+     v3->read("-2/3 -1/3 0/3 1/3");
+     ed1.add(Exiv2::ExifKey("Exif.Image.YResolution"), v3.get());
+ 
+-    Exiv2::Value::AutoPtr v4 = Exiv2::Value::create(Exiv2::undefined);
++    Exiv2::Value::UniquePtr v4 = Exiv2::Value::create(Exiv2::undefined);
+     v4->read("255 254 253 252");
+     ed1.add(Exiv2::ExifKey("Exif.Image.WhitePoint"), v4.get());
+ 
+@@ -87,7 +87,7 @@ int main(int argc, char* const argv[])
+     print(file);
+ 
+     std::cout <<"\n----- Non-intrusive writing of special Canon MakerNote tags\n";
+-    Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(file);
++    Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(file);
+     assert(image.get() != 0);
+     image->readMetadata();
+ 
+@@ -203,7 +203,7 @@ int main(int argc, char* const argv[])
+     std::cout <<"\n----- One IFD0 and one IFD1 tag\n";
+     Exiv2::ExifData ed7;
+     ed7["Exif.Thumbnail.Artist"] = "Test 7";
+-    Exiv2::Value::AutoPtr v5 = Exiv2::Value::create(Exiv2::unsignedShort);
++    Exiv2::Value::UniquePtr v5 = Exiv2::Value::create(Exiv2::unsignedShort);
+     v5->read("160 161 162 163");
+     ed7.add(Exiv2::ExifKey("Exif.Image.SamplesPerPixel"), v5.get());
+     write(file, ed7);
+@@ -219,7 +219,7 @@ catch (Exiv2::AnyError& e) {
+ 
+ void write(const std::string& file, Exiv2::ExifData& ed)
+ {
+-    Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(file);
++    Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(file);
+     assert(image.get() != 0);
+ 
+     image->setExifData(ed);
+@@ -228,7 +228,7 @@ void write(const std::string& file, Exiv2::ExifData& ed)
+ 
+ void print(const std::string& file)
+ {
+-    Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(file);
++    Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(file);
+     assert(image.get() != 0);
+     image->readMetadata();
+ 
+diff --git a/samples/xmpdump.cpp b/samples/xmpdump.cpp
+index 9780392..5c88459 100644
+--- a/samples/xmpdump.cpp
++++ b/samples/xmpdump.cpp
+@@ -39,7 +39,7 @@ int main(int argc, char* const argv[])
+             return 1;
+         }
+ 
+-        Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(argv[1]);
++        Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(argv[1]);
+         assert(image.get() != 0);
+         image->readMetadata();
+ 
+diff --git a/samples/xmpprint.cpp b/samples/xmpprint.cpp
+index d28a7e4..8df3d95 100644
+--- a/samples/xmpprint.cpp
++++ b/samples/xmpprint.cpp
+@@ -48,7 +48,7 @@ int main(int argc, char** argv)
+         return 1;
+       }
+ 
+-    Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(argv[1]);
++    Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(argv[1]);
+     assert (image.get() != 0);
+     image->readMetadata();
+ 
+diff --git a/samples/xmpsample.cpp b/samples/xmpsample.cpp
+index 94e6d99..021878e 100644
+--- a/samples/xmpsample.cpp
++++ b/samples/xmpsample.cpp
+@@ -136,7 +136,7 @@ try {
+     // properties and language alternatives.
+ 
+     // Add a simple XMP property in a known namespace
+-    Exiv2::Value::AutoPtr v = Exiv2::Value::create(Exiv2::xmpText);
++    Exiv2::Value::UniquePtr v = Exiv2::Value::create(Exiv2::xmpText);
+     v->read("image/jpeg");
+     xmpData.add(Exiv2::XmpKey("Xmp.dc.format"), v.get());
+ 
+diff --git a/src/actions.cpp b/src/actions.cpp
+index f234484..4e68960 100644
+--- a/src/actions.cpp
++++ b/src/actions.cpp
+@@ -166,9 +166,9 @@ namespace Action {
+     {
+     }
+ 
+-    Task::AutoPtr Task::clone() const
++    Task::UniquePtr Task::clone() const
+     {
+-        return AutoPtr(clone_());
++        return UniquePtr(clone_());
+     }
+ 
+     TaskFactory* TaskFactory::instance_ = 0;
+@@ -193,7 +193,7 @@ namespace Action {
+         }
+     } //TaskFactory::cleanup
+ 
+-    void TaskFactory::registerTask(TaskType type, Task::AutoPtr task)
++    void TaskFactory::registerTask(TaskType type, Task::UniquePtr task)
+     {
+         Registry::iterator i = registry_.find(type);
+         if (i != registry_.end()) {
+@@ -205,25 +205,25 @@ namespace Action {
+     TaskFactory::TaskFactory()
+     {
+         // Register a prototype of each known task
+-        registerTask(adjust,  Task::AutoPtr(new Adjust));
+-        registerTask(print,   Task::AutoPtr(new Print));
+-        registerTask(rename,  Task::AutoPtr(new Rename));
+-        registerTask(erase,   Task::AutoPtr(new Erase));
+-        registerTask(extract, Task::AutoPtr(new Extract));
+-        registerTask(insert,  Task::AutoPtr(new Insert));
+-        registerTask(modify,  Task::AutoPtr(new Modify));
+-        registerTask(fixiso,  Task::AutoPtr(new FixIso));
+-        registerTask(fixcom,  Task::AutoPtr(new FixCom));
++        registerTask(adjust,  Task::UniquePtr(new Adjust));
++        registerTask(print,   Task::UniquePtr(new Print));
++        registerTask(rename,  Task::UniquePtr(new Rename));
++        registerTask(erase,   Task::UniquePtr(new Erase));
++        registerTask(extract, Task::UniquePtr(new Extract));
++        registerTask(insert,  Task::UniquePtr(new Insert));
++        registerTask(modify,  Task::UniquePtr(new Modify));
++        registerTask(fixiso,  Task::UniquePtr(new FixIso));
++        registerTask(fixcom,  Task::UniquePtr(new FixCom));
+     } // TaskFactory c'tor
+ 
+-    Task::AutoPtr TaskFactory::create(TaskType type)
++    Task::UniquePtr TaskFactory::create(TaskType type)
+     {
+         Registry::const_iterator i = registry_.find(type);
+         if (i != registry_.end() && i->second != 0) {
+             Task* t = i->second;
+             return t->clone();
+         }
+-        return Task::AutoPtr(0);
++        return nullptr;
+     } // TaskFactory::create
+ 
+     Print::~Print()
+@@ -305,7 +305,7 @@ namespace Action {
+                       << _("Failed to open the file\n");
+             return -1;
+         }
+-        Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(path_);
++        Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path_);
+         assert(image.get() != 0);
+         image->readMetadata();
+         Exiv2::ExifData& exifData = image->exifData();
+@@ -441,7 +441,7 @@ namespace Action {
+                       << ": " << _("Failed to open the file\n");
+             return -1;
+         }
+-        Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(path_);
++        Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path_);
+         assert(image.get() != 0);
+         image->readMetadata();
+         // Set defaults for metadata types and data columns
+@@ -661,7 +661,7 @@ namespace Action {
+                       << ": " << _("Failed to open the file\n");
+             return -1;
+         }
+-        Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(path_);
++        Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path_);
+         assert(image.get() != 0);
+         image->readMetadata();
+         if (Params::instance().verbose_) {
+@@ -678,7 +678,7 @@ namespace Action {
+                       << ": " << _("Failed to open the file\n");
+             return -1;
+         }
+-        Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(path_);
++        Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path_);
+         assert(image.get() != 0);
+         image->readMetadata();
+         bool const manyFiles = Params::instance().files_.size() > 1;
+@@ -701,9 +701,9 @@ namespace Action {
+         return 0;
+     } // Print::printPreviewList
+ 
+-    Print::AutoPtr Print::clone() const
++    Print::UniquePtr Print::clone() const
+     {
+-        return AutoPtr(clone_());
++        return UniquePtr(clone_());
+     }
+ 
+     Print* Print::clone_() const
+@@ -726,7 +726,7 @@ namespace Action {
+         Timestamp ts;
+         if (Params::instance().preserve_) ts.read(path);
+ 
+-        Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(path);
++        Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path);
+         assert(image.get() != 0);
+         image->readMetadata();
+         Exiv2::ExifData& exifData = image->exifData();
+@@ -789,9 +789,9 @@ namespace Action {
+         return 1;
+     }} // Rename::run
+ 
+-    Rename::AutoPtr Rename::clone() const
++    Rename::UniquePtr Rename::clone() const
+     {
+-        return AutoPtr(clone_());
++        return UniquePtr(clone_());
+     }
+ 
+     Rename* Rename::clone_() const
+@@ -815,7 +815,7 @@ namespace Action {
+         Timestamp ts;
+         if (Params::instance().preserve_) ts.read(path);
+ 
+-        Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(path_);
++        Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path_);
+         assert(image.get() != 0);
+         image->readMetadata();
+         // Thumbnail must be before Exif
+@@ -915,9 +915,9 @@ namespace Action {
+         return 0;
+     }
+ 
+-    Erase::AutoPtr Erase::clone() const
++    Erase::UniquePtr Erase::clone() const
+     {
+-        return AutoPtr(clone_());
++        return UniquePtr(clone_());
+     }
+ 
+     Erase* Erase::clone_() const
+@@ -980,7 +980,7 @@ namespace Action {
+                       << ": " << _("Failed to open the file\n");
+             return -1;
+         }
+-        Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(path_);
++        Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path_);
+         assert(image.get() != 0);
+         image->readMetadata();
+         Exiv2::ExifData& exifData = image->exifData();
+@@ -1022,7 +1022,7 @@ namespace Action {
+                       << ": " << _("Failed to open the file\n");
+             return -1;
+         }
+-        Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(path_);
++        Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path_);
+         assert(image.get() != 0);
+         image->readMetadata();
+ 
+@@ -1062,7 +1062,7 @@ namespace Action {
+         bool bStdout = target == "-" ;
+ 
+         if ( rc == 0 ) {
+-            Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(path_);
++            Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path_);
+             assert(image.get() != 0);
+             image->readMetadata();
+             if ( !image->iccProfileDefined() ) {
+@@ -1109,9 +1109,9 @@ namespace Action {
+         }
+     } // Extract::writePreviewFile
+ 
+-    Extract::AutoPtr Extract::clone() const
++    Extract::UniquePtr Extract::clone() const
+     {
+-        return AutoPtr(clone_());
++        return UniquePtr(clone_());
+     }
+ 
+     Extract* Extract::clone_() const
+@@ -1210,7 +1210,7 @@ namespace Action {
+         for ( long i = 0 ; i < xmpBlob.size_ ; i++ ) {
+             xmpPacket += (char) xmpBlob.pData_[i];
+         }
+-        Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(path);
++        Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path);
+         assert(image.get() != 0);
+         image->readMetadata();
+         image->clearXmpData();
+@@ -1254,7 +1254,7 @@ namespace Action {
+ 
+         // read in the metadata
+         if ( rc == 0 ) {
+-            Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(path);
++            Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path);
+             assert(image.get() != 0);
+             image->readMetadata();
+             // clear existing profile, assign the blob and rewrite image
+@@ -1281,7 +1281,7 @@ namespace Action {
+                       << ": " << _("Failed to open the file\n");
+             return -1;
+         }
+-        Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(path);
++        Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path);
+         assert(image.get() != 0);
+         image->readMetadata();
+         Exiv2::ExifThumb exifThumb(image->exifData());
+@@ -1291,9 +1291,9 @@ namespace Action {
+         return 0;
+     } // Insert::insertThumbnail
+ 
+-    Insert::AutoPtr Insert::clone() const
++    Insert::UniquePtr Insert::clone() const
+     {
+-        return AutoPtr(clone_());
++        return UniquePtr(clone_());
+     }
+ 
+     Insert* Insert::clone_() const
+@@ -1316,7 +1316,7 @@ namespace Action {
+         Timestamp ts;
+         if (Params::instance().preserve_) ts.read(path);
+ 
+-        Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(path);
++        Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path);
+         assert(image.get() != 0);
+         image->readMetadata();
+ 
+@@ -1390,7 +1390,7 @@ namespace Action {
+         Exiv2::ExifData& exifData = pImage->exifData();
+         Exiv2::IptcData& iptcData = pImage->iptcData();
+         Exiv2::XmpData&  xmpData  = pImage->xmpData();
+-        Exiv2::Value::AutoPtr value = Exiv2::Value::create(modifyCmd.typeId_);
++        Exiv2::Value::UniquePtr value = Exiv2::Value::create(modifyCmd.typeId_);
+         int rc = value->read(modifyCmd.value_);
+         if (0 == rc) {
+             if (modifyCmd.metadataId_ == exif) {
+@@ -1451,7 +1451,7 @@ namespace Action {
+         // If a type was explicitly requested, use it; else
+         // use the current type of the metadatum, if any;
+         // or the default type
+-        Exiv2::Value::AutoPtr value;
++        Exiv2::Value::UniquePtr value;
+         if (metadatum) {
+             value = metadatum->getValue();
+         }
+@@ -1528,9 +1528,9 @@ namespace Action {
+         Exiv2::XmpProperties::registerNs(modifyCmd.value_, modifyCmd.key_);
+     }
+ 
+-    Modify::AutoPtr Modify::clone() const
++    Modify::UniquePtr Modify::clone() const
+     {
+-        return AutoPtr(clone_());
++        return UniquePtr(clone_());
+     }
+ 
+     Modify* Modify::clone_() const
+@@ -1557,7 +1557,7 @@ namespace Action {
+         Timestamp ts;
+         if (Params::instance().preserve_) ts.read(path);
+ 
+-        Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(path);
++        Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path);
+         assert(image.get() != 0);
+         image->readMetadata();
+         Exiv2::ExifData& exifData = image->exifData();
+@@ -1584,9 +1584,9 @@ namespace Action {
+         return 1;
+     } // Adjust::run
+ 
+-    Adjust::AutoPtr Adjust::clone() const
++    Adjust::UniquePtr Adjust::clone() const
+     {
+-        return AutoPtr(clone_());
++        return UniquePtr(clone_());
+     }
+ 
+     Adjust* Adjust::clone_() const
+@@ -1693,7 +1693,7 @@ namespace Action {
+         Timestamp ts;
+         if (Params::instance().preserve_) ts.read(path);
+ 
+-        Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(path);
++        Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path);
+         assert(image.get() != 0);
+         image->readMetadata();
+         Exiv2::ExifData& exifData = image->exifData();
+@@ -1731,9 +1731,9 @@ namespace Action {
+     }
+     } // FixIso::run
+ 
+-    FixIso::AutoPtr FixIso::clone() const
++    FixIso::UniquePtr FixIso::clone() const
+     {
+-        return AutoPtr(clone_());
++        return UniquePtr(clone_());
+     }
+ 
+     FixIso* FixIso::clone_() const
+@@ -1756,7 +1756,7 @@ namespace Action {
+         Timestamp ts;
+         if (Params::instance().preserve_) ts.read(path);
+ 
+-        Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(path);
++        Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path);
+         assert(image.get() != 0);
+         image->readMetadata();
+         Exiv2::ExifData& exifData = image->exifData();
+@@ -1772,7 +1772,7 @@ namespace Action {
+             }
+             return 0;
+         }
+-        Exiv2::Value::AutoPtr v = pos->getValue();
++        Exiv2::Value::UniquePtr v = pos->getValue();
+         const Exiv2::CommentValue* pcv = dynamic_cast<const Exiv2::CommentValue*>(v.get());
+         if (!pcv) {
+             if (Params::instance().verbose_) {
+@@ -1807,9 +1807,9 @@ namespace Action {
+     }
+     } // FixCom::run
+ 
+-    FixCom::AutoPtr FixCom::clone() const
++    FixCom::UniquePtr FixCom::clone() const
+     {
+-        return AutoPtr(clone_());
++        return UniquePtr(clone_());
+     }
+ 
+     FixCom* FixCom::clone_() const
+@@ -1985,9 +1985,9 @@ namespace {
+ 
+         Exiv2::DataBuf stdIn;
+         if ( bStdin )  Params::instance().getStdin(stdIn);
+-        Exiv2::BasicIo::AutoPtr ioStdin = Exiv2::BasicIo::AutoPtr(new Exiv2::MemIo(stdIn.pData_,stdIn.size_));
++        Exiv2::BasicIo::UniquePtr ioStdin = Exiv2::BasicIo::UniquePtr(new Exiv2::MemIo(stdIn.pData_,stdIn.size_));
+ 
+-        Exiv2::Image::AutoPtr sourceImage = bStdin ? Exiv2::ImageFactory::open(ioStdin) : Exiv2::ImageFactory::open(source);
++        Exiv2::Image::UniquePtr sourceImage = bStdin ? Exiv2::ImageFactory::open(std::move(ioStdin)) : Exiv2::ImageFactory::open(source);
+         assert(sourceImage.get() != 0);
+         sourceImage->readMetadata();
+ 
+@@ -1997,7 +1997,7 @@ namespace {
+         // Open or create the target file
+         std::string target(bStdout ? temporaryPath() : tgt);
+ 
+-        Exiv2::Image::AutoPtr targetImage;
++        Exiv2::Image::UniquePtr targetImage;
+         if (Exiv2::fileExists(target)) {
+             targetImage = Exiv2::ImageFactory::open(target);
+             assert(targetImage.get() != 0);
+@@ -2254,7 +2254,7 @@ namespace {
+                       << _("Failed to open the file\n");
+             return -1;
+         }
+-        Exiv2::Image::AutoPtr image = Exiv2::ImageFactory::open(path);
++        Exiv2::Image::UniquePtr image = Exiv2::ImageFactory::open(path);
+         assert(image.get() != 0);
+         image->printStructure(out,option);
+         return 0;
+diff --git a/src/actions.hpp b/src/actions.hpp
+index 7bcd8a6..8d07d78 100644
+--- a/src/actions.hpp
++++ b/src/actions.hpp
+@@ -65,13 +65,13 @@ namespace Action {
+     class Task {
+     public:
+         //! Shortcut for an auto pointer.
+-        typedef std::auto_ptr<Task> AutoPtr;
++        typedef std::unique_ptr<Task> UniquePtr;
+         //! Contructor.
+         Task() : binary_(false) {}
+         //! Virtual destructor.
+         virtual ~Task();
+         //! Virtual copy construction.
+-        AutoPtr clone() const;
++        UniquePtr clone() const;
+         /*!
+           @brief Application interface to perform a task.
+ 
+@@ -79,7 +79,7 @@ namespace Action {
+           @return 0 if successful.
+          */
+         virtual int run(const std::string& path) =0;
+-        
++
+         /*!
+           @brief Application interface to perform a task.
+ 
+@@ -92,7 +92,7 @@ namespace Action {
+     private:
+         //! Internal virtual copy constructor.
+         virtual Task* clone_() const =0;
+-        
++
+         //! copy binary_ from command-line params to task
+         bool binary_;
+ 
+@@ -127,7 +127,7 @@ namespace Action {
+                   returned auto pointer and take appropriate action (e.g., throw
+                   an exception) if it is 0.
+          */
+-        Task::AutoPtr create(TaskType type);
++        Task::UniquePtr create(TaskType type);
+ 
+         /*!
+           @brief Register a task prototype together with its type.
+@@ -141,7 +141,7 @@ namespace Action {
+           @param task Pointer to the prototype. Ownership is transferred to the
+                  task factory. That's what the auto pointer indicates.
+         */
+-        void registerTask(TaskType type, Task::AutoPtr task);
++        void registerTask(TaskType type, Task::UniquePtr task);
+ 
+     private:
+         //! Prevent construction other than through instance().
+@@ -163,8 +163,8 @@ namespace Action {
+     public:
+         virtual ~Print();
+         virtual int run(const std::string& path);
+-        typedef std::auto_ptr<Print> AutoPtr;
+-        AutoPtr clone() const;
++        typedef std::unique_ptr<Print> UniquePtr;
++        UniquePtr clone() const;
+ 
+         //! Print the Jpeg comment
+         int printComment();
+@@ -219,8 +219,8 @@ namespace Action {
+     public:
+         virtual ~Rename();
+         virtual int run(const std::string& path);
+-        typedef std::auto_ptr<Rename> AutoPtr;
+-        AutoPtr clone() const;
++        typedef std::unique_ptr<Rename> UniquePtr;
++        UniquePtr clone() const;
+ 
+     private:
+         virtual Rename* clone_() const;
+@@ -231,8 +231,8 @@ namespace Action {
+     public:
+         virtual ~Adjust();
+         virtual int run(const std::string& path);
+-        typedef std::auto_ptr<Adjust> AutoPtr;
+-        AutoPtr clone() const;
++        typedef std::unique_ptr<Adjust> UniquePtr;
++        UniquePtr clone() const;
+ 
+     private:
+         virtual Adjust* clone_() const;
+@@ -254,8 +254,8 @@ namespace Action {
+     public:
+         virtual ~Erase();
+         virtual int run(const std::string& path);
+-        typedef std::auto_ptr<Erase> AutoPtr;
+-        AutoPtr clone() const;
++        typedef std::unique_ptr<Erase> UniquePtr;
++        UniquePtr clone() const;
+ 
+         /*!
+           @brief Delete the thumbnail image, incl IFD1 metadata from the file.
+@@ -296,8 +296,8 @@ namespace Action {
+     public:
+         virtual ~Extract();
+         virtual int run(const std::string& path);
+-        typedef std::auto_ptr<Extract> AutoPtr;
+-        AutoPtr clone() const;
++        typedef std::unique_ptr<Extract> UniquePtr;
++        UniquePtr clone() const;
+ 
+         /*!
+           @brief Write the thumbnail image to a file. The filename is composed by
+@@ -335,8 +335,8 @@ namespace Action {
+     public:
+         virtual ~Insert();
+         virtual int run(const std::string& path);
+-        typedef std::auto_ptr<Insert> AutoPtr;
+-        AutoPtr clone() const;
++        typedef std::unique_ptr<Insert> UniquePtr;
++        UniquePtr clone() const;
+ 
+         /*!
+           @brief Insert a Jpeg thumbnail image from a file into file \em path.
+@@ -376,15 +376,15 @@ namespace Action {
+     public:
+         virtual ~Modify();
+         virtual int run(const std::string& path);
+-        typedef std::auto_ptr<Modify> AutoPtr;
+-        AutoPtr clone() const;
++        typedef std::unique_ptr<Modify> UniquePtr;
++        UniquePtr clone() const;
+         Modify() {}
+         //! Apply modification commands to the \em pImage, return 0 if successful.
+         static int applyCommands(Exiv2::Image* pImage);
+ 
+     private:
+         virtual Modify* clone_() const;
+-        //! Copy constructor needed because of AutoPtr member
++        //! Copy constructor needed because of UniquePtr member
+         Modify(const Modify& /*src*/) : Task() {}
+ 
+         //! Add a metadatum to \em pImage according to \em modifyCmd
+@@ -409,8 +409,8 @@ namespace Action {
+     public:
+         virtual ~FixIso();
+         virtual int run(const std::string& path);
+-        typedef std::auto_ptr<FixIso> AutoPtr;
+-        AutoPtr clone() const;
++        typedef std::unique_ptr<FixIso> UniquePtr;
++        UniquePtr clone() const;
+ 
+     private:
+         virtual FixIso* clone_() const;
+@@ -427,8 +427,8 @@ namespace Action {
+     public:
+         virtual ~FixCom();
+         virtual int run(const std::string& path);
+-        typedef std::auto_ptr<FixCom> AutoPtr;
+-        AutoPtr clone() const;
++        typedef std::unique_ptr<FixCom> UniquePtr;
++        UniquePtr clone() const;
+ 
+     private:
+         virtual FixCom* clone_() const;
+diff --git a/src/asfvideo.cpp b/src/asfvideo.cpp
+index 7f67752..e24378b 100644
+--- a/src/asfvideo.cpp
++++ b/src/asfvideo.cpp
+@@ -291,7 +291,7 @@ namespace Exiv2 {
+ 
+     using namespace Exiv2::Internal;
+ 
+-    AsfVideo::AsfVideo(BasicIo::AutoPtr io)
++    AsfVideo::AsfVideo(BasicIo::UniquePtr io)
+         : Image(ImageType::asf, mdNone, io)
+     {
+     } // AsfVideo::AsfVideo
+@@ -371,7 +371,7 @@ namespace Exiv2 {
+         DataBuf buf(1000);
+         unsigned long count = 0, tempLength = 0;
+         buf.pData_[4] = '\0' ;
+-        Exiv2::Value::AutoPtr v = Exiv2::Value::create(Exiv2::xmpSeq);
++        Exiv2::Value::UniquePtr v = Exiv2::Value::create(Exiv2::xmpSeq);
+ 
+         if(compareTag( exvGettext(tv->label_), "Header")) {
+             localPosition_ = 0;
+@@ -623,7 +623,7 @@ namespace Exiv2 {
+         DataBuf buf(5000);
+         io_->read(buf.pData_, 2);
+         int recordCount = Exiv2::getUShort(buf.pData_, littleEndian), nameLength = 0, dataLength = 0, dataType = 0;
+-        Exiv2::Value::AutoPtr v = Exiv2::Value::create(Exiv2::xmpSeq);
++        Exiv2::Value::UniquePtr v = Exiv2::Value::create(Exiv2::xmpSeq);
+         byte guidBuf[16];   char fileID[37] = "";
+ 
+         while(recordCount--) {
+@@ -785,9 +785,9 @@ namespace Exiv2 {
+     } // AsfVideo::aspectRatio
+ 
+ 
+-    Image::AutoPtr newAsfInstance(BasicIo::AutoPtr io, bool /*create*/)
++    Image::UniquePtr newAsfInstance(BasicIo::UniquePtr io, bool /*create*/)
+     {
+-        Image::AutoPtr image(new AsfVideo(io));
++        Image::UniquePtr image(new AsfVideo(io));
+         if (!image->good()) {
+             image.reset();
+         }
+diff --git a/src/bmffimage.cpp b/src/bmffimage.cpp
+index 4487403..930564f 100644
+--- a/src/bmffimage.cpp
++++ b/src/bmffimage.cpp
+@@ -96,8 +96,8 @@ namespace Exiv2
+         return Internal::stringFormat("ID = %u from,length = %u,%u", ID_, start_, length_);
+     }
+ 
+-    BmffImage::BmffImage(BasicIo::AutoPtr io, bool /* create */)
+-    : Image(ImageType::bmff, mdExif | mdIptc | mdXmp, io)
++    BmffImage::BmffImage(BasicIo::UniquePtr io, bool /* create */)
++    : Image(ImageType::bmff, mdExif | mdIptc | mdXmp, std::move(io))
+     , endian_(Exiv2::bigEndian)
+     {
+         pixelWidth_    = 0;
+@@ -718,9 +718,9 @@ namespace Exiv2
+ 
+     // *************************************************************************
+     // free functions
+-    Image::AutoPtr newBmffInstance(BasicIo::AutoPtr io, bool create)
++    Image::UniquePtr newBmffInstance(BasicIo::UniquePtr io, bool create)
+     {
+-        Image::AutoPtr image(new BmffImage(io, create));
++        Image::UniquePtr image(new BmffImage(std::move(io), create));
+         if (!image->good()) {
+             image.reset();
+         }
+diff --git a/src/bmpimage.cpp b/src/bmpimage.cpp
+index ef82f57..a2f3b3a 100644
+--- a/src/bmpimage.cpp
++++ b/src/bmpimage.cpp
+@@ -41,7 +41,7 @@
+ // class member definitions
+ namespace Exiv2
+ {
+-    BmpImage::BmpImage(BasicIo::AutoPtr io) : Image(ImageType::bmp, mdNone, io)
++    BmpImage::BmpImage(BasicIo::UniquePtr io) : Image(ImageType::bmp, mdNone, std::move(io))
+     {
+     }
+ 
+@@ -120,9 +120,9 @@ namespace Exiv2
+ 
+     // *************************************************************************
+     // free functions
+-    Image::AutoPtr newBmpInstance(BasicIo::AutoPtr io, bool /*create*/)
++    Image::UniquePtr newBmpInstance(BasicIo::UniquePtr io, bool /*create*/)
+     {
+-        Image::AutoPtr image(new BmpImage(io));
++        Image::UniquePtr image(new BmpImage(std::move(io)));
+         if (!image->good()) {
+             image.reset();
+         }
+diff --git a/src/cr2image.cpp b/src/cr2image.cpp
+index be4568b..4ea445d 100644
+--- a/src/cr2image.cpp
++++ b/src/cr2image.cpp
+@@ -46,8 +46,8 @@ namespace Exiv2 {
+ 
+     using namespace Internal;
+ 
+-    Cr2Image::Cr2Image(BasicIo::AutoPtr io, bool /*create*/)
+-        : Image(ImageType::cr2, mdExif | mdIptc | mdXmp, io)
++    Cr2Image::Cr2Image(BasicIo::UniquePtr io, bool /*create*/)
++        : Image(ImageType::cr2, mdExif | mdIptc | mdXmp, std::move(io))
+     {
+     } // Cr2Image::Cr2Image
+ 
+@@ -183,7 +183,7 @@ namespace Exiv2 {
+                      ed.end());
+         }
+ 
+-        std::auto_ptr<TiffHeaderBase> header(new Cr2Header(byteOrder));
++        std::unique_ptr<TiffHeaderBase> header(new Cr2Header(byteOrder));
+         OffsetWriter offsetWriter;
+         offsetWriter.setOrigin(OffsetWriter::cr2RawIfdOffset, Cr2Header::offset2addr(), byteOrder);
+         return TiffParserWorker::encode(io,
+@@ -200,9 +200,9 @@ namespace Exiv2 {
+ 
+     // *************************************************************************
+     // free functions
+-    Image::AutoPtr newCr2Instance(BasicIo::AutoPtr io, bool create)
++    Image::UniquePtr newCr2Instance(BasicIo::UniquePtr io, bool create)
+     {
+-        Image::AutoPtr image(new Cr2Image(io, create));
++        Image::UniquePtr image(new Cr2Image(std::move(io), create));
+         if (!image->good()) {
+             image.reset();
+         }
+diff --git a/src/crwimage.cpp b/src/crwimage.cpp
+index 4bc5b57..9c760aa 100644
+--- a/src/crwimage.cpp
++++ b/src/crwimage.cpp
+@@ -52,8 +52,8 @@ namespace Exiv2 {
+ 
+     using namespace Internal;
+ 
+-    CrwImage::CrwImage(BasicIo::AutoPtr io, bool /*create*/)
+-        : Image(ImageType::crw, mdExif | mdComment, io)
++    CrwImage::CrwImage(BasicIo::UniquePtr io, bool /*create*/)
++        : Image(ImageType::crw, mdExif | mdComment, std::move(io))
+     {
+     } // CrwImage::CrwImage
+ 
+@@ -132,7 +132,7 @@ namespace Exiv2 {
+         CrwParser::encode(blob, buf.pData_, buf.size_, this);
+ 
+         // Write new buffer to file
+-        MemIo::AutoPtr tempIo(new MemIo);
++        MemIo::UniquePtr tempIo(new MemIo);
+         assert(tempIo.get() != 0);
+         tempIo->write((blob.size() > 0 ? &blob[0] : 0), static_cast<long>(blob.size()));
+         io_->close();
+@@ -146,7 +146,7 @@ namespace Exiv2 {
+         assert(pData != 0);
+ 
+         // Parse the image, starting with a CIFF header component
+-        CiffHeader::AutoPtr head(new CiffHeader);
++        CiffHeader::UniquePtr head(new CiffHeader);
+         head->read(pData, size);
+ #ifdef EXIV2_DEBUG_MESSAGES
+         head->print(std::cerr);
+@@ -169,7 +169,7 @@ namespace Exiv2 {
+     )
+     {
+         // Parse image, starting with a CIFF header component
+-        CiffHeader::AutoPtr head(new CiffHeader);
++        CiffHeader::UniquePtr head(new CiffHeader);
+         if (size != 0) {
+             head->read(pData, size);
+         }
+@@ -183,9 +183,9 @@ namespace Exiv2 {
+ 
+     // *************************************************************************
+     // free functions
+-    Image::AutoPtr newCrwInstance(BasicIo::AutoPtr io, bool create)
++    Image::UniquePtr newCrwInstance(BasicIo::UniquePtr io, bool create)
+     {
+-        Image::AutoPtr image(new CrwImage(io, create));
++        Image::UniquePtr image(new CrwImage(std::move(io), create));
+         if (!image->good()) {
+             image.reset();
+         }
+diff --git a/src/crwimage_int.cpp b/src/crwimage_int.cpp
+index 2629197..59efed3 100644
+--- a/src/crwimage_int.cpp
++++ b/src/crwimage_int.cpp
+@@ -199,17 +199,17 @@ namespace Exiv2 {
+         }
+     }
+ 
+-    void CiffComponent::add(AutoPtr component)
++    void CiffComponent::add(UniquePtr component)
+     {
+-        doAdd(component);
++        doAdd(std::move(component));
+     }
+ 
+-    void CiffEntry::doAdd(AutoPtr /*component*/)
++    void CiffEntry::doAdd(UniquePtr /*component*/)
+     {
+         throw Error(kerFunctionNotSupported, "CiffEntry::add");
+     } // CiffEntry::doAdd
+ 
+-    void CiffDirectory::doAdd(AutoPtr component)
++    void CiffDirectory::doAdd(UniquePtr component)
+     {
+         components_.push_back(component.release());
+     } // CiffDirectory::doAdd
+@@ -333,14 +333,14 @@ namespace Exiv2 {
+ 
+         for (uint16_t i = 0; i < count; ++i) {
+             uint16_t tag = getUShort(pData + o, byteOrder);
+-            CiffComponent::AutoPtr m;
++            CiffComponent::UniquePtr m;
+             switch (CiffComponent::typeId(tag)) {
+-            case directory: m = CiffComponent::AutoPtr(new CiffDirectory); break;
+-            default: m = CiffComponent::AutoPtr(new CiffEntry); break;
++            case directory: m = CiffComponent::UniquePtr(new CiffDirectory); break;
++            default: m = CiffComponent::UniquePtr(new CiffEntry); break;
+             }
+             m->setDir(this->tag());
+             m->read(pData, size, o, byteOrder);
+-            add(m);
++            add(std::move(m));
+             o += 10;
+         }
+     }  // CiffDirectory::readDirectory
+@@ -554,7 +554,7 @@ namespace Exiv2 {
+            << ", " << _("size") << " = " << std::dec << size_
+            << ", " << _("offset") << " = " << offset_ << "\n";
+ 
+-        Value::AutoPtr value;
++        Value::UniquePtr value;
+         if (typeId() != directory) {
+             value = Value::create(typeId());
+             value->read(pData_, size_, byteOrder);
+@@ -710,9 +710,9 @@ namespace Exiv2 {
+             }
+             if (cc_ == 0) {
+                 // Directory doesn't exist yet, add it
+-                m_ = AutoPtr(new CiffDirectory(csd.crwDir_, csd.parent_));
++                m_ = UniquePtr(new CiffDirectory(csd.crwDir_, csd.parent_));
+                 cc_ = m_.get();
+-                add(m_);
++                add(std::move(m_));
+             }
+             // Recursive call to next lower level directory
+             cc_ = cc_->add(crwDirs, crwTagId);
+@@ -727,9 +727,9 @@ namespace Exiv2 {
+             }
+             if (cc_ == 0) {
+                 // Tag doesn't exist yet, add it
+-                m_ = AutoPtr(new CiffEntry(crwTagId, tag()));
++                m_ = UniquePtr(new CiffEntry(crwTagId, tag()));
+                 cc_ = m_.get();
+-                add(m_);
++                add(std::move(m_));
+             }
+         }
+         return cc_;
+@@ -845,7 +845,7 @@ namespace Exiv2 {
+ 
+         // Make
+         ExifKey key1("Exif.Image.Make");
+-        Value::AutoPtr value1 = Value::create(ciffComponent.typeId());
++        Value::UniquePtr value1 = Value::create(ciffComponent.typeId());
+         uint32_t i = 0;
+         while (i < ciffComponent.size() && ciffComponent.pData()[i++] != '\0') {
+             // empty
+@@ -855,7 +855,7 @@ namespace Exiv2 {
+ 
+         // Model
+         ExifKey key2("Exif.Image.Model");
+-        Value::AutoPtr value2 = Value::create(ciffComponent.typeId());
++        Value::UniquePtr value2 = Value::create(ciffComponent.typeId());
+         uint32_t j = i;
+         while (i < ciffComponent.size() && ciffComponent.pData()[i++] != '\0') {
+             // empty
+@@ -987,7 +987,7 @@ namespace Exiv2 {
+         assert(pCrwMapping != 0);
+         // create a key and value pair
+         ExifKey key(pCrwMapping->tag_, Internal::groupName(pCrwMapping->ifdId_));
+-        Value::AutoPtr value;
++        Value::UniquePtr value;
+         if (ciffComponent.typeId() != directory) {
+             value = Value::create(ciffComponent.typeId());
+             uint32_t size = 0;
+diff --git a/src/crwimage_int.hpp b/src/crwimage_int.hpp
+index 8a8dd57..54352ee 100644
+--- a/src/crwimage_int.hpp
++++ b/src/crwimage_int.hpp
+@@ -84,7 +84,7 @@ namespace Exiv2 {
+     class CiffComponent {
+     public:
+         //! CiffComponent auto_ptr type
+-        typedef std::auto_ptr<CiffComponent> AutoPtr;
++        typedef std::unique_ptr<CiffComponent> UniquePtr;
+         //! Container type to hold all metadata
+         typedef std::vector<CiffComponent*> Components;
+ 
+@@ -107,7 +107,7 @@ namespace Exiv2 {
+         // Default assignment operator is fine
+ 
+         //! Add a component to the composition
+-        void add(AutoPtr component);
++        void add(UniquePtr component);
+         /*!
+           @brief Add \em crwTagId to the parse tree, if it doesn't exist
+                  yet. \em crwDirs contains the path of subdirectories, starting
+@@ -250,7 +250,7 @@ namespace Exiv2 {
+         //! @name Manipulators
+         //@{
+         //! Implements add()
+-        virtual void doAdd(AutoPtr component) =0;
++        virtual void doAdd(UniquePtr component) =0;
+         //! Implements add(). The default implementation does nothing.
+         virtual CiffComponent* doAdd(CrwDirs& crwDirs, uint16_t crwTagId);
+         //! Implements remove(). The default implementation does nothing.
+@@ -321,7 +321,7 @@ namespace Exiv2 {
+         //@{
+         using CiffComponent::doAdd;
+         // See base class comment
+-        virtual void doAdd(AutoPtr component);
++        virtual void doAdd(UniquePtr component);
+         /*!
+           @brief Implements write(). Writes only the value data of the entry,
+                  using writeValueData().
+@@ -373,7 +373,7 @@ namespace Exiv2 {
+         //! @name Manipulators
+         //@{
+         // See base class comment
+-        virtual void doAdd(AutoPtr component);
++        virtual void doAdd(UniquePtr component);
+         // See base class comment
+         virtual CiffComponent* doAdd(CrwDirs& crwDirs, uint16_t crwTagId);
+         // See base class comment
+@@ -414,7 +414,7 @@ namespace Exiv2 {
+     private:
+         // DATA
+         Components components_; //!< List of components in this dir
+-        AutoPtr    m_; // used by recursive doAdd
++        UniquePtr    m_; // used by recursive doAdd
+         CiffComponent* cc_;
+ 
+     }; // class CiffDirectory
+@@ -428,7 +428,7 @@ namespace Exiv2 {
+     class CiffHeader {
+     public:
+         //! CiffHeader auto_ptr type
+-        typedef std::auto_ptr<CiffHeader> AutoPtr;
++        typedef std::unique_ptr<CiffHeader> UniquePtr;
+ 
+         //! @name Creators
+         //@{
+diff --git a/src/datasets.cpp b/src/datasets.cpp
+index 4c1df8a..0d509ae 100644
+--- a/src/datasets.cpp
++++ b/src/datasets.cpp
+@@ -656,9 +656,9 @@ namespace Exiv2 {
+         return record_;
+     }
+ 
+-    IptcKey::AutoPtr IptcKey::clone() const
++    IptcKey::UniquePtr IptcKey::clone() const
+     {
+-        return AutoPtr(clone_());
++        return UniquePtr(clone_());
+     }
+ 
+     IptcKey* IptcKey::clone_() const
+diff --git a/src/epsimage.cpp b/src/epsimage.cpp
+index 79402e6..cd15bde 100644
+--- a/src/epsimage.cpp
++++ b/src/epsimage.cpp
+@@ -805,7 +805,7 @@ namespace {
+             }
+ 
+             // create temporary output file
+-            BasicIo::AutoPtr tempIo(new MemIo);
++            BasicIo::UniquePtr tempIo(new MemIo);
+             assert (tempIo.get() != 0);
+             if (!tempIo->isopen()) {
+                 #ifndef SUPPRESS_WARNINGS
+@@ -1075,7 +1075,7 @@ namespace {
+ namespace Exiv2
+ {
+ 
+-    EpsImage::EpsImage(BasicIo::AutoPtr io, bool create)
++    EpsImage::EpsImage(BasicIo::UniquePtr io, bool create)
+             : Image(ImageType::eps, mdXmp, io)
+     {
+         //LogMsg::setLevel(LogMsg::debug);
+@@ -1151,9 +1151,9 @@ namespace Exiv2
+ 
+     // *************************************************************************
+     // free functions
+-    Image::AutoPtr newEpsInstance(BasicIo::AutoPtr io, bool create)
++    Image::UniquePtr newEpsInstance(BasicIo::UniquePtr io, bool create)
+     {
+-        Image::AutoPtr image(new EpsImage(io, create));
++        Image::UniquePtr image(new EpsImage(io, create));
+         if (!image->good()) {
+             image.reset();
+         }
+diff --git a/src/exif.cpp b/src/exif.cpp
+index 47330e1..248e599 100644
+--- a/src/exif.cpp
++++ b/src/exif.cpp
+@@ -80,7 +80,7 @@ namespace {
+     class Thumbnail {
+     public:
+         //! Shortcut for a %Thumbnail auto pointer.
+-        typedef std::auto_ptr<Thumbnail> AutoPtr;
++        typedef std::unique_ptr<Thumbnail> UniquePtr;
+ 
+         //! @name Creators
+         //@{
+@@ -89,7 +89,7 @@ namespace {
+         //@}
+ 
+         //! Factory function to create a thumbnail for the Exif metadata provided.
+-        static AutoPtr create(const Exiv2::ExifData& exifData);
++        static UniquePtr create(const Exiv2::ExifData& exifData);
+ 
+         //! @name Accessors
+         //@{
+@@ -123,7 +123,7 @@ namespace {
+     class TiffThumbnail : public Thumbnail {
+     public:
+         //! Shortcut for a %TiffThumbnail auto pointer.
+-        typedef std::auto_ptr<TiffThumbnail> AutoPtr;
++        typedef std::unique_ptr<TiffThumbnail> UniquePtr;
+ 
+         //! @name Manipulators
+         //@{
+@@ -147,7 +147,7 @@ namespace {
+     class JpegThumbnail : public Thumbnail {
+     public:
+         //! Shortcut for a %JpegThumbnail auto pointer.
+-        typedef std::auto_ptr<JpegThumbnail> AutoPtr;
++        typedef std::unique_ptr<JpegThumbnail> UniquePtr;
+ 
+         //! @name Manipulators
+         //@{
+@@ -192,10 +192,10 @@ namespace Exiv2 {
+     template<typename T>
+     Exiv2::Exifdatum& setValue(Exiv2::Exifdatum& exifDatum, const T& value)
+     {
+-        std::auto_ptr<Exiv2::ValueType<T> > v
+-            = std::auto_ptr<Exiv2::ValueType<T> >(new Exiv2::ValueType<T>);
++        std::unique_ptr<Exiv2::ValueType<T> > v
++            = std::unique_ptr<Exiv2::ValueType<T> >(new Exiv2::ValueType<T>);
+         v->value_.push_back(value);
+-        exifDatum.value_ = v;
++        exifDatum.value_ = std::move(v);
+         return exifDatum;
+     }
+ 
+@@ -431,9 +431,9 @@ namespace Exiv2 {
+         return value_.get() == 0 ? Rational(-1, 1) : value_->toRational(n);
+     }
+ 
+-    Value::AutoPtr Exifdatum::getValue() const
++    Value::UniquePtr Exifdatum::getValue() const
+     {
+-        return value_.get() == 0 ? Value::AutoPtr(0) : value_->clone();
++        return value_.get() == 0 ? nullptr : value_->clone();
+     }
+ 
+     long Exifdatum::sizeDataArea() const
+@@ -453,14 +453,14 @@ namespace Exiv2 {
+ 
+     DataBuf ExifThumbC::copy() const
+     {
+-        Thumbnail::AutoPtr thumbnail = Thumbnail::create(exifData_);
++        Thumbnail::UniquePtr thumbnail = Thumbnail::create(exifData_);
+         if (thumbnail.get() == 0) return DataBuf();
+         return thumbnail->copy(exifData_);
+     }
+ 
+     long ExifThumbC::writeFile(const std::string& path) const
+     {
+-        Thumbnail::AutoPtr thumbnail = Thumbnail::create(exifData_);
++        Thumbnail::UniquePtr thumbnail = Thumbnail::create(exifData_);
+         if (thumbnail.get() == 0) return 0;
+         std::string name = path + thumbnail->extension();
+         DataBuf buf(thumbnail->copy(exifData_));
+@@ -471,7 +471,7 @@ namespace Exiv2 {
+ #ifdef EXV_UNICODE_PATH
+     long ExifThumbC::writeFile(const std::wstring& wpath) const
+     {
+-        Thumbnail::AutoPtr thumbnail = Thumbnail::create(exifData_);
++        Thumbnail::UniquePtr thumbnail = Thumbnail::create(exifData_);
+         if (thumbnail.get() == 0) return 0;
+         std::wstring name = wpath + thumbnail->wextension();
+         DataBuf buf(thumbnail->copy(exifData_));
+@@ -482,14 +482,14 @@ namespace Exiv2 {
+ #endif
+     const char* ExifThumbC::mimeType() const
+     {
+-        Thumbnail::AutoPtr thumbnail = Thumbnail::create(exifData_);
++        Thumbnail::UniquePtr thumbnail = Thumbnail::create(exifData_);
+         if (thumbnail.get() == 0) return "";
+         return thumbnail->mimeType();
+     }
+ 
+     const char* ExifThumbC::extension() const
+     {
+-        Thumbnail::AutoPtr thumbnail = Thumbnail::create(exifData_);
++        Thumbnail::UniquePtr thumbnail = Thumbnail::create(exifData_);
+         if (thumbnail.get() == 0) return "";
+         return thumbnail->extension();
+     }
+@@ -497,7 +497,7 @@ namespace Exiv2 {
+ #ifdef EXV_UNICODE_PATH
+     const wchar_t* ExifThumbC::wextension() const
+     {
+-        Thumbnail::AutoPtr thumbnail = Thumbnail::create(exifData_);
++        Thumbnail::UniquePtr thumbnail = Thumbnail::create(exifData_);
+         if (thumbnail.get() == 0) return EXV_WIDEN("");
+         return thumbnail->wextension();
+     }
+@@ -741,7 +741,7 @@ namespace Exiv2 {
+ 
+         // Encode and check if the result fits into a JPEG Exif APP1 segment
+         MemIo mio1;
+-        std::auto_ptr<TiffHeaderBase> header(new TiffHeader(byteOrder, 0x00000008, false));
++        std::unique_ptr<TiffHeaderBase> header(new TiffHeader(byteOrder, 0x00000008, false));
+         WriteMethod wm = TiffParserWorker::encode(mio1,
+                                                   pData,
+                                                   size,
+@@ -875,26 +875,26 @@ namespace Exiv2 {
+ namespace {
+ 
+     //! @cond IGNORE
+-    Thumbnail::AutoPtr Thumbnail::create(const Exiv2::ExifData& exifData)
++    Thumbnail::UniquePtr Thumbnail::create(const Exiv2::ExifData& exifData)
+     {
+-        Thumbnail::AutoPtr thumbnail;
++        Thumbnail::UniquePtr thumbnail;
+         const Exiv2::ExifKey k1("Exif.Thumbnail.Compression");
+         Exiv2::ExifData::const_iterator pos = exifData.findKey(k1);
+         if (pos != exifData.end()) {
+             if (pos->count() == 0) return thumbnail;
+             long compression = pos->toLong();
+             if (compression == 6) {
+-                thumbnail = Thumbnail::AutoPtr(new JpegThumbnail);
++                thumbnail = Thumbnail::UniquePtr(new JpegThumbnail);
+             }
+             else {
+-                thumbnail = Thumbnail::AutoPtr(new TiffThumbnail);
++                thumbnail = Thumbnail::UniquePtr(new TiffThumbnail);
+             }
+         }
+         else {
+             const Exiv2::ExifKey k2("Exif.Thumbnail.JPEGInterchangeFormat");
+             pos = exifData.findKey(k2);
+             if (pos != exifData.end()) {
+-                thumbnail = Thumbnail::AutoPtr(new JpegThumbnail);
++                thumbnail = Thumbnail::UniquePtr(new JpegThumbnail);
+             }
+         }
+         return thumbnail;
+diff --git a/src/exiv2.cpp b/src/exiv2.cpp
+index a574718..51475ba 100644
+--- a/src/exiv2.cpp
++++ b/src/exiv2.cpp
+@@ -151,7 +151,7 @@ int main(int argc, char* const argv[])
+     try {
+         // Create the required action class
+         Action::TaskFactory& taskFactory = Action::TaskFactory::instance();
+-        Action::Task::AutoPtr task = taskFactory.create(Action::TaskType(params.action_));
++        Action::Task::UniquePtr task = taskFactory.create(Action::TaskType(params.action_));
+         assert(task.get());
+ 
+         // Process all files
+diff --git a/src/gifimage.cpp b/src/gifimage.cpp
+index 5f4932b..cec4b23 100644
+--- a/src/gifimage.cpp
++++ b/src/gifimage.cpp
+@@ -36,8 +36,8 @@
+ // class member definitions
+ namespace Exiv2 {
+ 
+-    GifImage::GifImage(BasicIo::AutoPtr io)
+-        : Image(ImageType::gif, mdNone, io)
++    GifImage::GifImage(BasicIo::UniquePtr io)
++        : Image(ImageType::gif, mdNone, std::move(io))
+     {
+     } // GifImage::GifImage
+ 
+@@ -98,9 +98,9 @@ namespace Exiv2 {
+ 
+     // *************************************************************************
+     // free functions
+-    Image::AutoPtr newGifInstance(BasicIo::AutoPtr io, bool /*create*/)
++    Image::UniquePtr newGifInstance(BasicIo::UniquePtr io, bool /*create*/)
+     {
+-        Image::AutoPtr image(new GifImage(io));
++        Image::UniquePtr image(new GifImage(std::move(io)));
+         if (!image->good())
+         {
+             image.reset();
+diff --git a/src/image.cpp b/src/image.cpp
+index fa5b8be..2a9998d 100644
+--- a/src/image.cpp
++++ b/src/image.cpp
+@@ -166,8 +166,8 @@ namespace Exiv2 {
+ 
+     Image::Image(int              imageType,
+                  uint16_t         supportedMetadata,
+-                 BasicIo::AutoPtr io)
+-        : io_(io),
++                 BasicIo::UniquePtr io)
++        : io_(std::move(io)),
+           pixelWidth_(0),
+           pixelHeight_(0),
+           imageType_(imageType),
+@@ -868,143 +868,143 @@ namespace Exiv2 {
+         return ImageType::none;
+     } // ImageFactory::getType
+ 
+-    BasicIo::AutoPtr ImageFactory::createIo(const std::string& path, bool useCurl)
++    BasicIo::UniquePtr ImageFactory::createIo(const std::string& path, bool useCurl)
+     {
+         Protocol fProt = fileProtocol(path);
+ 
+ #ifdef EXV_USE_SSH
+         if (fProt == pSsh || fProt == pSftp) {
+-            return BasicIo::AutoPtr(new SshIo(path)); // may throw
++            return BasicIo::UniquePtr(new SshIo(path)); // may throw
+         }
+ #endif
+ 
+ #ifdef EXV_USE_CURL
+         if (useCurl && (fProt == pHttp || fProt == pHttps || fProt == pFtp)) {
+-            return BasicIo::AutoPtr(new CurlIo(path)); // may throw
++            return BasicIo::UniquePtr(new CurlIo(path)); // may throw
+         }
+ #endif
+ 
+         if (fProt == pHttp)
+-            return BasicIo::AutoPtr(new HttpIo(path)); // may throw
++            return BasicIo::UniquePtr(new HttpIo(path)); // may throw
+         if (fProt == pFileUri)
+-            return BasicIo::AutoPtr(new FileIo(pathOfFileUrl(path)));
++            return BasicIo::UniquePtr(new FileIo(pathOfFileUrl(path)));
+         if (fProt == pStdin || fProt == pDataUri)
+-            return BasicIo::AutoPtr(new XPathIo(path)); // may throw
++            return BasicIo::UniquePtr(new XPathIo(path)); // may throw
+ 
+-        return BasicIo::AutoPtr(new FileIo(path));
++        return BasicIo::UniquePtr(new FileIo(path));
+ 
+         (void)(useCurl);
+     } // ImageFactory::createIo
+ 
+ #ifdef EXV_UNICODE_PATH
+-    BasicIo::AutoPtr ImageFactory::createIo(const std::wstring& wpath, bool useCurl)
++    BasicIo::UniquePtr ImageFactory::createIo(const std::wstring& wpath, bool useCurl)
+     {
+         Protocol fProt = fileProtocol(wpath);
+ #ifdef EXV_USE_SSH
+         if (fProt == pSsh || fProt == pSftp) {
+-            return BasicIo::AutoPtr(new SshIo(wpath));
++            return BasicIo::UniquePtr(new SshIo(wpath));
+         }
+ #endif
+ #ifdef EXV_USE_CURL
+         if (useCurl && (fProt == pHttp || fProt == pHttps || fProt == pFtp)) {
+-            return BasicIo::AutoPtr(new CurlIo(wpath));
++            return BasicIo::UniquePtr(new CurlIo(wpath));
+         }
+ #endif
+         if (fProt == pHttp)
+-            return BasicIo::AutoPtr(new HttpIo(wpath));
++            return BasicIo::UniquePtr(new HttpIo(wpath));
+         if (fProt == pFileUri)
+-            return BasicIo::AutoPtr(new FileIo(pathOfFileUrl(wpath)));
++            return BasicIo::UniquePtr(new FileIo(pathOfFileUrl(wpath)));
+         if (fProt == pStdin || fProt == pDataUri)
+-            return BasicIo::AutoPtr(new XPathIo(wpath)); // may throw
+-        return BasicIo::AutoPtr(new FileIo(wpath));
++            return BasicIo::UniquePtr(new XPathIo(wpath)); // may throw
++        return BasicIo::UniquePtr(new FileIo(wpath));
+     } // ImageFactory::createIo
+ #endif
+-    Image::AutoPtr ImageFactory::open(const std::string& path, bool useCurl)
++    Image::UniquePtr ImageFactory::open(const std::string& path, bool useCurl)
+     {
+-        Image::AutoPtr image = open(ImageFactory::createIo(path, useCurl)); // may throw
++        Image::UniquePtr image = open(ImageFactory::createIo(path, useCurl)); // may throw
+         if (image.get() == 0) throw Error(kerFileContainsUnknownImageType, path);
+         return image;
+     }
+ 
+ #ifdef EXV_UNICODE_PATH
+-    Image::AutoPtr ImageFactory::open(const std::wstring& wpath, bool useCurl)
++    Image::UniquePtr ImageFactory::open(const std::wstring& wpath, bool useCurl)
+     {
+-        Image::AutoPtr image = open(ImageFactory::createIo(wpath, useCurl)); // may throw
++        Image::UniquePtr image = open(ImageFactory::createIo(wpath, useCurl)); // may throw
+         if (image.get() == 0) throw WError(kerFileContainsUnknownImageType, wpath);
+         return image;
+     }
+ 
+ #endif
+-    Image::AutoPtr ImageFactory::open(const byte* data, long size)
++    Image::UniquePtr ImageFactory::open(const byte* data, long size)
+     {
+-        BasicIo::AutoPtr io(new MemIo(data, size));
+-        Image::AutoPtr image = open(io); // may throw
++        BasicIo::UniquePtr io(new MemIo(data, size));
++        Image::UniquePtr image = open(std::move(io)); // may throw
+         if (image.get() == 0) throw Error(kerMemoryContainsUnknownImageType);
+         return image;
+     }
+ 
+-    Image::AutoPtr ImageFactory::open(BasicIo::AutoPtr io)
++    Image::UniquePtr ImageFactory::open(BasicIo::UniquePtr io)
+     {
+         if (io->open() != 0) {
+             throw Error(kerDataSourceOpenFailed, io->path(), strError());
+         }
+         for (unsigned int i = 0; registry[i].imageType_ != ImageType::none; ++i) {
+             if (registry[i].isThisType_(*io, false)) {
+-                return registry[i].newInstance_(io, false);
++                return registry[i].newInstance_(std::move(io), false);
+             }
+         }
+-        return Image::AutoPtr();
++        return Image::UniquePtr();
+     } // ImageFactory::open
+ 
+-    Image::AutoPtr ImageFactory::create(int type,
++    Image::UniquePtr ImageFactory::create(int type,
+                                         const std::string& path)
+     {
+-        std::auto_ptr<FileIo> fileIo(new FileIo(path));
++        std::unique_ptr<FileIo> fileIo(new FileIo(path));
+         // Create or overwrite the file, then close it
+         if (fileIo->open("w+b") != 0) {
+             throw Error(kerFileOpenFailed, path, "w+b", strError());
+         }
+         fileIo->close();
+-        BasicIo::AutoPtr io(fileIo);
+-        Image::AutoPtr image = create(type, io);
++        BasicIo::UniquePtr io(std::move(fileIo));
++        Image::UniquePtr image = create(type, std::move(io));
+         if (image.get() == 0) throw Error(kerUnsupportedImageType, type);
+         return image;
+     }
+ 
+ #ifdef EXV_UNICODE_PATH
+-    Image::AutoPtr ImageFactory::create(int type,
++    Image::UniquePtr ImageFactory::create(int type,
+                                         const std::wstring& wpath)
+     {
+-        std::auto_ptr<FileIo> fileIo(new FileIo(wpath));
++        std::unique_ptr<FileIo> fileIo(new FileIo(wpath));
+         // Create or overwrite the file, then close it
+         if (fileIo->open("w+b") != 0) {
+             throw WError(kerFileOpenFailed, wpath, "w+b", strError().c_str());
+         }
+         fileIo->close();
+-        BasicIo::AutoPtr io(fileIo);
+-        Image::AutoPtr image = create(type, io);
++        BasicIo::UniquePtr io(fileIo);
++        Image::UniquePtr image = create(type, io);
+         if (image.get() == 0) throw Error(kerUnsupportedImageType, type);
+         return image;
+     }
+ 
+ #endif
+-    Image::AutoPtr ImageFactory::create(int type)
++    Image::UniquePtr ImageFactory::create(int type)
+     {
+-        BasicIo::AutoPtr io(new MemIo);
+-        Image::AutoPtr image = create(type, io);
++        BasicIo::UniquePtr io(new MemIo);
++        Image::UniquePtr image = create(type, std::move(io));
+         if (image.get() == 0) throw Error(kerUnsupportedImageType, type);
+         return image;
+     }
+ 
+-    Image::AutoPtr ImageFactory::create(int type,
+-                                        BasicIo::AutoPtr io)
++    Image::UniquePtr ImageFactory::create(int type,
++                                        BasicIo::UniquePtr io)
+     {
+         // BasicIo instance does not need to be open
+         const Registry* r = find(registry, type);
+         if (0 != r) {
+-            return r->newInstance_(io, true);
++            return r->newInstance_(std::move(io), true);
+         }
+-        return Image::AutoPtr();
++        return Image::UniquePtr();
+     } // ImageFactory::create
+ 
+ // *****************************************************************************
+diff --git a/src/iptc.cpp b/src/iptc.cpp
+index 75024f3..06d267e 100644
+--- a/src/iptc.cpp
++++ b/src/iptc.cpp
+@@ -199,9 +199,9 @@ namespace Exiv2 {
+         return value_.get() == 0 ? Rational(-1, 1) : value_->toRational(n);
+     }
+ 
+-    Value::AutoPtr Iptcdatum::getValue() const
++    Value::UniquePtr Iptcdatum::getValue() const
+     {
+-        return value_.get() == 0 ? Value::AutoPtr(0) : value_->clone();
++        return value_.get() == 0 ? nullptr : value_->clone();
+     }
+ 
+     const Value& Iptcdatum::value() const
+@@ -226,9 +226,9 @@ namespace Exiv2 {
+ 
+     Iptcdatum& Iptcdatum::operator=(const uint16_t& value)
+     {
+-        UShortValue::AutoPtr v(new UShortValue);
++        UShortValue::UniquePtr v(new UShortValue);
+         v->value_.push_back(value);
+-        value_ = v;
++        value_ = std::move(v);
+         return *this;
+     }
+ 
+@@ -559,7 +559,7 @@ namespace {
+               uint32_t         sizeData
+     )
+     {
+-        Exiv2::Value::AutoPtr value;
++        Exiv2::Value::UniquePtr value;
+         Exiv2::TypeId type = Exiv2::IptcDataSets::dataSetType(dataSet, record);
+         value = Exiv2::Value::create(type);
+         int rc = value->read(data, sizeData, Exiv2::bigEndian);
+diff --git a/src/jp2image.cpp b/src/jp2image.cpp
+index 9a47537..87ffa66 100644
+--- a/src/jp2image.cpp
++++ b/src/jp2image.cpp
+@@ -132,8 +132,8 @@ struct Jp2UuidBox
+ namespace Exiv2
+ {
+ 
+-    Jp2Image::Jp2Image(BasicIo::AutoPtr io, bool create)
+-            : Image(ImageType::jp2, mdExif | mdIptc | mdXmp, io)
++    Jp2Image::Jp2Image(BasicIo::UniquePtr io, bool create)
++            : Image(ImageType::jp2, mdExif | mdIptc | mdXmp, std::move(io))
+     {
+         if (create)
+         {
+@@ -602,7 +602,7 @@ static void boxes_check(size_t b,size_t m)
+                             if (bIsExif && bRecursive && rawData.size_ > 8) { // "II*\0long"
+                                 if ((rawData.pData_[0] == rawData.pData_[1]) &&
+                                     (rawData.pData_[0] == 'I' || rawData.pData_[0] == 'M')) {
+-                                    BasicIo::AutoPtr p = BasicIo::AutoPtr(new MemIo(rawData.pData_, rawData.size_));
++                                    BasicIo::UniquePtr p = BasicIo::UniquePtr(new MemIo(rawData.pData_, rawData.size_));
+                                     printTiffStructure(*p, out, option, depth);
+                                 }
+                             }
+@@ -638,7 +638,7 @@ static void boxes_check(size_t b,size_t m)
+             throw Error(kerDataSourceOpenFailed, io_->path(), strError());
+         }
+         IoCloser closer(*io_);
+-        BasicIo::AutoPtr tempIo(new MemIo);
++        BasicIo::UniquePtr tempIo(new MemIo);
+         assert (tempIo.get() != 0);
+ 
+         doWriteMetadata(*tempIo); // may throw
+@@ -972,9 +972,9 @@ static void boxes_check(size_t b,size_t m)
+ 
+     // *************************************************************************
+     // free functions
+-    Image::AutoPtr newJp2Instance(BasicIo::AutoPtr io, bool create)
++    Image::UniquePtr newJp2Instance(BasicIo::UniquePtr io, bool create)
+     {
+-        Image::AutoPtr image(new Jp2Image(io, create));
++        Image::UniquePtr image(new Jp2Image(std::move(io), create));
+         if (!image->good())
+         {
+             image.reset();
+diff --git a/src/jpgimage.cpp b/src/jpgimage.cpp
+index e57bffb..a14a0e0 100644
+--- a/src/jpgimage.cpp
++++ b/src/jpgimage.cpp
+@@ -312,9 +312,9 @@ namespace Exiv2 {
+ 
+     } // Photoshop::setIptcIrb
+ 
+-    JpegBase::JpegBase(int type, BasicIo::AutoPtr io, bool create,
++    JpegBase::JpegBase(int type, BasicIo::UniquePtr io, bool create,
+                        const byte initData[], long dataSize)
+-        : Image(type, mdExif | mdIptc | mdXmp | mdComment, io)
++        : Image(type, mdExif | mdIptc | mdXmp | mdComment, std::move(io))
+     {
+         if (create) {
+             initImage(initData, dataSize);
+@@ -770,7 +770,7 @@ namespace Exiv2 {
+                             IptcData::printStructure(out, makeSlice(exif, 0, size), depth);
+                         } else {
+                             // create a copy on write memio object with the data, then print the structure
+-                            BasicIo::AutoPtr p = BasicIo::AutoPtr(new MemIo(exif + start, size - start));
++                            BasicIo::UniquePtr p = BasicIo::UniquePtr(new MemIo(exif + start, size - start));
+                             if (start < max)
+                                 printTiffStructure(*p, out, option, depth);
+                         }
+@@ -843,7 +843,7 @@ namespace Exiv2 {
+             // exiv2 -pS E.jpg
+ 
+             // binary copy io_ to a temporary file
+-            BasicIo::AutoPtr tempIo(new MemIo);
++            BasicIo::UniquePtr tempIo(new MemIo);
+ 
+             assert(tempIo.get() != 0);
+             for (size_t i = 0; i < (count / 2) + 1; i++) {
+@@ -875,7 +875,7 @@ namespace Exiv2 {
+             throw Error(kerDataSourceOpenFailed, io_->path(), strError());
+         }
+         IoCloser closer(*io_);
+-        BasicIo::AutoPtr tempIo(new MemIo);
++        BasicIo::UniquePtr tempIo(new MemIo);
+         assert (tempIo.get() != 0);
+ 
+         doWriteMetadata(*tempIo); // may throw
+@@ -1316,8 +1316,8 @@ namespace Exiv2 {
+         0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0xFF,0xDA,0x00,0x0C,0x03,0x01,0x00,0x02,
+         0x11,0x03,0x11,0x00,0x3F,0x00,0xA0,0x00,0x0F,0xFF,0xD9 };
+ 
+-    JpegImage::JpegImage(BasicIo::AutoPtr io, bool create)
+-        : JpegBase(ImageType::jpeg, io, create, blank_, sizeof(blank_))
++    JpegImage::JpegImage(BasicIo::UniquePtr io, bool create)
++        : JpegBase(ImageType::jpeg, std::move(io), create, blank_, sizeof(blank_))
+     {
+     }
+ 
+@@ -1342,9 +1342,9 @@ namespace Exiv2 {
+         return isJpegType(iIo, advance);
+     }
+ 
+-    Image::AutoPtr newJpegInstance(BasicIo::AutoPtr io, bool create)
++    Image::UniquePtr newJpegInstance(BasicIo::UniquePtr io, bool create)
+     {
+-        Image::AutoPtr image(new JpegImage(io, create));
++        Image::UniquePtr image(new JpegImage(std::move(io), create));
+         if (!image->good()) {
+             image.reset();
+         }
+@@ -1368,8 +1368,8 @@ namespace Exiv2 {
+     const char ExvImage::exiv2Id_[] = "Exiv2";
+     const byte ExvImage::blank_[] = { 0xff,0x01,'E','x','i','v','2',0xff,0xd9 };
+ 
+-    ExvImage::ExvImage(BasicIo::AutoPtr io, bool create)
+-        : JpegBase(ImageType::exv, io, create, blank_, sizeof(blank_))
++    ExvImage::ExvImage(BasicIo::UniquePtr io, bool create)
++        : JpegBase(ImageType::exv, std::move(io), create, blank_, sizeof(blank_))
+     {
+     }
+ 
+@@ -1395,10 +1395,10 @@ namespace Exiv2 {
+         return isExvType(iIo, advance);
+     }
+ 
+-    Image::AutoPtr newExvInstance(BasicIo::AutoPtr io, bool create)
++    Image::UniquePtr newExvInstance(BasicIo::UniquePtr io, bool create)
+     {
+-        Image::AutoPtr image;
+-        image = Image::AutoPtr(new ExvImage(io, create));
++        Image::UniquePtr image;
++        image = Image::UniquePtr(new ExvImage(std::move(io), create));
+         if (!image->good()) image.reset();
+         return image;
+     }
+diff --git a/src/matroskavideo.cpp b/src/matroskavideo.cpp
+index b97feb7..ae3d29b 100644
+--- a/src/matroskavideo.cpp
++++ b/src/matroskavideo.cpp
+@@ -471,7 +471,7 @@ namespace Exiv2 {
+ 
+     using namespace Exiv2::Internal;
+ 
+-    MatroskaVideo::MatroskaVideo(BasicIo::AutoPtr io)
++    MatroskaVideo::MatroskaVideo(BasicIo::UniquePtr io)
+         : Image(ImageType::mkv, mdNone, io)
+     {
+     } // MatroskaVideo::MatroskaVideo
+@@ -730,9 +730,9 @@ namespace Exiv2 {
+         else              return 0;
+     } // MatroskaVideo::findBlockSize
+ 
+-    Image::AutoPtr newMkvInstance(BasicIo::AutoPtr io, bool /*create*/)
++    Image::UniquePtr newMkvInstance(BasicIo::UniquePtr io, bool /*create*/)
+     {
+-        Image::AutoPtr image(new MatroskaVideo(io));
++        Image::UniquePtr image(new MatroskaVideo(io));
+         if (!image->good()) {
+             image.reset();
+         }
+diff --git a/src/metadatum.cpp b/src/metadatum.cpp
+index 69a32ed..d506388 100644
+--- a/src/metadatum.cpp
++++ b/src/metadatum.cpp
+@@ -34,9 +34,9 @@ namespace Exiv2 {
+     {
+     }
+ 
+-    Key::AutoPtr Key::clone() const
++    Key::UniquePtr Key::clone() const
+     {
+-        return AutoPtr(clone_());
++        return UniquePtr(clone_());
+     }
+ 
+     Key& Key::operator=(const Key& /*rhs*/)
+diff --git a/src/mrwimage.cpp b/src/mrwimage.cpp
+index c837805..3a8d33c 100644
+--- a/src/mrwimage.cpp
++++ b/src/mrwimage.cpp
+@@ -39,8 +39,8 @@
+ // class member definitions
+ namespace Exiv2 {
+ 
+-    MrwImage::MrwImage(BasicIo::AutoPtr io, bool /*create*/)
+-        : Image(ImageType::mrw, mdExif | mdIptc | mdXmp, io)
++    MrwImage::MrwImage(BasicIo::UniquePtr io, bool /*create*/)
++        : Image(ImageType::mrw, mdExif | mdIptc | mdXmp, std::move(io))
+     {
+     } // MrwImage::MrwImage
+ 
+@@ -153,9 +153,9 @@ namespace Exiv2 {
+ 
+     // *************************************************************************
+     // free functions
+-    Image::AutoPtr newMrwInstance(BasicIo::AutoPtr io, bool create)
++    Image::UniquePtr newMrwInstance(BasicIo::UniquePtr io, bool create)
+     {
+-        Image::AutoPtr image(new MrwImage(io, create));
++        Image::UniquePtr image(new MrwImage(std::move(io), create));
+         if (!image->good()) {
+             image.reset();
+         }
+diff --git a/src/orfimage.cpp b/src/orfimage.cpp
+index 9835af2..e3bf520 100644
+--- a/src/orfimage.cpp
++++ b/src/orfimage.cpp
+@@ -43,8 +43,8 @@ namespace Exiv2 {
+ 
+     using namespace Internal;
+ 
+-    OrfImage::OrfImage(BasicIo::AutoPtr io, bool create)
+-        : TiffImage(/*ImageType::orf, mdExif | mdIptc | mdXmp,*/ io,create)
++    OrfImage::OrfImage(BasicIo::UniquePtr io, bool create)
++        : TiffImage(/*ImageType::orf, mdExif | mdIptc | mdXmp,*/ std::move(io),create)
+     {
+         setTypeSupported(ImageType::orf, mdExif | mdIptc | mdXmp);
+     } // OrfImage::OrfImage
+@@ -189,7 +189,7 @@ namespace Exiv2 {
+                      ed.end());
+         }
+ 
+-        std::auto_ptr<TiffHeaderBase> header(new OrfHeader(byteOrder));
++        std::unique_ptr<TiffHeaderBase> header(new OrfHeader(byteOrder));
+         return TiffParserWorker::encode(io,
+                                         pData,
+                                         size,
+@@ -204,9 +204,9 @@ namespace Exiv2 {
+ 
+     // *************************************************************************
+     // free functions
+-    Image::AutoPtr newOrfInstance(BasicIo::AutoPtr io, bool create)
++    Image::UniquePtr newOrfInstance(BasicIo::UniquePtr io, bool create)
+     {
+-        Image::AutoPtr image(new OrfImage(io, create));
++        Image::UniquePtr image(new OrfImage(std::move(io), create));
+         if (!image->good()) {
+             image.reset();
+         }
+diff --git a/src/pgfimage.cpp b/src/pgfimage.cpp
+index 4dfb948..20228bb 100644
+--- a/src/pgfimage.cpp
++++ b/src/pgfimage.cpp
+@@ -76,8 +76,8 @@ namespace Exiv2 {
+         return result;
+     }
+ 
+-    PgfImage::PgfImage(BasicIo::AutoPtr io, bool create)
+-            : Image(ImageType::pgf, mdExif | mdIptc| mdXmp | mdComment, io)
++    PgfImage::PgfImage(BasicIo::UniquePtr io, bool create)
++            : Image(ImageType::pgf, mdExif | mdIptc| mdXmp | mdComment, std::move(io))
+             , bSwap_(isBigEndianPlatform())
+     {
+         if (create)
+@@ -143,7 +143,7 @@ namespace Exiv2 {
+         if (io_->error()) throw Error(kerFailedToReadImageData);
+         if (bufRead != imgData.size_) throw Error(kerInputDataReadFailed);
+ 
+-        Image::AutoPtr image = Exiv2::ImageFactory::open(imgData.pData_, imgData.size_);
++        Image::UniquePtr image = Exiv2::ImageFactory::open(imgData.pData_, imgData.size_);
+         image->readMetadata();
+         exifData() = image->exifData();
+         iptcData() = image->iptcData();
+@@ -158,7 +158,7 @@ namespace Exiv2 {
+             throw Error(kerDataSourceOpenFailed, io_->path(), strError());
+         }
+         IoCloser closer(*io_);
+-        BasicIo::AutoPtr tempIo(new MemIo);
++        BasicIo::UniquePtr tempIo(new MemIo);
+         assert (tempIo.get() != 0);
+ 
+         doWriteMetadata(*tempIo); // may throw
+@@ -192,7 +192,7 @@ namespace Exiv2 {
+         int w = 0, h = 0;
+         DataBuf header      = readPgfHeaderStructure(*io_, w, h);
+ 
+-        Image::AutoPtr img  = ImageFactory::create(ImageType::png);
++        Image::UniquePtr img  = ImageFactory::create(ImageType::png);
+ 
+         img->setExifData(exifData_);
+         img->setIptcData(iptcData_);
+@@ -314,9 +314,9 @@ namespace Exiv2 {
+ 
+     // *************************************************************************
+     // free functions
+-    Image::AutoPtr newPgfInstance(BasicIo::AutoPtr io, bool create)
++    Image::UniquePtr newPgfInstance(BasicIo::UniquePtr io, bool create)
+     {
+-        Image::AutoPtr image(new PgfImage(io, create));
++        Image::UniquePtr image(new PgfImage(std::move(io), create));
+         if (!image->good())
+         {
+             image.reset();
+diff --git a/src/pngimage.cpp b/src/pngimage.cpp
+index 64fce49..5c592f7 100644
+--- a/src/pngimage.cpp
++++ b/src/pngimage.cpp
+@@ -73,8 +73,8 @@ namespace Exiv2 {
+ 
+     using namespace Internal;
+ 
+-    PngImage::PngImage(BasicIo::AutoPtr io, bool create)
+-            : Image(ImageType::png, mdExif | mdIptc | mdXmp | mdComment, io)
++    PngImage::PngImage(BasicIo::UniquePtr io, bool create)
++            : Image(ImageType::png, mdExif | mdIptc | mdXmp | mdComment, std::move(io))
+     {
+         if (create)
+         {
+@@ -361,7 +361,7 @@ namespace Exiv2 {
+                             if ( parsedBuf.size_ ) {
+                                 if ( bExif ) {
+                                     // create memio object with the data, then print the structure
+-                                    BasicIo::AutoPtr p = BasicIo::AutoPtr(new MemIo(parsedBuf.pData_+6,parsedBuf.size_-6));
++                                    BasicIo::UniquePtr p = BasicIo::UniquePtr(new MemIo(parsedBuf.pData_+6,parsedBuf.size_-6));
+                                     printTiffStructure(*p,out,option,depth);
+                                 }
+                                 if ( bIptc ) {
+@@ -391,7 +391,7 @@ namespace Exiv2 {
+                         }
+                         if ( eXIf && option == kpsRecursive ) {
+                             // create memio object with the data, then print the structure
+-                            BasicIo::AutoPtr p = BasicIo::AutoPtr(new MemIo(data.pData_, dataOffset));
++                            BasicIo::UniquePtr p = BasicIo::UniquePtr(new MemIo(data.pData_, dataOffset));
+                             printTiffStructure(*p,out,option,depth);
+                         }
+ 
+@@ -527,7 +527,7 @@ namespace Exiv2 {
+             throw Error(kerDataSourceOpenFailed, io_->path(), strError());
+         }
+         IoCloser closer(*io_);
+-        BasicIo::AutoPtr tempIo(new MemIo);
++        BasicIo::UniquePtr tempIo(new MemIo);
+         assert (tempIo.get() != 0);
+ 
+         doWriteMetadata(*tempIo); // may throw
+@@ -742,9 +742,9 @@ namespace Exiv2 {
+ 
+     // *************************************************************************
+     // free functions
+-    Image::AutoPtr newPngInstance(BasicIo::AutoPtr io, bool create)
++    Image::UniquePtr newPngInstance(BasicIo::UniquePtr io, bool create)
+     {
+-        Image::AutoPtr image(new PngImage(io, create));
++        Image::UniquePtr image(new PngImage(std::move(io), create));
+         if (!image->good())
+         {
+             image.reset();
+diff --git a/src/preview.cpp b/src/preview.cpp
+index 8b68a3c..c96f559 100644
+--- a/src/preview.cpp
++++ b/src/preview.cpp
+@@ -88,10 +88,10 @@ namespace {
+         virtual ~Loader() {}
+ 
+         //! Loader auto pointer
+-        typedef std::auto_ptr<Loader> AutoPtr;
++        typedef std::unique_ptr<Loader> UniquePtr;
+ 
+         //! Create a Loader subclass for requested id
+-        static AutoPtr create(PreviewId id, const Image &image);
++        static UniquePtr create(PreviewId id, const Image &image);
+ 
+         //! Check if a preview image with given params exists in the image
+         virtual bool valid() const { return valid_; }
+@@ -113,7 +113,7 @@ namespace {
+         Loader(PreviewId id, const Image &image);
+ 
+         //! Functions that creates a loader from given parameters
+-        typedef AutoPtr (*CreateFunc)(PreviewId id, const Image &image, int parIdx);
++        typedef UniquePtr (*CreateFunc)(PreviewId id, const Image &image, int parIdx);
+ 
+         //! Structure to list possible loaders
+         struct LoaderList {
+@@ -165,7 +165,7 @@ namespace {
+     };
+ 
+     //! Function to create new LoaderNative
+-    Loader::AutoPtr createLoaderNative(PreviewId id, const Image &image, int parIdx);
++    Loader::UniquePtr createLoaderNative(PreviewId id, const Image &image, int parIdx);
+ 
+     //! Loader for Jpeg previews that are not read into ExifData directly
+     class LoaderExifJpeg : public Loader {
+@@ -199,7 +199,7 @@ namespace {
+     };
+ 
+     //! Function to create new LoaderExifJpeg
+-    Loader::AutoPtr createLoaderExifJpeg(PreviewId id, const Image &image, int parIdx);
++    Loader::UniquePtr createLoaderExifJpeg(PreviewId id, const Image &image, int parIdx);
+ 
+     //! Loader for Jpeg previews that are read into ExifData
+     class LoaderExifDataJpeg : public Loader {
+@@ -232,7 +232,7 @@ namespace {
+     };
+ 
+     //! Function to create new LoaderExifDataJpeg
+-    Loader::AutoPtr createLoaderExifDataJpeg(PreviewId id, const Image &image, int parIdx);
++    Loader::UniquePtr createLoaderExifDataJpeg(PreviewId id, const Image &image, int parIdx);
+ 
+     //! Loader for Tiff previews - it can get image data from ExifData or image_.io() as needed
+     class LoaderTiff : public Loader {
+@@ -269,7 +269,7 @@ namespace {
+     };
+ 
+     //! Function to create new LoaderTiff
+-    Loader::AutoPtr createLoaderTiff(PreviewId id, const Image &image, int parIdx);
++    Loader::UniquePtr createLoaderTiff(PreviewId id, const Image &image, int parIdx);
+ 
+     //! Loader for JPEG previews stored in the XMP metadata
+     class LoaderXmpJpeg : public Loader {
+@@ -292,7 +292,7 @@ namespace {
+     };
+ 
+     //! Function to create new LoaderXmpJpeg
+-    Loader::AutoPtr createLoaderXmpJpeg(PreviewId id, const Image &image, int parIdx);
++    Loader::UniquePtr createLoaderXmpJpeg(PreviewId id, const Image &image, int parIdx);
+ 
+ // *****************************************************************************
+ // class member definitions
+@@ -372,16 +372,16 @@ namespace {
+         { "Image2",    0,                               0   }   // 7
+     };
+ 
+-    Loader::AutoPtr Loader::create(PreviewId id, const Image &image)
++    Loader::UniquePtr Loader::create(PreviewId id, const Image &image)
+     {
+         if (id < 0 || id >= Loader::getNumLoaders())
+-            return AutoPtr();
++            return UniquePtr();
+ 
+         if (loaderList_[id].imageMimeType_ &&
+             std::string(loaderList_[id].imageMimeType_) != image.mimeType())
+-            return AutoPtr();
++            return UniquePtr();
+ 
+-        AutoPtr loader = loaderList_[id].create_(id, image, loaderList_[id].parIdx_);
++        UniquePtr loader = loaderList_[id].create_(id, image, loaderList_[id].parIdx_);
+ 
+         if (loader.get() && !loader->valid()) loader.reset();
+         return loader;
+@@ -425,9 +425,9 @@ namespace {
+         }
+     }
+ 
+-    Loader::AutoPtr createLoaderNative(PreviewId id, const Image &image, int parIdx)
++    Loader::UniquePtr createLoaderNative(PreviewId id, const Image &image, int parIdx)
+     {
+-        return Loader::AutoPtr(new LoaderNative(id, image, parIdx));
++        return Loader::UniquePtr(new LoaderNative(id, image, parIdx));
+     }
+ 
+     PreviewProperties LoaderNative::getProperties() const
+@@ -501,7 +501,7 @@ namespace {
+         const DataBuf data = getData();
+         if (data.size_ == 0) return false;
+         try {
+-            Image::AutoPtr image = ImageFactory::open(data.pData_, data.size_);
++            Image::UniquePtr image = ImageFactory::open(data.pData_, data.size_);
+             if (image.get() == 0) return false;
+             image->readMetadata();
+ 
+@@ -547,9 +547,9 @@ namespace {
+         valid_ = true;
+     }
+ 
+-    Loader::AutoPtr createLoaderExifJpeg(PreviewId id, const Image &image, int parIdx)
++    Loader::UniquePtr createLoaderExifJpeg(PreviewId id, const Image &image, int parIdx)
+     {
+-        return Loader::AutoPtr(new LoaderExifJpeg(id, image, parIdx));
++        return Loader::UniquePtr(new LoaderExifJpeg(id, image, parIdx));
+     }
+ 
+     PreviewProperties LoaderExifJpeg::getProperties() const
+@@ -592,7 +592,7 @@ namespace {
+         const Exiv2::byte* base = io.mmap();
+ 
+         try {
+-            Image::AutoPtr image = ImageFactory::open(base + offset_, size_);
++            Image::UniquePtr image = ImageFactory::open(base + offset_, size_);
+             if (image.get() == 0) return false;
+             image->readMetadata();
+ 
+@@ -625,9 +625,9 @@ namespace {
+         valid_ = true;
+     }
+ 
+-    Loader::AutoPtr createLoaderExifDataJpeg(PreviewId id, const Image &image, int parIdx)
++    Loader::UniquePtr createLoaderExifDataJpeg(PreviewId id, const Image &image, int parIdx)
+     {
+-        return Loader::AutoPtr(new LoaderExifDataJpeg(id, image, parIdx));
++        return Loader::UniquePtr(new LoaderExifDataJpeg(id, image, parIdx));
+     }
+ 
+     PreviewProperties LoaderExifDataJpeg::getProperties() const
+@@ -669,7 +669,7 @@ namespace {
+         if (buf.size_ == 0) return false;
+ 
+         try {
+-            Image::AutoPtr image = ImageFactory::open(buf.pData_, buf.size_);
++            Image::UniquePtr image = ImageFactory::open(buf.pData_, buf.size_);
+             if (image.get() == 0) return false;
+             image->readMetadata();
+ 
+@@ -737,9 +737,9 @@ namespace {
+         valid_ = true;
+     }
+ 
+-    Loader::AutoPtr createLoaderTiff(PreviewId id, const Image &image, int parIdx)
++    Loader::UniquePtr createLoaderTiff(PreviewId id, const Image &image, int parIdx)
+     {
+-        return Loader::AutoPtr(new LoaderTiff(id, image, parIdx));
++        return Loader::UniquePtr(new LoaderTiff(id, image, parIdx));
+     }
+ 
+     PreviewProperties LoaderTiff::getProperties() const
+@@ -867,9 +867,9 @@ namespace {
+         valid_ = true;
+     }
+ 
+-    Loader::AutoPtr createLoaderXmpJpeg(PreviewId id, const Image &image, int parIdx)
++    Loader::UniquePtr createLoaderXmpJpeg(PreviewId id, const Image &image, int parIdx)
+     {
+-        return Loader::AutoPtr(new LoaderXmpJpeg(id, image, parIdx));
++        return Loader::UniquePtr(new LoaderXmpJpeg(id, image, parIdx));
+     }
+ 
+     PreviewProperties LoaderXmpJpeg::getProperties() const
+@@ -1148,7 +1148,7 @@ namespace Exiv2 {
+         PreviewPropertiesList list;
+         // go through the loader table and store all successfully created loaders in the list
+         for (PreviewId id = 0; id < Loader::getNumLoaders(); ++id) {
+-            Loader::AutoPtr loader = Loader::create(id, image_);
++            Loader::UniquePtr loader = Loader::create(id, image_);
+             if (loader.get() && loader->readDimensions()) {
+                 PreviewProperties props = loader->getProperties();
+                 DataBuf buf             = loader->getData(); // #16 getPreviewImage()
+@@ -1162,7 +1162,7 @@ namespace Exiv2 {
+ 
+     PreviewImage PreviewManager::getPreviewImage(const PreviewProperties &properties) const
+     {
+-        Loader::AutoPtr loader = Loader::create(properties.id_, image_);
++        Loader::UniquePtr loader = Loader::create(properties.id_, image_);
+         DataBuf buf;
+         if (loader.get()) {
+             buf = loader->getData();
+diff --git a/src/properties.cpp b/src/properties.cpp
+index 0d4395d..9a94480 100644
+--- a/src/properties.cpp
++++ b/src/properties.cpp
+@@ -2749,9 +2749,9 @@ namespace Exiv2 {
+         return *this;
+     }
+ 
+-    XmpKey::AutoPtr XmpKey::clone() const
++    XmpKey::UniquePtr XmpKey::clone() const
+     {
+-        return AutoPtr(clone_());
++        return UniquePtr(clone_());
+     }
+ 
+     XmpKey* XmpKey::clone_() const
+diff --git a/src/psdimage.cpp b/src/psdimage.cpp
+index 2d1472f..47ee993 100644
+--- a/src/psdimage.cpp
++++ b/src/psdimage.cpp
+@@ -117,8 +117,8 @@ enum {
+ // class member definitions
+ namespace Exiv2 {
+ 
+-    PsdImage::PsdImage(BasicIo::AutoPtr io)
+-        : Image(ImageType::psd, mdExif | mdIptc | mdXmp, io)
++    PsdImage::PsdImage(BasicIo::UniquePtr io)
++        : Image(ImageType::psd, mdExif | mdIptc | mdXmp, std::move(io))
+     {
+     } // PsdImage::PsdImage
+ 
+@@ -350,7 +350,7 @@ namespace Exiv2 {
+             throw Error(kerDataSourceOpenFailed, io_->path(), strError());
+         }
+         IoCloser closer(*io_);
+-        BasicIo::AutoPtr tempIo(new MemIo);
++        BasicIo::UniquePtr tempIo(new MemIo);
+         assert (tempIo.get() != 0);
+ 
+         doWriteMetadata(*tempIo); // may throw
+@@ -683,9 +683,9 @@ namespace Exiv2 {
+ 
+     // *************************************************************************
+     // free functions
+-    Image::AutoPtr newPsdInstance(BasicIo::AutoPtr io, bool /*create*/)
++    Image::UniquePtr newPsdInstance(BasicIo::UniquePtr io, bool /*create*/)
+     {
+-        Image::AutoPtr image(new PsdImage(io));
++        Image::UniquePtr image(new PsdImage(std::move(io)));
+         if (!image->good())
+         {
+             image.reset();
+diff --git a/src/quicktimevideo.cpp b/src/quicktimevideo.cpp
+index 335d884..55320ee 100644
+--- a/src/quicktimevideo.cpp
++++ b/src/quicktimevideo.cpp
+@@ -601,7 +601,7 @@ namespace Exiv2 {
+ 
+     using namespace Exiv2::Internal;
+ 
+-    QuickTimeVideo::QuickTimeVideo(BasicIo::AutoPtr io)
++    QuickTimeVideo::QuickTimeVideo(BasicIo::UniquePtr io)
+             : Image(ImageType::qtime, mdNone, io)
+             , timeScale_(1)
+     {
+@@ -1388,7 +1388,7 @@ namespace Exiv2 {
+         DataBuf buf(5);
+         std::memset(buf.pData_, 0x0, buf.size_);
+         buf.pData_[4] = '\0';
+-        Exiv2::Value::AutoPtr v = Exiv2::Value::create(Exiv2::xmpSeq);
++        Exiv2::Value::UniquePtr v = Exiv2::Value::create(Exiv2::xmpSeq);
+         const TagVocabulary* td;
+ 
+         for (int i = 0; size/4 != 0; size -=4, i++) {
+@@ -1624,8 +1624,8 @@ namespace Exiv2 {
+     } // QuickTimeVideo::aspectRatio
+ 
+ 
+-    Image::AutoPtr newQTimeInstance(BasicIo::AutoPtr io, bool /*create*/) {
+-        Image::AutoPtr image(new QuickTimeVideo(io));
++    Image::UniquePtr newQTimeInstance(BasicIo::UniquePtr io, bool /*create*/) {
++        Image::UniquePtr image(new QuickTimeVideo(io));
+         if (!image->good()) {
+             image.reset();
+         }
+diff --git a/src/rafimage.cpp b/src/rafimage.cpp
+index 5cec4b9..e567521 100644
+--- a/src/rafimage.cpp
++++ b/src/rafimage.cpp
+@@ -41,8 +41,8 @@
+ // class member definitions
+ namespace Exiv2 {
+ 
+-    RafImage::RafImage(BasicIo::AutoPtr io, bool /*create*/)
+-        : Image(ImageType::raf, mdExif | mdIptc | mdXmp, io)
++    RafImage::RafImage(BasicIo::UniquePtr io, bool /*create*/)
++        : Image(ImageType::raf, mdExif | mdIptc | mdXmp, std::move(io))
+     {
+     } // RafImage::RafImage
+ 
+@@ -396,9 +396,9 @@ namespace Exiv2 {
+ 
+     // *************************************************************************
+     // free functions
+-    Image::AutoPtr newRafInstance(BasicIo::AutoPtr io, bool create)
++    Image::UniquePtr newRafInstance(BasicIo::UniquePtr io, bool create)
+     {
+-        Image::AutoPtr image(new RafImage(io, create));
++        Image::UniquePtr image(new RafImage(std::move(io), create));
+         if (!image->good()) {
+             image.reset();
+         }
+diff --git a/src/riffvideo.cpp b/src/riffvideo.cpp
+index ad00cf9..a88b5f8 100644
+--- a/src/riffvideo.cpp
++++ b/src/riffvideo.cpp
+@@ -496,7 +496,7 @@ namespace Exiv2 {
+ namespace Exiv2 {
+     using namespace Exiv2::Internal;
+ 
+-    RiffVideo::RiffVideo(BasicIo::AutoPtr io)
++    RiffVideo::RiffVideo(BasicIo::UniquePtr io)
+             : Image(ImageType::riff, mdNone, io)
+     {
+     } // RiffVideo::RiffVideo
+@@ -572,7 +572,7 @@ namespace Exiv2 {
+ 
+                 if ( equalsRiffTag(chunkId, RIFF_CHUNK_HEADER_EXIF) && option==kpsRecursive ) {
+                     // create memio object with the payload, then print the structure
+-                    BasicIo::AutoPtr p = BasicIo::AutoPtr(new MemIo(payload.pData_,payload.size_));
++                    BasicIo::UniquePtr p = BasicIo::UniquePtr(new MemIo(payload.pData_,payload.size_));
+                     printTiffStructure(*p,out,option,depth);
+                 }
+ 
+@@ -1298,9 +1298,9 @@ namespace Exiv2 {
+         xmpData_["Xmp.video.Duration"] = duration; //Duration in number of seconds
+     } // RiffVideo::fillDuration
+ 
+-    Image::AutoPtr newRiffInstance(BasicIo::AutoPtr io, bool /*create*/)
++    Image::UniquePtr newRiffInstance(BasicIo::UniquePtr io, bool /*create*/)
+     {
+-        Image::AutoPtr image(new RiffVideo(io));
++        Image::UniquePtr image(new RiffVideo(io));
+         if (!image->good()) {
+             image.reset();
+         }
+diff --git a/src/rw2image.cpp b/src/rw2image.cpp
+index 1fdd72e..e8a9e60 100644
+--- a/src/rw2image.cpp
++++ b/src/rw2image.cpp
+@@ -41,8 +41,8 @@ namespace Exiv2 {
+ 
+     using namespace Internal;
+ 
+-    Rw2Image::Rw2Image(BasicIo::AutoPtr io)
+-        : Image(ImageType::rw2, mdExif | mdIptc | mdXmp, io)
++    Rw2Image::Rw2Image(BasicIo::UniquePtr io)
++        : Image(ImageType::rw2, mdExif | mdIptc | mdXmp, std::move(io))
+     {
+     } // Rw2Image::Rw2Image
+ 
+@@ -139,7 +139,7 @@ namespace Exiv2 {
+         if (list.size() != 1) return;
+         ExifData exifData;
+         PreviewImage preview = loader.getPreviewImage(*list.begin());
+-        Image::AutoPtr image = ImageFactory::open(preview.pData(), preview.size());
++        Image::UniquePtr image = ImageFactory::open(preview.pData(), preview.size());
+         if (image.get() == 0) {
+ #ifndef SUPPRESS_WARNINGS
+             EXV_WARNING << "Failed to open RW2 preview image.\n";
+@@ -238,9 +238,9 @@ namespace Exiv2 {
+ 
+     // *************************************************************************
+     // free functions
+-    Image::AutoPtr newRw2Instance(BasicIo::AutoPtr io, bool /*create*/)
++    Image::UniquePtr newRw2Instance(BasicIo::UniquePtr io, bool /*create*/)
+     {
+-        Image::AutoPtr image(new Rw2Image(io));
++        Image::UniquePtr image(new Rw2Image(std::move(io)));
+         if (!image->good()) {
+             image.reset();
+         }
+diff --git a/src/tags.cpp b/src/tags.cpp
+index df0d5f6..d6ec406 100644
+--- a/src/tags.cpp
++++ b/src/tags.cpp
+@@ -407,9 +407,9 @@ namespace Exiv2 {
+         return p_->tag_;
+     }
+ 
+-    ExifKey::AutoPtr ExifKey::clone() const
++    ExifKey::UniquePtr ExifKey::clone() const
+     {
+-        return AutoPtr(clone_());
++        return UniquePtr(clone_());
+     }
+ 
+     ExifKey* ExifKey::clone_() const
+diff --git a/src/tgaimage.cpp b/src/tgaimage.cpp
+index 3c012a4..315c112 100644
+--- a/src/tgaimage.cpp
++++ b/src/tgaimage.cpp
+@@ -36,8 +36,8 @@
+ // class member definitions
+ namespace Exiv2 {
+ 
+-    TgaImage::TgaImage(BasicIo::AutoPtr io)
+-        : Image(ImageType::tga, mdNone, io)
++    TgaImage::TgaImage(BasicIo::UniquePtr io)
++        : Image(ImageType::tga, mdNone, std::move(io))
+     {
+     } // TgaImage::TgaImage
+ 
+@@ -120,9 +120,9 @@ namespace Exiv2 {
+ 
+     // *************************************************************************
+     // free functions
+-    Image::AutoPtr newTgaInstance(BasicIo::AutoPtr io, bool /*create*/)
++    Image::UniquePtr newTgaInstance(BasicIo::UniquePtr io, bool /*create*/)
+     {
+-        Image::AutoPtr image(new TgaImage(io));
++        Image::UniquePtr image(new TgaImage(std::move(io)));
+         if (!image->good())
+         {
+             image.reset();
+diff --git a/src/tiffcomposite_int.cpp b/src/tiffcomposite_int.cpp
+index 0d98f77..ab84d63 100644
+--- a/src/tiffcomposite_int.cpp
++++ b/src/tiffcomposite_int.cpp
+@@ -285,9 +285,9 @@ namespace Exiv2 {
+     {
+     }
+ 
+-    TiffComponent::AutoPtr TiffComponent::clone() const
++    TiffComponent::UniquePtr TiffComponent::clone() const
+     {
+-        return AutoPtr(doClone());
++        return UniquePtr(doClone());
+     }
+ 
+     TiffEntry* TiffEntry::doClone() const
+@@ -369,7 +369,7 @@ namespace Exiv2 {
+         if (pData_ == 0) size_ = 0;
+     }
+ 
+-    void TiffEntryBase::updateValue(Value::AutoPtr value, ByteOrder byteOrder)
++    void TiffEntryBase::updateValue(Value::UniquePtr value, ByteOrder byteOrder)
+     {
+         if (value.get() == 0) return;
+         uint32_t newSize = value->size();
+@@ -381,10 +381,10 @@ namespace Exiv2 {
+         }
+         size_ = value->copy(pData_, byteOrder);
+         assert(size_ == newSize);
+-        setValue(value);
++        setValue(std::move(value));
+     } // TiffEntryBase::updateValue
+ 
+-    void TiffEntryBase::setValue(Value::AutoPtr value)
++    void TiffEntryBase::setValue(Value::UniquePtr value)
+     {
+         if (value.get() == 0) return;
+         tiffType_ = toTiffType(value->typeId());
+@@ -611,7 +611,7 @@ namespace Exiv2 {
+     {
+         uint16_t tag = static_cast<uint16_t>(idx / cfg()->tagStep());
+         int32_t sz = EXV_MIN(def.size(tag, cfg()->group_), TiffEntryBase::doSize() - idx);
+-        TiffComponent::AutoPtr tc = TiffCreator::create(tag, cfg()->group_);
++        TiffComponent::UniquePtr tc = TiffCreator::create(tag, cfg()->group_);
+         TiffBinaryElement* tp = dynamic_cast<TiffBinaryElement*>(tc.get());
+         // The assertion typically fails if a component is not configured in
+         // the TIFF structure table (TiffCreator::tiffTreeStruct_)
+@@ -620,22 +620,22 @@ namespace Exiv2 {
+         tp->setData(const_cast<byte*>(pData() + idx), sz);
+         tp->setElDef(def);
+         tp->setElByteOrder(cfg()->byteOrder_);
+-        addChild(tc);
++        addChild(std::move(tc));
+         return sz;
+     } // TiffBinaryArray::addElement
+ 
+     TiffComponent* TiffComponent::addPath(uint16_t tag,
+                                           TiffPath& tiffPath,
+                                           TiffComponent* const pRoot,
+-                                          TiffComponent::AutoPtr object)
++                                          TiffComponent::UniquePtr object)
+     {
+-        return doAddPath(tag, tiffPath, pRoot, object);
++        return doAddPath(tag, tiffPath, pRoot, std::move(object));
+     } // TiffComponent::addPath
+ 
+     TiffComponent* TiffComponent::doAddPath(uint16_t  /*tag*/,
+                                             TiffPath& /*tiffPath*/,
+                                             TiffComponent* const /*pRoot*/,
+-                                            TiffComponent::AutoPtr /*object*/)
++                                            TiffComponent::UniquePtr /*object*/)
+     {
+         return this;
+     } // TiffComponent::doAddPath
+@@ -643,7 +643,7 @@ namespace Exiv2 {
+     TiffComponent* TiffDirectory::doAddPath(uint16_t tag,
+                                             TiffPath& tiffPath,
+                                             TiffComponent* const pRoot,
+-                                            TiffComponent::AutoPtr object)
++                                            TiffComponent::UniquePtr object)
+     {
+         assert(tiffPath.size() > 1);
+         tiffPath.pop();
+@@ -669,9 +669,9 @@ namespace Exiv2 {
+             }
+         }
+         if (tc == 0) {
+-            TiffComponent::AutoPtr atc;
++            TiffComponent::UniquePtr atc;
+             if (tiffPath.size() == 1 && object.get() != 0) {
+-                atc = object;
++                atc = std::move(object);
+             }
+             else {
+                 atc = TiffCreator::create(tpi.extendedTag(), tpi.group());
+@@ -683,19 +683,19 @@ namespace Exiv2 {
+             if (tiffPath.size() == 1 && dynamic_cast<TiffSubIfd*>(atc.get()) != 0) return 0;
+ 
+             if (tpi.extendedTag() == Tag::next) {
+-                tc = this->addNext(atc);
++                tc = this->addNext(std::move(atc));
+             }
+             else {
+-                tc = this->addChild(atc);
++                tc = this->addChild(std::move(atc));
+             }
+         }
+-        return tc->addPath(tag, tiffPath, pRoot, object);
++        return tc->addPath(tag, tiffPath, pRoot, std::move(object));
+     } // TiffDirectory::doAddPath
+ 
+     TiffComponent* TiffSubIfd::doAddPath(uint16_t tag,
+                                          TiffPath& tiffPath,
+                                          TiffComponent* const pRoot,
+-                                         TiffComponent::AutoPtr object)
++                                         TiffComponent::UniquePtr object)
+     {
+         assert(!tiffPath.empty());
+         const TiffPathItem tpi1 = tiffPath.top();
+@@ -716,21 +716,21 @@ namespace Exiv2 {
+         }
+         if (tc == 0) {
+             if (tiffPath.size() == 1 && object.get() != 0) {
+-                tc = addChild(object);
++                tc = addChild(std::move(object));
+             }
+             else {
+-                TiffComponent::AutoPtr atc(new TiffDirectory(tpi1.tag(), tpi2.group()));
+-                tc = addChild(atc);
++                TiffComponent::UniquePtr atc(new TiffDirectory(tpi1.tag(), tpi2.group()));
++                tc = addChild(std::move(atc));
+             }
+             setCount(static_cast<uint32_t>(ifds_.size()));
+         }
+-        return tc->addPath(tag, tiffPath, pRoot, object);
++        return tc->addPath(tag, tiffPath, pRoot, std::move(object));
+     } // TiffSubIfd::doAddPath
+ 
+     TiffComponent* TiffMnEntry::doAddPath(uint16_t tag,
+                                           TiffPath& tiffPath,
+                                           TiffComponent* const pRoot,
+-                                          TiffComponent::AutoPtr object)
++                                          TiffComponent::UniquePtr object)
+     {
+         assert(!tiffPath.empty());
+         const TiffPathItem tpi1 = tiffPath.top();
+@@ -746,21 +746,21 @@ namespace Exiv2 {
+             mn_ = TiffMnCreator::create(tpi1.tag(), tpi1.group(), mnGroup_);
+             assert(mn_);
+         }
+-        return mn_->addPath(tag, tiffPath, pRoot, object);
++        return mn_->addPath(tag, tiffPath, pRoot, std::move(object));
+     } // TiffMnEntry::doAddPath
+ 
+     TiffComponent* TiffIfdMakernote::doAddPath(uint16_t tag,
+                                                TiffPath& tiffPath,
+                                                TiffComponent* const pRoot,
+-                                               TiffComponent::AutoPtr object)
++                                               TiffComponent::UniquePtr object)
+     {
+-        return ifd_.addPath(tag, tiffPath, pRoot, object);
++        return ifd_.addPath(tag, tiffPath, pRoot, std::move(object));
+     }
+ 
+     TiffComponent* TiffBinaryArray::doAddPath(uint16_t tag,
+                                               TiffPath& tiffPath,
+                                               TiffComponent* const pRoot,
+-                                              TiffComponent::AutoPtr object)
++                                              TiffComponent::UniquePtr object)
+     {
+         pRoot_ = pRoot;
+         if (tiffPath.size() == 1) {
+@@ -784,39 +784,39 @@ namespace Exiv2 {
+             }
+         }
+         if (tc == 0) {
+-            TiffComponent::AutoPtr atc;
++            TiffComponent::UniquePtr atc;
+             if (tiffPath.size() == 1 && object.get() != 0) {
+-                atc = object;
++                atc = std::move(object);
+             }
+             else {
+                 atc = TiffCreator::create(tpi.extendedTag(), tpi.group());
+             }
+             assert(atc.get() != 0);
+             assert(tpi.extendedTag() != Tag::next);
+-            tc = addChild(atc);
++            tc = addChild(std::move(atc));
+             setCount(static_cast<uint32_t>(elements_.size()));
+         }
+-        return tc->addPath(tag, tiffPath, pRoot, object);
++        return tc->addPath(tag, tiffPath, pRoot, std::move(object));
+     } // TiffBinaryArray::doAddPath
+ 
+-    TiffComponent* TiffComponent::addChild(TiffComponent::AutoPtr tiffComponent)
++    TiffComponent* TiffComponent::addChild(TiffComponent::UniquePtr tiffComponent)
+     {
+-        return doAddChild(tiffComponent);
++        return doAddChild(std::move(tiffComponent));
+     } // TiffComponent::addChild
+ 
+-    TiffComponent* TiffComponent::doAddChild(AutoPtr /*tiffComponent*/)
++    TiffComponent* TiffComponent::doAddChild(UniquePtr /*tiffComponent*/)
+     {
+         return 0;
+     } // TiffComponent::doAddChild
+ 
+-    TiffComponent* TiffDirectory::doAddChild(TiffComponent::AutoPtr tiffComponent)
++    TiffComponent* TiffDirectory::doAddChild(TiffComponent::UniquePtr tiffComponent)
+     {
+         TiffComponent* tc = tiffComponent.release();
+         components_.push_back(tc);
+         return tc;
+     } // TiffDirectory::doAddChild
+ 
+-    TiffComponent* TiffSubIfd::doAddChild(TiffComponent::AutoPtr tiffComponent)
++    TiffComponent* TiffSubIfd::doAddChild(TiffComponent::UniquePtr tiffComponent)
+     {
+         TiffDirectory* d = dynamic_cast<TiffDirectory*>(tiffComponent.release());
+         assert(d);
+@@ -824,21 +824,21 @@ namespace Exiv2 {
+         return d;
+     } // TiffSubIfd::doAddChild
+ 
+-    TiffComponent* TiffMnEntry::doAddChild(TiffComponent::AutoPtr tiffComponent)
++    TiffComponent* TiffMnEntry::doAddChild(TiffComponent::UniquePtr tiffComponent)
+     {
+         TiffComponent* tc = 0;
+         if (mn_) {
+-            tc =  mn_->addChild(tiffComponent);
++            tc =  mn_->addChild(std::move(tiffComponent));
+         }
+         return tc;
+     } // TiffMnEntry::doAddChild
+ 
+-    TiffComponent* TiffIfdMakernote::doAddChild(TiffComponent::AutoPtr tiffComponent)
++    TiffComponent* TiffIfdMakernote::doAddChild(TiffComponent::UniquePtr tiffComponent)
+     {
+-        return ifd_.addChild(tiffComponent);
++        return ifd_.addChild(std::move(tiffComponent));
+     }
+ 
+-    TiffComponent* TiffBinaryArray::doAddChild(TiffComponent::AutoPtr tiffComponent)
++    TiffComponent* TiffBinaryArray::doAddChild(TiffComponent::UniquePtr tiffComponent)
+     {
+         TiffComponent* tc = tiffComponent.release();
+         elements_.push_back(tc);
+@@ -846,17 +846,17 @@ namespace Exiv2 {
+         return tc;
+     } // TiffBinaryArray::doAddChild
+ 
+-    TiffComponent* TiffComponent::addNext(TiffComponent::AutoPtr tiffComponent)
++    TiffComponent* TiffComponent::addNext(TiffComponent::UniquePtr tiffComponent)
+     {
+-        return doAddNext(tiffComponent);
++        return doAddNext(std::move(tiffComponent));
+     } // TiffComponent::addNext
+ 
+-    TiffComponent* TiffComponent::doAddNext(AutoPtr /*tiffComponent*/)
++    TiffComponent* TiffComponent::doAddNext(UniquePtr /*tiffComponent*/)
+     {
+         return 0;
+     } // TiffComponent::doAddNext
+ 
+-    TiffComponent* TiffDirectory::doAddNext(TiffComponent::AutoPtr tiffComponent)
++    TiffComponent* TiffDirectory::doAddNext(TiffComponent::UniquePtr tiffComponent)
+     {
+         TiffComponent* tc = 0;
+         if (hasNext_) {
+@@ -866,18 +866,18 @@ namespace Exiv2 {
+         return tc;
+     } // TiffDirectory::doAddNext
+ 
+-    TiffComponent* TiffMnEntry::doAddNext(TiffComponent::AutoPtr tiffComponent)
++    TiffComponent* TiffMnEntry::doAddNext(TiffComponent::UniquePtr tiffComponent)
+     {
+         TiffComponent* tc = 0;
+         if (mn_) {
+-            tc = mn_->addNext(tiffComponent);
++            tc = mn_->addNext(std::move(tiffComponent));
+         }
+         return tc;
+     } // TiffMnEntry::doAddNext
+ 
+-    TiffComponent* TiffIfdMakernote::doAddNext(TiffComponent::AutoPtr tiffComponent)
++    TiffComponent* TiffIfdMakernote::doAddNext(TiffComponent::UniquePtr tiffComponent)
+     {
+-        return ifd_.addNext(tiffComponent);
++        return ifd_.addNext(std::move(tiffComponent));
+     }
+ 
+     void TiffComponent::accept(TiffVisitor& visitor)
+@@ -1918,19 +1918,19 @@ namespace Exiv2 {
+         return lhs->group() < rhs->group();
+     }
+ 
+-    TiffComponent::AutoPtr newTiffEntry(uint16_t tag, IfdId group)
++    TiffComponent::UniquePtr newTiffEntry(uint16_t tag, IfdId group)
+     {
+-        return TiffComponent::AutoPtr(new TiffEntry(tag, group));
++        return TiffComponent::UniquePtr(new TiffEntry(tag, group));
+     }
+ 
+-    TiffComponent::AutoPtr newTiffMnEntry(uint16_t tag, IfdId group)
++    TiffComponent::UniquePtr newTiffMnEntry(uint16_t tag, IfdId group)
+     {
+-        return TiffComponent::AutoPtr(new TiffMnEntry(tag, group, mnId));
++        return TiffComponent::UniquePtr(new TiffMnEntry(tag, group, mnId));
+     }
+ 
+-    TiffComponent::AutoPtr newTiffBinaryElement(uint16_t tag, IfdId group)
++    TiffComponent::UniquePtr newTiffBinaryElement(uint16_t tag, IfdId group)
+     {
+-        return TiffComponent::AutoPtr(new TiffBinaryElement(tag, group));
++        return TiffComponent::UniquePtr(new TiffBinaryElement(tag, group));
+     }
+ 
+ }}                                      // namespace Internal, Exiv2
+diff --git a/src/tiffcomposite_int.hpp b/src/tiffcomposite_int.hpp
+index f19026e..46a581b 100644
+--- a/src/tiffcomposite_int.hpp
++++ b/src/tiffcomposite_int.hpp
+@@ -28,6 +28,7 @@
+ 
+ // + standard includes
+ #include <iosfwd>
++#include <memory>
+ #include <vector>
+ #include <string>
+ #include <cassert>
+@@ -171,7 +172,7 @@ namespace Exiv2 {
+     class TiffComponent {
+     public:
+         //! TiffComponent auto_ptr type
+-        typedef std::auto_ptr<TiffComponent> AutoPtr;
++        typedef std::unique_ptr<TiffComponent> UniquePtr;
+         //! Container type to hold all metadata
+         typedef std::vector<TiffComponent*> Components;
+ 
+@@ -200,20 +201,20 @@ namespace Exiv2 {
+         TiffComponent* addPath(uint16_t tag,
+                                TiffPath& tiffPath,
+                                TiffComponent* const pRoot,
+-                               AutoPtr object =AutoPtr(0));
++                               UniquePtr object =UniquePtr(nullptr));
+         /*!
+           @brief Add a child to the component. Default is to do nothing.
+           @param tiffComponent Auto pointer to the component to add.
+           @return Return a pointer to the newly added child element or 0.
+          */
+-        TiffComponent* addChild(AutoPtr tiffComponent);
++        TiffComponent* addChild(UniquePtr tiffComponent);
+         /*!
+             @brief Add a "next" component to the component. Default is to do
+                    nothing.
+             @param tiffComponent Auto pointer to the component to add.
+             @return Return a pointer to the newly added "next" element or 0.
+          */
+-        TiffComponent* addNext(AutoPtr tiffComponent);
++        TiffComponent* addNext(UniquePtr tiffComponent);
+         /*!
+           @brief Interface to accept visitors (Visitor pattern). Visitors
+                  can perform operations on all components of the composite.
+@@ -262,7 +263,7 @@ namespace Exiv2 {
+                  without any children). The caller owns this copy and the
+                  auto-pointer ensures that it will be deleted.
+          */
+-        AutoPtr clone() const;
++        UniquePtr clone() const;
+         /*!
+           @brief Write the IFD data of this component to a binary image.
+                  Return the number of bytes written. Components derived from
+@@ -318,11 +319,11 @@ namespace Exiv2 {
+         virtual TiffComponent* doAddPath(uint16_t  tag,
+                                          TiffPath& tiffPath,
+                                          TiffComponent* const pRoot,
+-                                         TiffComponent::AutoPtr object);
++                                         TiffComponent::UniquePtr object);
+         //! Implements addChild(). The default implementation does nothing.
+-        virtual TiffComponent* doAddChild(AutoPtr tiffComponent);
++        virtual TiffComponent* doAddChild(UniquePtr tiffComponent);
+         //! Implements addNext(). The default implementation does nothing.
+-        virtual TiffComponent* doAddNext(AutoPtr tiffComponent);
++        virtual TiffComponent* doAddNext(UniquePtr tiffComponent);
+         //! Implements accept().
+         virtual void doAccept(TiffVisitor& visitor) =0;
+         //! Implements write().
+@@ -442,13 +443,13 @@ namespace Exiv2 {
+ 
+           Update binary value data and call setValue().
+         */
+-        void updateValue(Value::AutoPtr value, ByteOrder byteOrder);
++        void updateValue(Value::UniquePtr value, ByteOrder byteOrder);
+         /*!
+           @brief Set tag value. Takes ownership of the pointer passed in.
+ 
+           Update type, count and the pointer to the value.
+         */
+-        void setValue(Value::AutoPtr value);
++        void setValue(Value::UniquePtr value);
+         //@}
+ 
+         //! @name Accessors
+@@ -886,9 +887,9 @@ namespace Exiv2 {
+         virtual TiffComponent* doAddPath(uint16_t tag,
+                                          TiffPath& tiffPath,
+                                          TiffComponent* const pRoot,
+-                                         TiffComponent::AutoPtr object);
+-        virtual TiffComponent* doAddChild(TiffComponent::AutoPtr tiffComponent);
+-        virtual TiffComponent* doAddNext(TiffComponent::AutoPtr tiffComponent);
++                                         TiffComponent::UniquePtr object);
++        virtual TiffComponent* doAddChild(TiffComponent::UniquePtr tiffComponent);
++        virtual TiffComponent* doAddNext(TiffComponent::UniquePtr tiffComponent);
+         virtual void doAccept(TiffVisitor& visitor);
+         /*!
+           @brief Implements write(). Write the TIFF directory, values and
+@@ -1002,8 +1003,8 @@ namespace Exiv2 {
+         virtual TiffComponent* doAddPath(uint16_t tag,
+                                          TiffPath& tiffPath,
+                                          TiffComponent* const pRoot,
+-                                         TiffComponent::AutoPtr object);
+-        virtual TiffComponent* doAddChild(TiffComponent::AutoPtr tiffComponent);
++                                         TiffComponent::UniquePtr object);
++        virtual TiffComponent* doAddChild(TiffComponent::UniquePtr tiffComponent);
+         virtual void doAccept(TiffVisitor& visitor);
+         virtual void doEncode(TiffEncoder& encoder, const Exifdatum* datum);
+         /*!
+@@ -1087,9 +1088,9 @@ namespace Exiv2 {
+         virtual TiffComponent* doAddPath(uint16_t tag,
+                                          TiffPath& tiffPath,
+                                          TiffComponent* const pRoot,
+-                                         TiffComponent::AutoPtr object);
+-        virtual TiffComponent* doAddChild(TiffComponent::AutoPtr tiffComponent);
+-        virtual TiffComponent* doAddNext(TiffComponent::AutoPtr tiffComponent);
++                                         TiffComponent::UniquePtr object);
++        virtual TiffComponent* doAddChild(TiffComponent::UniquePtr tiffComponent);
++        virtual TiffComponent* doAddNext(TiffComponent::UniquePtr tiffComponent);
+         virtual void doAccept(TiffVisitor& visitor);
+         virtual void doEncode(TiffEncoder& encoder, const Exifdatum* datum);
+         /*!
+@@ -1219,9 +1220,9 @@ namespace Exiv2 {
+         virtual TiffComponent* doAddPath(uint16_t tag,
+                                          TiffPath& tiffPath,
+                                          TiffComponent* const pRoot,
+-                                         TiffComponent::AutoPtr object);
+-        virtual TiffComponent* doAddChild(TiffComponent::AutoPtr tiffComponent);
+-        virtual TiffComponent* doAddNext(TiffComponent::AutoPtr tiffComponent);
++                                         TiffComponent::UniquePtr object);
++        virtual TiffComponent* doAddChild(TiffComponent::UniquePtr tiffComponent);
++        virtual TiffComponent* doAddNext(TiffComponent::UniquePtr tiffComponent);
+         virtual void doAccept(TiffVisitor& visitor);
+         /*!
+           @brief Implements write(). Write the Makernote header, TIFF directory,
+@@ -1433,11 +1434,11 @@ namespace Exiv2 {
+         virtual TiffComponent* doAddPath(uint16_t tag,
+                                          TiffPath& tiffPath,
+                                          TiffComponent* const pRoot,
+-                                         TiffComponent::AutoPtr object);
++                                         TiffComponent::UniquePtr object);
+         /*!
+           @brief Implements addChild(). Todo: Document it!
+          */
+-        virtual TiffComponent* doAddChild(TiffComponent::AutoPtr tiffComponent);
++        virtual TiffComponent* doAddChild(TiffComponent::UniquePtr tiffComponent);
+         virtual void doAccept(TiffVisitor& visitor);
+         virtual void doEncode(TiffEncoder& encoder, const Exifdatum* datum);
+         /*!
+@@ -1581,83 +1582,83 @@ namespace Exiv2 {
+     bool cmpGroupLt(TiffComponent const* lhs, TiffComponent const* rhs);
+ 
+     //! Function to create and initialize a new TIFF entry
+-    TiffComponent::AutoPtr newTiffEntry(uint16_t tag, IfdId group);
++    TiffComponent::UniquePtr newTiffEntry(uint16_t tag, IfdId group);
+ 
+     //! Function to create and initialize a new TIFF makernote entry
+-    TiffComponent::AutoPtr newTiffMnEntry(uint16_t tag, IfdId group);
++    TiffComponent::UniquePtr newTiffMnEntry(uint16_t tag, IfdId group);
+ 
+     //! Function to create and initialize a new binary array element
+-    TiffComponent::AutoPtr newTiffBinaryElement(uint16_t tag, IfdId group);
++    TiffComponent::UniquePtr newTiffBinaryElement(uint16_t tag, IfdId group);
+ 
+     //! Function to create and initialize a new TIFF directory
+     template<IfdId newGroup>
+-    TiffComponent::AutoPtr newTiffDirectory(uint16_t tag, IfdId /*group*/)
++    TiffComponent::UniquePtr newTiffDirectory(uint16_t tag, IfdId /*group*/)
+     {
+-        return TiffComponent::AutoPtr(new TiffDirectory(tag, newGroup));
++        return TiffComponent::UniquePtr(new TiffDirectory(tag, newGroup));
+     }
+ 
+     //! Function to create and initialize a new TIFF sub-directory
+     template<IfdId newGroup>
+-    TiffComponent::AutoPtr newTiffSubIfd(uint16_t tag, IfdId group)
++    TiffComponent::UniquePtr newTiffSubIfd(uint16_t tag, IfdId group)
+     {
+-        return TiffComponent::AutoPtr(new TiffSubIfd(tag, group, newGroup));
++        return TiffComponent::UniquePtr(new TiffSubIfd(tag, group, newGroup));
+     }
+ 
+     //! Function to create and initialize a new binary array entry
+     template<const ArrayCfg* arrayCfg, int N, const ArrayDef (&arrayDef)[N]>
+-    TiffComponent::AutoPtr newTiffBinaryArray0(uint16_t tag, IfdId group)
++    TiffComponent::UniquePtr newTiffBinaryArray0(uint16_t tag, IfdId group)
+     {
+         // *& acrobatics is a workaround for a MSVC 7.1 bug
+-        return TiffComponent::AutoPtr(
++        return TiffComponent::UniquePtr(
+             new TiffBinaryArray(tag, group, arrayCfg, *(&arrayDef), N));
+     }
+ 
+     //! Function to create and initialize a new simple binary array entry
+     template<const ArrayCfg* arrayCfg>
+-    TiffComponent::AutoPtr newTiffBinaryArray1(uint16_t tag, IfdId group)
++    TiffComponent::UniquePtr newTiffBinaryArray1(uint16_t tag, IfdId group)
+     {
+-        return TiffComponent::AutoPtr(
++        return TiffComponent::UniquePtr(
+             new TiffBinaryArray(tag, group, arrayCfg, 0, 0));
+     }
+ 
+     //! Function to create and initialize a new complex binary array entry
+     template<const ArraySet* arraySet, int N, CfgSelFct cfgSelFct>
+-    TiffComponent::AutoPtr newTiffBinaryArray2(uint16_t tag, IfdId group)
++    TiffComponent::UniquePtr newTiffBinaryArray2(uint16_t tag, IfdId group)
+     {
+-        return TiffComponent::AutoPtr(
++        return TiffComponent::UniquePtr(
+             new TiffBinaryArray(tag, group, arraySet, N, cfgSelFct));
+     }
+ 
+     //! Function to create and initialize a new TIFF entry for a thumbnail (data)
+     template<uint16_t szTag, IfdId szGroup>
+-    TiffComponent::AutoPtr newTiffThumbData(uint16_t tag, IfdId group)
++    TiffComponent::UniquePtr newTiffThumbData(uint16_t tag, IfdId group)
+     {
+-        return TiffComponent::AutoPtr(
++        return TiffComponent::UniquePtr(
+             new TiffDataEntry(tag, group, szTag, szGroup));
+     }
+ 
+     //! Function to create and initialize a new TIFF entry for a thumbnail (size)
+     template<uint16_t dtTag, IfdId dtGroup>
+-    TiffComponent::AutoPtr newTiffThumbSize(uint16_t tag, IfdId group)
++    TiffComponent::UniquePtr newTiffThumbSize(uint16_t tag, IfdId group)
+     {
+-        return TiffComponent::AutoPtr(
++        return TiffComponent::UniquePtr(
+             new TiffSizeEntry(tag, group, dtTag, dtGroup));
+     }
+ 
+     //! Function to create and initialize a new TIFF entry for image data
+     template<uint16_t szTag, IfdId szGroup>
+-    TiffComponent::AutoPtr newTiffImageData(uint16_t tag, IfdId group)
++    TiffComponent::UniquePtr newTiffImageData(uint16_t tag, IfdId group)
+     {
+-        return TiffComponent::AutoPtr(
++        return TiffComponent::UniquePtr(
+             new TiffImageEntry(tag, group, szTag, szGroup));
+     }
+ 
+     //! Function to create and initialize a new TIFF entry for image data (size)
+     template<uint16_t dtTag, IfdId dtGroup>
+-    TiffComponent::AutoPtr newTiffImageSize(uint16_t tag, IfdId group)
++    TiffComponent::UniquePtr newTiffImageSize(uint16_t tag, IfdId group)
+     {
+         // Todo: Same as newTiffThumbSize - consolidate (rename)?
+-        return TiffComponent::AutoPtr(
++        return TiffComponent::UniquePtr(
+             new TiffSizeEntry(tag, group, dtTag, dtGroup));
+     }
+ 
+diff --git a/src/tifffwd_int.hpp b/src/tifffwd_int.hpp
+index 46a390a..55ea91a 100644
+--- a/src/tifffwd_int.hpp
++++ b/src/tifffwd_int.hpp
+@@ -95,10 +95,10 @@ namespace Exiv2 {
+     );
+     /*!
+       @brief Type for a function pointer for a function to create a TIFF component.
+-             Use TiffComponent::AutoPtr, it is not used in this declaration only
++             Use TiffComponent::UniquePtr, it is not used in this declaration only
+              to reduce dependencies.
+      */
+-    typedef std::auto_ptr<TiffComponent> (*NewTiffCompFct)(uint16_t tag, IfdId group);
++    typedef std::unique_ptr<TiffComponent> (*NewTiffCompFct)(uint16_t tag, IfdId group);
+ 
+     //! Stack to hold a path from the TIFF root element to a TIFF entry
+     typedef std::stack<TiffPathItem> TiffPath;
+diff --git a/src/tiffimage.cpp b/src/tiffimage.cpp
+index 9a56fc4..454fee9 100644
+--- a/src/tiffimage.cpp
++++ b/src/tiffimage.cpp
+@@ -67,8 +67,8 @@ namespace Exiv2 {
+ 
+     using namespace Internal;
+ 
+-    TiffImage::TiffImage(BasicIo::AutoPtr io, bool /*create*/)
+-        : Image(ImageType::tiff, mdExif | mdIptc | mdXmp, io),
++    TiffImage::TiffImage(BasicIo::UniquePtr io, bool /*create*/)
++        : Image(ImageType::tiff, mdExif | mdIptc | mdXmp, std::move(io)),
+           pixelWidth_(0), pixelHeight_(0)
+     {
+     } // TiffImage::TiffImage
+@@ -299,7 +299,7 @@ namespace Exiv2 {
+                      ed.end());
+         }
+ 
+-        std::auto_ptr<TiffHeaderBase> header(new TiffHeader(byteOrder));
++        std::unique_ptr<TiffHeaderBase> header(new TiffHeader(byteOrder));
+         return TiffParserWorker::encode(io,
+                                         pData,
+                                         size,
+@@ -314,9 +314,9 @@ namespace Exiv2 {
+ 
+     // *************************************************************************
+     // free functions
+-    Image::AutoPtr newTiffInstance(BasicIo::AutoPtr io, bool create)
++    Image::UniquePtr newTiffInstance(BasicIo::UniquePtr io, bool create)
+     {
+-        Image::AutoPtr image(new TiffImage(io, create));
++        Image::UniquePtr image(new TiffImage(std::move(io), create));
+         if (!image->good()) {
+             image.reset();
+         }
+diff --git a/src/tiffimage_int.cpp b/src/tiffimage_int.cpp
+index e6f7020..ea4d2fa 100644
+--- a/src/tiffimage_int.cpp
++++ b/src/tiffimage_int.cpp
+@@ -1672,10 +1672,10 @@ namespace Exiv2 {
+         return key.r_ == root_ && key.g_ == group_;
+     }
+ 
+-    TiffComponent::AutoPtr TiffCreator::create(uint32_t extendedTag,
++    TiffComponent::UniquePtr TiffCreator::create(uint32_t extendedTag,
+                                                IfdId    group)
+     {
+-        TiffComponent::AutoPtr tc(0);
++        TiffComponent::UniquePtr tc;
+         uint16_t tag = static_cast<uint16_t>(extendedTag & 0xffff);
+         const TiffGroupStruct* ts = find(tiffGroupStruct_,
+                                          TiffGroupStruct::Key(extendedTag, group));
+@@ -1726,12 +1726,12 @@ namespace Exiv2 {
+     )
+     {
+         // Create standard TIFF header if necessary
+-        std::auto_ptr<TiffHeaderBase> ph;
++        std::unique_ptr<TiffHeaderBase> ph;
+         if (!pHeader) {
+-            ph = std::auto_ptr<TiffHeaderBase>(new TiffHeader);
++            ph = std::unique_ptr<TiffHeaderBase>(new TiffHeader);
+             pHeader = ph.get();
+         }
+-        TiffComponent::AutoPtr rootDir = parse(pData, size, root, pHeader);
++        TiffComponent::UniquePtr rootDir = parse(pData, size, root, pHeader);
+         if (0 != rootDir.get()) {
+             TiffDecoder decoder(exifData,
+                                 iptcData,
+@@ -1767,7 +1767,7 @@ namespace Exiv2 {
+         assert(pHeader);
+         assert(pHeader->byteOrder() != invalidByteOrder);
+         WriteMethod writeMethod = wmIntrusive;
+-        TiffComponent::AutoPtr parsedTree = parse(pData, size, root, pHeader);
++        TiffComponent::UniquePtr parsedTree = parse(pData, size, root, pHeader);
+         PrimaryGroups primaryGroups;
+         findPrimaryGroups(primaryGroups, parsedTree.get());
+         if (0 != parsedTree.get()) {
+@@ -1784,7 +1784,7 @@ namespace Exiv2 {
+             if (!encoder.dirty()) writeMethod = wmNonIntrusive;
+         }
+         if (writeMethod == wmIntrusive) {
+-            TiffComponent::AutoPtr createdTree = TiffCreator::create(root, ifdIdNotSet);
++            TiffComponent::UniquePtr createdTree = TiffCreator::create(root, ifdIdNotSet);
+             if (0 != parsedTree.get()) {
+                 // Copy image tags from the original image to the composite
+                 TiffCopier copier(createdTree.get(), root, pHeader, &primaryGroups);
+@@ -1802,7 +1802,7 @@ namespace Exiv2 {
+             encoder.add(createdTree.get(), parsedTree.get(), root);
+             // Write binary representation from the composite tree
+             DataBuf header = pHeader->write();
+-            BasicIo::AutoPtr tempIo(new MemIo);
++            BasicIo::UniquePtr tempIo(new MemIo);
+             assert(tempIo.get() != 0);
+             IoWrapper ioWrapper(*tempIo, header.pData_, header.size_, pOffsetWriter);
+             uint32_t imageIdx(uint32_t(-1));
+@@ -1826,18 +1826,18 @@ namespace Exiv2 {
+         return writeMethod;
+     } // TiffParserWorker::encode
+ 
+-    TiffComponent::AutoPtr TiffParserWorker::parse(
++    TiffComponent::UniquePtr TiffParserWorker::parse(
+         const byte*              pData,
+               uint32_t           size,
+               uint32_t           root,
+               TiffHeaderBase*    pHeader
+     )
+     {
+-        if (pData == 0 || size == 0) return TiffComponent::AutoPtr(0);
++        if (pData == 0 || size == 0) return nullptr;
+         if (!pHeader->read(pData, size) || pHeader->offset() >= size) {
+             throw Error(kerNotAnImage, "TIFF");
+         }
+-        TiffComponent::AutoPtr rootDir = TiffCreator::create(root, ifdIdNotSet);
++        TiffComponent::UniquePtr rootDir = TiffCreator::create(root, ifdIdNotSet);
+         if (0 != rootDir.get()) {
+             rootDir->setStart(pData + pHeader->offset());
+             TiffRwState state(pHeader->byteOrder(), 0);
+diff --git a/src/tiffimage_int.hpp b/src/tiffimage_int.hpp
+index d564f3a..327e3ac 100644
+--- a/src/tiffimage_int.hpp
++++ b/src/tiffimage_int.hpp
+@@ -249,7 +249,7 @@ namespace Exiv2 {
+                  component creation function. If the pointer that is returned
+                  is 0, then the TIFF entry should be ignored.
+         */
+-        static std::auto_ptr<TiffComponent> create(uint32_t extendedTag,
++        static std::unique_ptr<TiffComponent> create(uint32_t extendedTag,
+                                                    IfdId    group);
+         /*!
+           @brief Get the path, i.e., a list of extended tag and group pairs, from
+@@ -342,7 +342,7 @@ namespace Exiv2 {
+                            composite structure. If \em pData is 0 or \em size
+                            is 0, the return value is a 0 pointer.
+          */
+-        static std::auto_ptr<TiffComponent> parse(
++        static std::unique_ptr<TiffComponent> parse(
+             const byte*              pData,
+                   uint32_t           size,
+                   uint32_t           root,
+diff --git a/src/tiffvisitor_int.cpp b/src/tiffvisitor_int.cpp
+index 9c472b5..b6c9b64 100644
+--- a/src/tiffvisitor_int.cpp
++++ b/src/tiffvisitor_int.cpp
+@@ -210,11 +210,11 @@ namespace Exiv2 {
+         assert(object != 0);
+ 
+         if (pHeader_->isImageTag(object->tag(), object->group(), pPrimaryGroups_)) {
+-            TiffComponent::AutoPtr clone = object->clone();
++            TiffComponent::UniquePtr clone = object->clone();
+             // Assumption is that the corresponding TIFF entry doesn't exist
+             TiffPath tiffPath;
+             TiffCreator::getPath(tiffPath, object->tag(), object->group(), root_);
+-            pRoot_->addPath(object->tag(), tiffPath, pRoot_, clone);
++            pRoot_->addPath(object->tag(), tiffPath, pRoot_, std::move(clone));
+ #ifdef EXIV2_DEBUG_MESSAGES
+             ExifKey key(object->tag(), groupName(object->group()));
+             std::cerr << "Copied " << key << "\n";
+@@ -520,7 +520,7 @@ namespace Exiv2 {
+             const TagInfo* pTags = ExifTags::tagList("Canon") ;
+             const TagInfo* pTag  = findTag(pTags,records[i].tag);
+             if ( pTag ) {
+-                Exiv2::Value::AutoPtr v = Exiv2::Value::create(records[i].bSigned?Exiv2::signedShort:Exiv2::unsignedShort);
++                Exiv2::Value::UniquePtr v = Exiv2::Value::create(records[i].bSigned?Exiv2::signedShort:Exiv2::unsignedShort);
+                 std::ostringstream    s;
+                 if ( records[i].bSigned ) {
+                     for ( uint16_t k = 0 ; k < records[i].size ; k++ ) s << " " << ints.at(nStart++);
+@@ -645,7 +645,7 @@ namespace Exiv2 {
+             irbKey.setIdx(pos->idx());
+         }
+         if (rawIptc.size_ != 0 && (del || pos == exifData_.end())) {
+-            Value::AutoPtr value = Value::create(unsignedLong);
++            Value::UniquePtr value = Value::create(unsignedLong);
+             DataBuf buf;
+             if (rawIptc.size_ % 4 != 0) {
+                 // Pad the last unsignedLong value with 0s
+@@ -669,7 +669,7 @@ namespace Exiv2 {
+             irbBuf = Photoshop::setIptcIrb(irbBuf.pData_, irbBuf.size_, iptcData_);
+             exifData_.erase(pos);
+             if (irbBuf.size_ != 0) {
+-                Value::AutoPtr value = Value::create(unsignedByte);
++                Value::UniquePtr value = Value::create(unsignedByte);
+                 value->read(irbBuf.pData_, irbBuf.size_, invalidByteOrder);
+                 Exifdatum iptcDatum(irbKey, value.get());
+                 exifData_.add(iptcDatum);
+@@ -699,7 +699,7 @@ namespace Exiv2 {
+         }
+         if (!xmpPacket.empty()) {
+             // Set the XMP Exif tag to the new value
+-            Value::AutoPtr value = Value::create(unsignedByte);
++            Value::UniquePtr value = Value::create(unsignedByte);
+             value->read(reinterpret_cast<const byte*>(&xmpPacket[0]),
+                         static_cast<long>(xmpPacket.size()),
+                         invalidByteOrder);
+@@ -1368,10 +1368,10 @@ namespace Exiv2 {
+                 return;
+             }
+             uint16_t tag = getUShort(p, byteOrder());
+-            TiffComponent::AutoPtr tc = TiffCreator::create(tag, object->group());
++            TiffComponent::UniquePtr tc = TiffCreator::create(tag, object->group());
+             if (tc.get()) {
+                 tc->setStart(p);
+-                object->addChild(tc);
++                object->addChild(std::move(tc));
+             } else {
+                EXV_WARNING << "Unable to handle tag " << tag << ".\n";
+             }
+@@ -1386,7 +1386,7 @@ namespace Exiv2 {
+ #endif
+                 return;
+             }
+-            TiffComponent::AutoPtr tc(0);
++            TiffComponent::UniquePtr tc;
+             uint32_t next = getLong(p, byteOrder());
+             if (next) {
+                 tc = TiffCreator::create(Tag::next, object->group());
+@@ -1406,7 +1406,7 @@ namespace Exiv2 {
+                     return;
+                 }
+                 tc->setStart(pData_ + baseOffset() + next);
+-                object->addNext(tc);
++                object->addNext(std::move(tc));
+             }
+         } // object->hasNext()
+ 
+@@ -1445,10 +1445,10 @@ namespace Exiv2 {
+                     break;
+                 }
+                 // If there are multiple dirs, group is incremented for each
+-                TiffComponent::AutoPtr td(new TiffDirectory(object->tag(),
++                TiffComponent::UniquePtr td(new TiffDirectory(object->tag(),
+                                                             static_cast<IfdId>(object->newGroup_ + i)));
+                 td->setStart(pData_ + baseOffset() + offset);
+-                object->addChild(td);
++                object->addChild(std::move(td));
+             }
+         }
+ #ifndef SUPPRESS_WARNINGS
+@@ -1627,7 +1627,7 @@ namespace Exiv2 {
+                 size = 0;
+             }
+         }
+-        Value::AutoPtr v = Value::create(typeId);
++        Value::UniquePtr v = Value::create(typeId);
+         enforce(v.get() != NULL, kerCorruptedMetadata);
+         if ( !isize ) {
+             v->read(pData, size, byteOrder());
+@@ -1644,7 +1644,7 @@ namespace Exiv2 {
+             ::free(buffer);
+         }
+ 
+-        object->setValue(v);
++        object->setValue(std::move(v));
+         object->setData(pData, size);
+         object->setOffset(offset);
+         object->setIdx(nextIdx(object->group()));
+@@ -1738,11 +1738,11 @@ namespace Exiv2 {
+         ByteOrder bo = object->elByteOrder();
+         if (bo == invalidByteOrder) bo = byteOrder();
+         TypeId typeId = toTypeId(object->elDef()->tiffType_, object->tag(), object->group());
+-        Value::AutoPtr v = Value::create(typeId);
++        Value::UniquePtr v = Value::create(typeId);
+         enforce(v.get() != NULL, kerCorruptedMetadata);
+         v->read(pData, size, bo);
+ 
+-        object->setValue(v);
++        object->setValue(std::move(v));
+         object->setOffset(0);
+         object->setIdx(nextIdx(object->group()));
+ 
+diff --git a/src/value.cpp b/src/value.cpp
+index d83fdd3..9c1f124 100644
+--- a/src/value.cpp
++++ b/src/value.cpp
+@@ -90,71 +90,71 @@ namespace Exiv2 {
+         return *this;
+     }
+ 
+-    Value::AutoPtr Value::create(TypeId typeId)
++    Value::UniquePtr Value::create(TypeId typeId)
+     {
+-        AutoPtr value;
++        UniquePtr value;
+         switch (typeId) {
+         case invalidTypeId:
+         case signedByte:
+         case unsignedByte:
+-            value = AutoPtr(new DataValue(typeId));
++            value = UniquePtr(new DataValue(typeId));
+             break;
+         case asciiString:
+-            value = AutoPtr(new AsciiValue);
++            value = UniquePtr(new AsciiValue);
+             break;
+         case unsignedShort:
+-            value = AutoPtr(new ValueType<uint16_t>);
++            value = UniquePtr(new ValueType<uint16_t>);
+             break;
+         case unsignedLong:
+         case tiffIfd:
+-            value = AutoPtr(new ValueType<uint32_t>(typeId));
++            value = UniquePtr(new ValueType<uint32_t>(typeId));
+             break;
+         case unsignedRational:
+-            value = AutoPtr(new ValueType<URational>);
++            value = UniquePtr(new ValueType<URational>);
+             break;
+         case undefined:
+-            value = AutoPtr(new DataValue);
++            value = UniquePtr(new DataValue);
+             break;
+         case signedShort:
+-            value = AutoPtr(new ValueType<int16_t>);
++            value = UniquePtr(new ValueType<int16_t>);
+             break;
+         case signedLong:
+-            value = AutoPtr(new ValueType<int32_t>);
++            value = UniquePtr(new ValueType<int32_t>);
+             break;
+         case signedRational:
+-            value = AutoPtr(new ValueType<Rational>);
++            value = UniquePtr(new ValueType<Rational>);
+             break;
+         case tiffFloat:
+-            value = AutoPtr(new ValueType<float>);
++            value = UniquePtr(new ValueType<float>);
+             break;
+         case tiffDouble:
+-            value = AutoPtr(new ValueType<double>);
++            value = UniquePtr(new ValueType<double>);
+             break;
+         case string:
+-            value = AutoPtr(new StringValue);
++            value = UniquePtr(new StringValue);
+             break;
+         case date:
+-            value = AutoPtr(new DateValue);
++            value = UniquePtr(new DateValue);
+             break;
+         case time:
+-            value = AutoPtr(new TimeValue);
++            value = UniquePtr(new TimeValue);
+             break;
+         case comment:
+-            value = AutoPtr(new CommentValue);
++            value = UniquePtr(new CommentValue);
+             break;
+         case xmpText:
+-            value = AutoPtr(new XmpTextValue);
++            value = UniquePtr(new XmpTextValue);
+             break;
+         case xmpBag:
+         case xmpSeq:
+         case xmpAlt:
+-            value = AutoPtr(new XmpArrayValue(typeId));
++            value = UniquePtr(new XmpArrayValue(typeId));
+             break;
+         case langAlt:
+-            value = AutoPtr(new LangAltValue);
++            value = UniquePtr(new LangAltValue);
+             break;
+         default:
+-            value = AutoPtr(new DataValue(typeId));
++            value = UniquePtr(new DataValue(typeId));
+             break;
+         }
+         return value;
+@@ -722,9 +722,9 @@ namespace Exiv2 {
+         return 0;
+     }
+ 
+-    XmpTextValue::AutoPtr XmpTextValue::clone() const
++    XmpTextValue::UniquePtr XmpTextValue::clone() const
+     {
+-        return AutoPtr(clone_());
++        return UniquePtr(clone_());
+     }
+ 
+     long XmpTextValue::size() const
+@@ -792,9 +792,9 @@ namespace Exiv2 {
+         return 0;
+     }
+ 
+-    XmpArrayValue::AutoPtr XmpArrayValue::clone() const
++    XmpArrayValue::UniquePtr XmpArrayValue::clone() const
+     {
+-        return AutoPtr(clone_());
++        return UniquePtr(clone_());
+     }
+ 
+     long XmpArrayValue::count() const
+@@ -891,9 +891,9 @@ namespace Exiv2 {
+         return 0;
+     }
+ 
+-    LangAltValue::AutoPtr LangAltValue::clone() const
++    LangAltValue::UniquePtr LangAltValue::clone() const
+     {
+-        return AutoPtr(clone_());
++        return UniquePtr(clone_());
+     }
+ 
+     long LangAltValue::count() const
+diff --git a/src/webpimage.cpp b/src/webpimage.cpp
+index 3eb9dfa..e47b404 100644
+--- a/src/webpimage.cpp
++++ b/src/webpimage.cpp
+@@ -68,8 +68,8 @@ namespace Exiv2 {
+       enforce(!iIo.error(), err);
+     }
+ 
+-    WebPImage::WebPImage(BasicIo::AutoPtr io)
+-    : Image(ImageType::webp, mdNone, io)
++    WebPImage::WebPImage(BasicIo::UniquePtr io)
++    : Image(ImageType::webp, mdNone, std::move(io))
+     {
+     } // WebPImage::WebPImage
+ 
+@@ -123,7 +123,7 @@ namespace Exiv2 {
+             throw Error(kerDataSourceOpenFailed, io_->path(), strError());
+         }
+         IoCloser closer(*io_);
+-        BasicIo::AutoPtr tempIo(new MemIo);
++        BasicIo::UniquePtr tempIo(new MemIo);
+         assert (tempIo.get() != 0);
+ 
+         doWriteMetadata(*tempIo); // may throw
+@@ -481,7 +481,7 @@ namespace Exiv2 {
+ 
+                 if ( equalsWebPTag(chunkId, WEBP_CHUNK_HEADER_EXIF) && option==kpsRecursive ) {
+                     // create memio object with the payload, then print the structure
+-                    BasicIo::AutoPtr p = BasicIo::AutoPtr(new MemIo(payload.pData_,payload.size_));
++                    BasicIo::UniquePtr p = BasicIo::UniquePtr(new MemIo(payload.pData_,payload.size_));
+                     printTiffStructure(*p,out,option,depth);
+                 }
+ 
+@@ -731,9 +731,9 @@ namespace Exiv2 {
+ 
+     /* =========================================== */
+ 
+-    Image::AutoPtr newWebPInstance(BasicIo::AutoPtr io, bool /*create*/)
++    Image::UniquePtr newWebPInstance(BasicIo::UniquePtr io, bool /*create*/)
+     {
+-        Image::AutoPtr image(new WebPImage(io));
++        Image::UniquePtr image(new WebPImage(std::move(io)));
+         if (!image->good()) {
+             image.reset();
+         }
+diff --git a/src/xmp.cpp b/src/xmp.cpp
+index c074914..8e5493e 100644
+--- a/src/xmp.cpp
++++ b/src/xmp.cpp
+@@ -257,7 +257,7 @@ namespace {
+                    const XMP_OptionBits& opt);
+ 
+     //! Make an XMP key from a schema namespace and property path
+-    Exiv2::XmpKey::AutoPtr makeXmpKey(const std::string& schemaNs,
++    Exiv2::XmpKey::UniquePtr makeXmpKey(const std::string& schemaNs,
+                                       const std::string& propPath);
+ #endif // EXV_HAVE_XMP_TOOLKIT
+ 
+@@ -291,8 +291,8 @@ namespace Exiv2 {
+         Impl& operator=(const Impl& rhs);              //!< Assignment
+ 
+         // DATA
+-        XmpKey::AutoPtr key_;                          //!< Key
+-        Value::AutoPtr  value_;                        //!< Value
++        XmpKey::UniquePtr key_;                          //!< Key
++        Value::UniquePtr  value_;                        //!< Value
+     };
+ 
+     Xmpdatum::Impl::Impl(const XmpKey& key, const Value* pValue)
+@@ -419,9 +419,9 @@ namespace Exiv2 {
+         return p_->value_.get() == 0 ? Rational(-1, 1) : p_->value_->toRational(n);
+     }
+ 
+-    Value::AutoPtr Xmpdatum::getValue() const
++    Value::UniquePtr Xmpdatum::getValue() const
+     {
+-        return p_->value_.get() == 0 ? Value::AutoPtr(0) : p_->value_->clone();
++        return p_->value_.get() == 0 ? nullptr : p_->value_->clone();
+     }
+ 
+     const Value& Xmpdatum::value() const
+@@ -788,10 +788,10 @@ namespace Exiv2 {
+                 }
+                 continue;
+             }
+-            XmpKey::AutoPtr key = makeXmpKey(schemaNs, propPath);
++            XmpKey::UniquePtr key = makeXmpKey(schemaNs, propPath);
+             if (XMP_ArrayIsAltText(opt)) {
+                 // Read Lang Alt property
+-                LangAltValue::AutoPtr val(new LangAltValue);
++                LangAltValue::UniquePtr val(new LangAltValue);
+                 XMP_Index count = meta.CountArrayItems(schemaNs.c_str(), propPath.c_str());
+                 while (count-- > 0) {
+                     // Get the text
+@@ -838,7 +838,7 @@ namespace Exiv2 {
+                 }
+                 if (simpleArray) {
+                     // Read the array into an XmpArrayValue
+-                    XmpArrayValue::AutoPtr val(new XmpArrayValue(arrayValueTypeId(opt)));
++                    XmpArrayValue::UniquePtr val(new XmpArrayValue(arrayValueTypeId(opt)));
+                     XMP_Index count = meta.CountArrayItems(schemaNs.c_str(), propPath.c_str());
+                     while (count-- > 0) {
+                         iter.Next(&schemaNs, &propPath, &propValue, &opt);
+@@ -849,7 +849,7 @@ namespace Exiv2 {
+                     continue;
+                 }
+             }
+-            XmpTextValue::AutoPtr val(new XmpTextValue);
++            XmpTextValue::UniquePtr val(new XmpTextValue);
+             if (   XMP_PropIsStruct(opt)
+                 || XMP_PropIsArray(opt)) {
+                 // Create a metadatum with only XMP options
+@@ -1139,7 +1139,7 @@ namespace {
+     {}
+ #endif // EXIV2_DEBUG_MESSAGES
+ 
+-    Exiv2::XmpKey::AutoPtr makeXmpKey(const std::string& schemaNs,
++    Exiv2::XmpKey::UniquePtr makeXmpKey(const std::string& schemaNs,
+                                       const std::string& propPath)
+     {
+         std::string property;
+@@ -1153,7 +1153,7 @@ namespace {
+         if (prefix.empty()) {
+             throw Exiv2::Error(Exiv2::kerNoPrefixForNamespace, propPath, schemaNs);
+         }
+-        return Exiv2::XmpKey::AutoPtr(new Exiv2::XmpKey(prefix, property));
++        return Exiv2::XmpKey::UniquePtr(new Exiv2::XmpKey(prefix, property));
+     } // makeXmpKey
+ #endif // EXV_HAVE_XMP_TOOLKIT
+ 
+diff --git a/src/xmpsidecar.cpp b/src/xmpsidecar.cpp
+index d9d5e09..1234425 100644
+--- a/src/xmpsidecar.cpp
++++ b/src/xmpsidecar.cpp
+@@ -45,8 +45,8 @@ namespace {
+ namespace Exiv2 {
+ 
+ 
+-    XmpSidecar::XmpSidecar(BasicIo::AutoPtr io, bool create)
+-        : Image(ImageType::xmp, mdXmp, io)
++    XmpSidecar::XmpSidecar(BasicIo::UniquePtr io, bool create)
++        : Image(ImageType::xmp, mdXmp, std::move(io))
+     {
+         if (create) {
+             if (io_->open() == 0) {
+@@ -177,7 +177,7 @@ namespace Exiv2 {
+             if (xmpPacket_.substr(0, 5)  != "<?xml") {
+                 xmpPacket_ = xmlHeader + xmpPacket_ + xmlFooter;
+             }
+-            BasicIo::AutoPtr tempIo(new MemIo);
++            BasicIo::UniquePtr tempIo(new MemIo);
+             assert(tempIo.get() != 0);
+             // Write XMP packet
+             if (   tempIo->write(reinterpret_cast<const byte*>(xmpPacket_.data()),
+@@ -191,9 +191,9 @@ namespace Exiv2 {
+ 
+     // *************************************************************************
+     // free functions
+-    Image::AutoPtr newXmpInstance(BasicIo::AutoPtr io, bool create)
++    Image::UniquePtr newXmpInstance(BasicIo::UniquePtr io, bool create)
+     {
+-        Image::AutoPtr image(new XmpSidecar(io, create));
++        Image::UniquePtr image(new XmpSidecar(std::move(io), create));
+         if (!image->good()) {
+             image.reset();
+         }
+diff --git a/unitTests/test_XmpKey.cpp b/unitTests/test_XmpKey.cpp
+index 279e161..089840d 100644
+--- a/unitTests/test_XmpKey.cpp
++++ b/unitTests/test_XmpKey.cpp
+@@ -89,7 +89,7 @@ TEST_F(AXmpKey, canBeCopied)
+ TEST_F(AXmpKey, canBeCloned)
+ {
+     XmpKey key(expectedPrefix, expectedProperty);
+-    XmpKey::AutoPtr clonedKey = key.clone();
++    XmpKey::UniquePtr clonedKey = key.clone();
+     checkValidity(*clonedKey);
+ }
+ 


### PR DESCRIPTION
This is a backport of Exiv2/exiv2@0bbaa6e, and is needed to unblock
Homebrew/homebrew-core#93627.