### PR TITLE
liblinear: improve platform consistency

### DIFF
--- a/liblinear/patch-Makefile.diff
+++ b/liblinear/patch-Makefile.diff
@@ -27,7 +27,7 @@
   
   lib: linear.o newton.o blas/blas.a
   	if [ "$(OS)" = "Darwin" ]; then \
-! 		LIBEXT=".dylib"; \
+! 		LIBEXT=".$(SHVER).dylib"; \
 ! 		SHARED_LIB_FLAG="-dynamiclib -install_name $(PREFIX)/lib/liblinear$${LIBEXT}"; \
   	else \
 ! 		LIBEXT=".so.$(SHVER)"; \


### PR DESCRIPTION
The `LIBEXT` is handled differently on macOS and Linux, which makes the
current formula fail to install on Linux.

Needed for Homebrew/homebrew-core#103456.