### PR TITLE
jam: fix undeclared functions

### DIFF
--- a/jam/2.6.1-undeclared_functions.diff
+++ b/jam/2.6.1-undeclared_functions.diff
@@ -1,0 +1,22 @@
+--- a/jam.h 2014-08-07 14:24:14
++++ b/jam.h 2023-09-23 22:35:06
+@@ -410,7 +410,7 @@
+ # include <sys/types.h>
+ # include <sys/stat.h>
+
+-# ifdef OS_HPUX
++# if defined(__APPLE__) || defined(OS_HPUX)
+ # include <unistd.h>
+ # endif
+
+--- a/scan.h  2014-08-07 14:24:14
++++ b/scan.h  2023-09-23 22:35:19
+@@ -50,7 +50,7 @@
+ int yylex();
+ int yyparse();
+ const char *yyfname();
+-int yylineo();
++int yylineno();
+
+ # define SCAN_NORMAL 0 /* normal parsing */
+ # define SCAN_STRING 1 /* look only for matching } */


### PR DESCRIPTION
This fixes a couple of `undeclared function` errors that have surfaced on macOS Sonoma:

```
make1.c:392:8: error: call to undeclared function 'unlink'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
                if( !unlink( targets->string ) )
                     ^
make1.c:392:8: note: did you mean 'unlinkat'?
/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/usr/include/sys/unistd.h:214:9: note: 'unlinkat' declared here
int     unlinkat(int, const char *, int) __OSX_AVAILABLE_STARTING(__MAC_10_10, __IPHONE_8_0);
        ^
1 error generated.
parse.c:102:20: error: call to undeclared function 'yylineno'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
            p->yylineno = yylineno();
                          ^
parse.c:102:20: note: did you mean 'yylineo'?
./scan.h:53:5: note: 'yylineo' declared here
int yylineo();
    ^
1 error generated.
make: *** [jam0] Error 1
```

The first change ensures that `<unistd.h>` is included on macOS, as `unlink` is used in `make1.c`. The second change fixes a typo in the `yylineno` function declaration.

This patch is currently included in a related draft PR in homebrew/core (https://github.com/Homebrew/homebrew-core/pull/145338) and I will update it to use this patch file if/when merged.