### PR TITLE
attempting to patch https://sourceware.org/git/binutils-gdb.git @ 2bc…

### DIFF
--- a/gdb@14/gdb_DYLD_VERSION_MAX_17.patch
+++ b/gdb@14/gdb_DYLD_VERSION_MAX_17.patch
@@ -1,0 +1,13 @@
+diff --git a/gdb/solib-darwin.c b/gdb/solib-darwin.c
+index 4819afe8863..7b000da2465 100644
+--- a/gdb/solib-darwin.c
++++ b/gdb/solib-darwin.c
+@@ -59,7 +59,7 @@ struct gdb_dyld_all_image_infos
+
+ /* Current all_image_infos version.  */
+ #define DYLD_VERSION_MIN 1
+-#define DYLD_VERSION_MAX 15
++#define DYLD_VERSION_MAX 17
+
+ /* Per PSPACE specific data.  */
+ struct darwin_info


### PR DESCRIPTION
…fdb758bb18e29cf6c0486c448bf78dbbc0c8a to fix warning: unhandled dyld version (17)

- modeled after https://github.com/bminor/binutils-gdb/commit/4bbd4ef219c5b4c7d437618ba8937af86dd1032e
- planning to attempt to install this roughly like https://stackoverflow.com/a/54542969/689119