### PR TITLE
cdparanoia: Fix buffer overrun

### DIFF
--- a/cdparanoia/osx_interface.patch
+++ b/cdparanoia/osx_interface.patch
@@ -456,7 +456,7 @@ index 0000000..f672316
 +    return -1;
 +  }
 +
-+  buf_len = CFDataGetLength(data) + 1;
++  buf_len = CFDataGetLength(data);
 +  range = CFRangeMake(0, buf_len);
 +
 +  d->raw_toc = (CDTOC *)malloc(buf_len);


### PR DESCRIPTION
Sync patch from MacPorts
See macports/macports-ports@c8e15973bc3c