### PR TITLE
gnupg: add setup-scm error patch

### DIFF
--- a/gnupg/2.4.0-setup-scm.patch
+++ b/gnupg/2.4.0-setup-scm.patch
@@ -1,0 +1,63 @@
+From e89d57a2cb10bd04d266165015f159be2ab48984 Mon Sep 17 00:00:00 2001
+From: NIIBE Yutaka <gniibe@fsij.org>
+Date: Wed, 21 Dec 2022 10:52:24 +0900
+Subject: [PATCH] tests: Fix tests/gpgme for in-source-tree builds.
+
+* tests/gpgme/Makefile.am: Don't use setup.scm/ dir.
+* tests/gpgme/all-tests.scm: Fix the name of the environment.
+
+--
+
+GnuPG-bug-id: 6313
+Fixes-commit: c19ea75f10d6278569619f90977ce7c820e9319d
+Signed-off-by: NIIBE Yutaka <gniibe@fsij.org>
+---
+ tests/gpgme/Makefile.am   | 5 ++---
+ tests/gpgme/all-tests.scm | 4 ++--
+ 2 files changed, 4 insertions(+), 5 deletions(-)
+
+diff --git a/tests/gpgme/Makefile.am b/tests/gpgme/Makefile.am
+index ca7be13df..ae98db4a0 100644
+--- a/tests/gpgme/Makefile.am
++++ b/tests/gpgme/Makefile.am
+@@ -47,8 +47,7 @@ check: xcheck
+ 
+ .PHONY: xcheck
+ xcheck:
+-	@$(MKDIR_P) setup.scm/tests \
+-	  tests/gpg lang/qt/tests lang/python/tests
++	@$(MKDIR_P) tests/gpg lang/qt/tests lang/python/tests
+ 	$(TESTS_ENVIRONMENT) $(abs_top_builddir)/tests/gpgscm/gpgscm$(EXEEXT) \
+ 	  $(abs_srcdir)/run-tests.scm $(TESTFLAGS) $(TESTS)
+ 
+@@ -61,4 +60,4 @@ CLEANFILES = *.log report.xml
+ all-local: $(required_pgms)
+ 
+ clean-local:
+-	-rm -rf setup.scm/tests tests/gpg lang/qt/tests lang/python/tests
++	-rm -rf tests lang
+diff --git a/tests/gpgme/all-tests.scm b/tests/gpgme/all-tests.scm
+index 1746c4ee1..aef7d6a21 100644
+--- a/tests/gpgme/all-tests.scm
++++ b/tests/gpgme/all-tests.scm
+@@ -41,7 +41,7 @@
+     (test::scm
+      #f
+      #f
+-     (path-join "tests" "gpgme" "setup.scm" "tests" "gpg")
++     (path-join "tests" "gpgme" "tests" "gpg")
+      (in-srcdir "tests" "gpgme" "setup.scm")
+      "--" "tests" "gpg")))
+  (define setup-py
+@@ -49,7 +49,7 @@
+     (test::scm
+      #f
+      #f
+-     (path-join "tests" "gpgme" "setup.scm" "lang" "python" "tests")
++     (path-join "tests" "gpgme" "lang" "python" "tests")
+      (in-srcdir "tests" "gpgme" "setup.scm")
+      "--" "lang" "python" "tests")))
+ 
+-- 
+2.11.0
+


### PR DESCRIPTION
Adding this patch from upstream, https://git.gnupg.org/cgi-bin/gitweb.cgi?p=gnupg.git;a=commit;h=e89d57a2cb10bd04d266165015f159be2ab48984, to fix the build failure in https://github.com/Homebrew/homebrew-core/pull/118607.