### PR TITLE
aalib: fix implicit function declarations

### DIFF
--- a/aalib/1.4rc5.patch
+++ b/aalib/1.4rc5.patch
@@ -1,3 +1,16 @@
+diff --git a/aalib.m4 b/aalib.m4
+index 736ec32..c3faa4a 100644
+--- a/aalib.m4
++++ b/aalib.m4
+@@ -9,7 +9,7 @@
+ dnl AM_PATH_AALIB([MINIMUM-VERSION, [ACTION-IF-FOUND [, ACTION-IF-NOT-FOUND]]])
+ dnl Test for AALIB, and define AALIB_CFLAGS and AALIB_LIBS
+ dnl
+-AC_DEFUN(AM_PATH_AALIB,
++AC_DEFUN([AM_PATH_AALIB],
+ [dnl 
+ dnl Get the cflags and libraries from the aalib-config script
+ dnl
 diff --git a/src/aaedit.c b/src/aaedit.c
 index 09534d2..2ea52f9 100644
 --- a/src/aaedit.c
@@ -10,14 +23,34 @@ index 09534d2..2ea52f9 100644
  #include "aalib.h"
  #include "aaint.h"
  static void aa_editdisplay(struct aa_edit *e)
+diff --git a/src/aafire.c b/src/aafire.c
+index 4f36149..a59b5c5 100644
+--- a/src/aafire.c
++++ b/src/aafire.c
+@@ -1,4 +1,5 @@
+ #include <stdio.h>
++#include <stdlib.h>
+ #include "aalib.h"
  
+ #define XSIZ aa_imgwidth(context)
+diff --git a/src/aainfo.c b/src/aainfo.c
+index d3f6d50..e4eb423 100644
+--- a/src/aainfo.c
++++ b/src/aainfo.c
+@@ -1,4 +1,4 @@
+-
++#include <stdlib.h>
+ #include "aalib.h"
+ #include "aaint.h"
+ int main(int argc, char **argv)
 diff --git a/src/aakbdreg.c b/src/aakbdreg.c
-index def65fe..f4f8efb 100644
+index def65fe..337a64a 100644
 --- a/src/aakbdreg.c
 +++ b/src/aakbdreg.c
-@@ -1,4 +1,4 @@
+@@ -1,4 +1,5 @@
 -#include <malloc.h>
 +#include <stdlib.h>
++#include <string.h>
  #include "config.h"
  #include "aalib.h"
  #include "aaint.h"
@@ -34,12 +67,13 @@ index 11fecc8..e3063b4 100644
  #include "aaint.h"
  
 diff --git a/src/aamoureg.c b/src/aamoureg.c
-index 0380828..bb55fe3 100644
+index 0380828..936438d 100644
 --- a/src/aamoureg.c
 +++ b/src/aamoureg.c
-@@ -1,4 +1,4 @@
+@@ -1,4 +1,5 @@
 -#include <malloc.h>
 +#include <stdlib.h>
++#include <string.h>
  #include "config.h"
  #include "aalib.h"
  #include "aaint.h"
@@ -55,17 +89,37 @@ index 70f4ebc..ee43e8a 100644
  #include "aaint.h"
  aa_linkedlist *aa_kbdrecommended = NULL, *aa_mouserecommended = NULL,
 diff --git a/src/aaregist.c b/src/aaregist.c
-index 54abec0..765155e 100644
+index 54abec0..fcf2505 100644
 --- a/src/aaregist.c
 +++ b/src/aaregist.c
-@@ -1,4 +1,4 @@
+@@ -1,4 +1,5 @@
 -#include <malloc.h>
 +#include <stdlib.h>
++#include <string.h>
  #include "config.h"
  #include "aalib.h"
  #include "aaint.h"
+diff --git a/src/aasavefont.c b/src/aasavefont.c
+index b00e1e6..864ba22 100644
+--- a/src/aasavefont.c
++++ b/src/aasavefont.c
+@@ -1,3 +1,4 @@
++#include <stdlib.h>
+ #include "aalib.h"
+ int main(int argc, char **argv)
+ {
+diff --git a/src/aatest.c b/src/aatest.c
+index 9816f5d..89933cf 100644
+--- a/src/aatest.c
++++ b/src/aatest.c
+@@ -1,3 +1,5 @@
++#include <stdlib.h>
++#include <string.h>
+ #include "aalib.h"
+ int main(int argc, char **argv)
+ {
 diff --git a/src/aax.c b/src/aax.c
-index adcbd82..36e3294 100644
+index 02797c4..d329564 100644
 --- a/src/aax.c
 +++ b/src/aax.c
 @@ -1,4 +1,3 @@
@@ -74,7 +128,7 @@ index adcbd82..36e3294 100644
  #include <string.h>
  #include <stdio.h>
 diff --git a/src/aaxkbd.c b/src/aaxkbd.c
-index 30d5903..da2248d 100644
+index f16afc6..c331c24 100644
 --- a/src/aaxkbd.c
 +++ b/src/aaxkbd.c
 @@ -1,4 +1,3 @@
@@ -91,16 +145,3 @@ index 9935b03..7e725ad 100644
  #include <stdlib.h>
  #include <string.h>
  #include <stdio.h>
-diff --git a/aalib.m4 b/aalib.m4
-index c40b8db..991fbda 100644
---- a/aalib.m4
-+++ b/aalib.m4
-@@ -9,7 +9,7 @@
- dnl AM_PATH_AALIB([MINIMUM-VERSION, [ACTION-IF-FOUND [, ACTION-IF-NOT-FOUND]]])
- dnl Test for AALIB, and define AALIB_CFLAGS and AALIB_LIBS
- dnl
--AC_DEFUN(AM_PATH_AALIB,
-+AC_DEFUN([AM_PATH_AALIB],
- [dnl 
- dnl Get the cflags and libraries from the aalib-config script
- dnl


### PR DESCRIPTION
Building `aalib` on macOS Sonoma produces a number of implicit function declaration errors (see https://github.com/Homebrew/homebrew-core/issues/142161#issuecomment-1730715657). This modifies the existing patch to add more `#include` statements to resolve these errors.

I've created a draft homebrew/core PR that uses this (https://github.com/Homebrew/homebrew-core/pull/144725) and I will modify that PR to use this updated patch once available.