### PR TITLE
pdf2djvu: port upstream patch for poppler 22.04.0 compatibility

### DIFF
--- a/pdf2djvu/main-use-pdf-link-Destination-copy-constructor.patch
+++ b/pdf2djvu/main-use-pdf-link-Destination-copy-constructor.patch
@@ -1,0 +1,34 @@
+From ee121db4ba205f47b4c09e4f6645fbaec0226f9d Mon Sep 17 00:00:00 2001
+From: Jakub Wilk <jwilk@jwilk.net>
+Date: Wed, 16 Feb 2022 09:10:28 +0000
+Subject: [PATCH] main: use pdf::link::Destination copy constructor.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Fixes:
+
+  main.cc: In function ‘int get_page_for_goto_link(pdf::link::GoTo*, pdf::Catalog*)’:
+  main.cc:92:27: error: ‘const Destination’ {aka ‘const class LinkDest’} has no member named ‘copy’
+
+https://cgit.freedesktop.org/poppler/poppler/commit/?id=7a429c3cf9fba67e
+---
+ pdf2djvu.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pdf2djvu.cc b/pdf2djvu.cc
+index 2b42d16..bb5fd57 100644
+--- a/pdf2djvu.cc
++++ b/pdf2djvu.cc
+@@ -89,7 +89,7 @@ static int get_page_for_goto_link(pdf::link::GoTo *goto_link, pdf::Catalog *cata
+ #endif
+   }
+   else
+-    dest.reset(orig_dest->copy());
++    dest.reset(new pdf::link::Destination(*orig_dest));
+   if (dest.get() != nullptr)
+   {
+     int page;
+-- 
+2.35.3
+


### PR DESCRIPTION
See https://github.com/Homebrew/homebrew-core/pull/98905

Signed-off-by: Yurii Kolesnykov <root@yurikoles.com>
