### PR TITLE
pyqt: backport qt 6.7.0 support from PyQt6-6.7.0.dev2404171245

### DIFF
--- a/pyqt/qt-6.7.0.patch
+++ b/pyqt/qt-6.7.0.patch
@@ -1,0 +1,2573 @@
+--- a/qpy/QtQml/qpyqmlobject.cpp
++++ b/qpy/QtQml/qpyqmlobject.cpp
+@@ -51,7 +51,8 @@ QPyQmlObjectProxy::~QPyQmlObjectProxy()
+     SIP_UNBLOCK_THREADS
+ 
+     if (!proxied.isNull())
+-        delete proxied.data();
++        // Deleting it now can cause a crash.
++        proxied.data()->deleteLater();
+ }
+ 
+ 
+@@ -146,6 +147,12 @@ void QPyQmlObjectProxy::createPyObject(QObject *parent)
+ 
+     if (py_proxied)
+     {
++        // If there is no parent (which seems always to be the case) then
++        // things seem to work better if we handle the destruction of the
++        // Python and C++ objects separately.
++        if (!parent)
++            sipTransferTo(py_proxied, NULL);
++
+         proxied = reinterpret_cast<QObject *>(
+                 sipGetAddress((sipSimpleWrapper *)py_proxied));
+ 
+--- a/sip/QtBluetooth/qbluetoothuuid.sip
++++ b/sip/QtBluetooth/qbluetoothuuid.sip
+@@ -335,6 +335,14 @@ public:
+     static QString protocolToString(QBluetoothUuid::ProtocolUuid uuid);
+     static QString characteristicToString(QBluetoothUuid::CharacteristicType uuid);
+     static QString descriptorToString(QBluetoothUuid::DescriptorType uuid);
++%If (Qt_6_7_0 -)
++    Py_hash_t __hash__() const;
++%MethodCode
++        // The tp_hash slot (from QUuid) should be inherited.  Is this a SIP bug?
++        sipRes = qHash(*sipCpp);
++%End
++
++%End
+ };
+ 
+ %End
+--- a/sip/QtCore/QtCoremod.sip
++++ b/sip/QtCore/QtCoremod.sip
+@@ -22,7 +22,7 @@
+ 
+ %Module(name=PyQt6.QtCore, call_super_init=True, default_VirtualErrorHandler=PyQt6, keyword_arguments="Optional", use_limited_api=True, py_ssize_t_clean=True)
+ 
+-%Timeline {Qt_6_0_0 Qt_6_1_0 Qt_6_2_0 Qt_6_3_0 Qt_6_4_0 Qt_6_5_0 Qt_6_6_0}
++%Timeline {Qt_6_0_0 Qt_6_1_0 Qt_6_2_0 Qt_6_3_0 Qt_6_4_0 Qt_6_5_0 Qt_6_6_0 Qt_6_7_0}
+ 
+ %Platforms {Android iOS Linux macOS WebAssembly Windows}
+ 
+@@ -186,6 +186,7 @@ static const char *PYQT_VERSION_STR = "6.6.1";
+ %Include qtipccommon.sip
+ %Include qtranslator.sip
+ %Include qtransposeproxymodel.sip
++%Include qtyperevision.sip
+ %Include qtypes.sip
+ %Include qurl.sip
+ %Include qurlquery.sip
+@@ -195,12 +196,14 @@ static const char *PYQT_VERSION_STR = "6.6.1";
+ %Include qversionnumber.sip
+ %Include qwaitcondition.sip
+ %Include qxmlstream.sip
++%Include qyieldcpu.sip
+ %Include qanystringview.sip
+ %Include qflags.sip
+ %Include qstring.sip
+ %Include qbytearraylist.sip
+ %Include qjsonobject.sip
+ %Include qpycore_std_pair.sip
++%Include qpycore_std_optional.sip
+ %Include qpycore_qset.sip
+ %Include qstringview.sip
+ %Include qchar.sip
+--- a/sip/QtCore/qbitarray.sip
++++ b/sip/QtCore/qbitarray.sip
+@@ -47,7 +47,10 @@ public:
+     QBitArray &operator&=(const QBitArray &);
+     QBitArray &operator|=(const QBitArray &);
+     QBitArray &operator^=(const QBitArray &);
++%If (- Qt_6_7_0)
++    // This was changed to be a global operator in Qt v6.7 but this isn't supported by SIP v6.8.
+     QBitArray operator~() const;
++%End
+     bool operator==(const QBitArray &a) const;
+     bool operator!=(const QBitArray &a) const;
+     void fill(bool val, qsizetype first, qsizetype last);
+--- a/sip/QtCore/qcalendar.sip
++++ b/sip/QtCore/qcalendar.sip
+@@ -93,4 +93,7 @@ public:
+     QString standaloneWeekDayName(const QLocale &locale, int day, QLocale::FormatType format = QLocale::LongFormat) const;
+     QString dateTimeToString(QStringView format, const QDateTime &datetime, QDate dateOnly, QTime timeOnly, const QLocale &locale) const;
+     static QStringList availableCalendars();
++%If (Qt_6_7_0 -)
++    QDate matchCenturyToWeekday(const QCalendar::YearMonthDay &parts, int dow) const;
++%End
+ };
+--- a/sip/QtCore/qcborstreamreader.sip
++++ b/sip/QtCore/qcborstreamreader.sip
+@@ -63,7 +63,12 @@ public:
+     void reparse();
+     void clear();
+     void reset();
++%If (Qt_6_7_0 -)
++    QCborError lastError() const;
++%End
++%If (- Qt_6_7_0)
+     QCborError lastError();
++%End
+     qint64 currentOffset() const;
+     bool isValid() const;
+     int containerDepth() const;
+@@ -117,11 +122,42 @@ public:
+         sipRes = sipBuildResult(NULL, "NF", qba, sipType_QByteArray, NULL, res.status, sipType_QCborStreamReader_StringResultCode);
+ %End
+ 
++%If (Qt_6_7_0 -)
++    SIP_PYTUPLE readUtf8String() /TypeHint="Tuple[QByteArray, QCborStreamReader.StringResultCode]"/;
++%MethodCode
++        QCborStreamReader::StringResult<QByteArray> res = sipCpp->readUtf8String();
++        
++        QByteArray *qba = new QByteArray;
++        if (res.status != QCborStreamReader::Error)
++            *qba = res.data;
++        
++        sipRes = sipBuildResult(NULL, "NF", qba, sipType_QByteArray, NULL, res.status, sipType_QCborStreamReader_StringResultCode);
++%End
++
++%End
+     bool toBool() const;
+     quint64 toUnsignedInteger() const;
+     QCborSimpleType toSimpleType() const;
+     double toDouble() const;
+     qint64 toInteger() const;
++%If (Qt_6_7_0 -)
++    bool readAndAppendToString(QString &dst);
++%End
++%If (Qt_6_7_0 -)
++    bool readAndAppendToUtf8String(QByteArray &dst);
++%End
++%If (Qt_6_7_0 -)
++    bool readAndAppendToByteArray(QByteArray &dst);
++%End
++%If (Qt_6_7_0 -)
++    QString readAllString();
++%End
++%If (Qt_6_7_0 -)
++    QByteArray readAllUtf8String();
++%End
++%If (Qt_6_7_0 -)
++    QByteArray readAllByteArray();
++%End
+ 
+ private:
+     QCborStreamReader(const QCborStreamReader &);
+--- a/sip/QtCore/qcoreapplication.sip
++++ b/sip/QtCore/qcoreapplication.sip
+@@ -72,6 +72,9 @@ public:
+     static int exec() /PostHook=__pyQtPostEventLoopHook__,PreHook=__pyQtPreEventLoopHook__,ReleaseGIL/;
+     static void processEvents(QEventLoop::ProcessEventsFlags flags = QEventLoop::AllEvents) /ReleaseGIL/;
+     static void processEvents(QEventLoop::ProcessEventsFlags flags, int maxtime) /ReleaseGIL/;
++%If (Qt_6_7_0 -)
++    static void processEvents(QEventLoop::ProcessEventsFlags flags, QDeadlineTimer deadline) /ReleaseGIL/;
++%End
+     static bool sendEvent(QObject *receiver, QEvent *event) /ReleaseGIL/;
+     static void postEvent(QObject *receiver, QEvent *event /Transfer/, int priority = Qt::NormalEventPriority);
+     static void sendPostedEvents(QObject *receiver = 0, int eventType = 0) /ReleaseGIL/;
+--- a/sip/QtCore/qcoreevent.sip
++++ b/sip/QtCore/qcoreevent.sip
+@@ -204,6 +204,18 @@ public:
+         LeaveEditFocus,
+ %If (Qt_6_6_0 -)
+         DevicePixelRatioChange,
++%End
++%If (Qt_6_7_0 -)
++        ChildWindowAdded,
++%End
++%If (Qt_6_7_0 -)
++        ChildWindowRemoved,
++%End
++%If (Qt_6_7_0 -)
++        ParentWindowAboutToChange,
++%End
++%If (Qt_6_7_0 -)
++        ParentWindowChange,
+ %End
+         User,
+         MaxUser,
+--- a/sip/QtCore/qdatastream.sip
++++ b/sip/QtCore/qdatastream.sip
+@@ -79,6 +79,9 @@ public:
+ %End
+ %If (Qt_6_6_0 -)
+         Qt_6_6,
++%End
++%If (Qt_6_7_0 -)
++        Qt_6_7,
+ %End
+     };
+ 
+@@ -94,6 +97,9 @@ public:
+         ReadPastEnd,
+         ReadCorruptData,
+         WriteFailed,
++%If (Qt_6_7_0 -)
++        SizeLimitExceeded,
++%End
+     };
+ 
+     enum FloatingPointPrecision
+@@ -119,6 +125,25 @@ public:
+     void setByteOrder(QDataStream::ByteOrder);
+     int version() const;
+     void setVersion(int);
++%If (Qt_6_7_0 -)
++    SIP_PYOBJECT readBytes() /ReleaseGIL,TypeHint="bytes"/;
++%MethodCode
++        char *s;
++        qint64 l;
++        
++        Py_BEGIN_ALLOW_THREADS
++        sipCpp->readBytes(s, l);
++        Py_END_ALLOW_THREADS
++        
++        if ((sipRes = PyBytes_FromStringAndSize(s, l)) == NULL)
++            sipIsErr = 1;
++        
++        if (s)
++            delete[] s;
++%End
++
++%End
++%If (- Qt_6_7_0)
+     SIP_PYOBJECT readBytes() /ReleaseGIL,TypeHint="bytes"/;
+ %MethodCode
+         char *s;
+@@ -135,6 +160,44 @@ public:
+             delete[] s;
+ %End
+ 
++%End
++%If (Qt_6_7_0 -)
++    SIP_PYOBJECT readRawData(qint64 len) /Encoding="None",ReleaseGIL,TypeHint="bytes"/;
++%MethodCode
++        // Return the data read or None if there was an error.
++        if (a0 < 0)
++        {
++            PyErr_SetString(PyExc_ValueError, "maximum length of data to be read cannot be negative");
++            sipIsErr = 1;
++        }
++        else
++        {
++            char *s = new char[a0];
++            qint64 len;
++        
++            Py_BEGIN_ALLOW_THREADS
++            len = sipCpp->readRawData(s, a0);
++            Py_END_ALLOW_THREADS
++        
++            if (len < 0)
++            {
++                Py_INCREF(Py_None);
++                sipRes = Py_None;
++            }
++            else
++            {
++                sipRes = PyBytes_FromStringAndSize(s, len);
++        
++                if (!sipRes)
++                    sipIsErr = 1;
++            }
++        
++            delete[] s;
++        }
++%End
++
++%End
++%If (- Qt_6_7_0)
+     SIP_PYOBJECT readRawData(int len) /Encoding="None",ReleaseGIL,TypeHint="bytes"/;
+ %MethodCode
+         // Return the data read or None if there was an error.
+@@ -169,6 +232,29 @@ public:
+         }
+ %End
+ 
++%End
++%If (Qt_6_7_0 -)
++    QDataStream &writeBytes(SIP_PYBUFFER) /ReleaseGIL/;
++%MethodCode
++        sipBufferInfoDef bi;
++        
++        if (sipGetBufferInfo(a0, &bi) > 0)
++        {
++            Py_BEGIN_ALLOW_THREADS
++            sipRes = &sipCpp->writeBytes(reinterpret_cast<char *>(bi.bi_buf),
++                    bi.bi_len);
++            Py_END_ALLOW_THREADS
++            
++            sipReleaseBufferInfo(&bi);
++        }
++        else
++        {
++            sipIsErr = 1;
++        }
++%End
++
++%End
++%If (- Qt_6_7_0)
+     QDataStream &writeBytes(SIP_PYBUFFER) /ReleaseGIL/;
+ %MethodCode
+         sipBufferInfoDef bi;
+@@ -188,6 +274,29 @@ public:
+         }
+ %End
+ 
++%End
++%If (Qt_6_7_0 -)
++    qint64 writeRawData(SIP_PYBUFFER) /ReleaseGIL/;
++%MethodCode
++        sipBufferInfoDef bi;
++        
++        if (sipGetBufferInfo(a0, &bi) > 0)
++        {
++            Py_BEGIN_ALLOW_THREADS
++            sipRes = sipCpp->writeRawData(reinterpret_cast<char *>(bi.bi_buf),
++                    bi.bi_len);
++            Py_END_ALLOW_THREADS
++            
++            sipReleaseBufferInfo(&bi);
++        }
++        else
++        {
++            sipIsErr = 1;
++        }
++%End
++
++%End
++%If (- Qt_6_7_0)
+     int writeRawData(SIP_PYBUFFER) /ReleaseGIL/;
+ %MethodCode
+         sipBufferInfoDef bi;
+@@ -207,7 +316,13 @@ public:
+         }
+ %End
+ 
++%End
++%If (Qt_6_7_0 -)
++    qint64 skipRawData(qint64 len) /ReleaseGIL/;
++%End
++%If (- Qt_6_7_0)
+     int skipRawData(int len) /ReleaseGIL/;
++%End
+     void startTransaction();
+     bool commitTransaction();
+     void rollbackTransaction();
+--- a/sip/QtCore/qdatetime.sip
++++ b/sip/QtCore/qdatetime.sip
+@@ -114,6 +114,8 @@ public:
+     int daysInYear() const;
+     int daysInYear(QCalendar cal) const;
+     int weekNumber(int *yearNumber = 0) const;
++    // In Qt v6.7 this was replaced by two overloads bu twe need to retain the optional keyword argument.
++    QString toString(const QString &format, QCalendar cal = QCalendar()) const;
+     QString toString(Qt::DateFormat format = Qt::TextDate) const;
+     QDate addDays(qint64 days) const;
+     QDate addMonths(int months) const;
+@@ -122,20 +124,26 @@ public:
+     QDate addYears(int years, QCalendar cal) const;
+     static QDate currentDate();
+     static QDate fromString(const QString &string, Qt::DateFormat format = Qt::TextDate);
++    // Qt v6.7 replaced this with two overloads but we need to retain the optional keyword argument.
++    static QDate fromString(const QString &string, const QString &format, QCalendar cal = QCalendar());
++%If (Qt_6_7_0 -)
++    // This replaces two overloads added in Qy v6.7 designed to maintain compatibility regarding optional keyword arguments.
++    static QDate fromString(const QString &string, const QString &format, int baseYear, QCalendar cal = QCalendar());
++%End
+     static bool isValid(int y, int m, int d);
+     static bool isLeapYear(int year);
+     static QDate fromJulianDay(qint64 jd);
+     qint64 toJulianDay() const;
+     bool setDate(int year, int month, int date);
+     void getDate(int *year, int *month, int *day) const;
++    // The arguments are marked as deprecated in Qt v6.9.
+     QDateTime startOfDay(Qt::TimeSpec spec = Qt::LocalTime, int offsetSeconds = 0) const;
+     QDateTime startOfDay(const QTimeZone &zone) const;
++    // The arguments are marked as deprecated in Qt v6.9.
+     QDateTime endOfDay(Qt::TimeSpec spec = Qt::LocalTime, int offsetSeconds = 0) const;
+     QDateTime endOfDay(const QTimeZone &zone) const;
+     bool setDate(int year, int month, int day, QCalendar cal);
+-    QString toString(const QString &format, QCalendar cal = QCalendar()) const;
+     qint64 daysTo(QDate d) const;
+-    static QDate fromString(const QString &string, const QString &format, QCalendar cal = QCalendar());
+ };
+ 
+ class QTime /TypeHintIn="Union[QTime, datetime.time]"/
+@@ -301,6 +309,21 @@ return 0;
+ %End
+ 
+ public:
++%If (Qt_6_7_0 -)
++
++    enum class TransitionResolution
++    {
++        Reject,
++        RelativeToBefore,
++        RelativeToAfter,
++        PreferBefore,
++        PreferAfter,
++        PreferStandard,
++        PreferDaylightSaving,
++        LegacyBehavior,
++    };
++
++%End
+     QDateTime();
+     QDateTime(const QDateTime &other);
+     QDateTime(int year, int month, int day, int hour, int minute, int second = 0, int msec = 0, int timeSpec = 0) /NoDerived/;
+@@ -312,8 +335,18 @@ public:
+         sipCpp = new QDateTime(qd, qt, (Qt::TimeSpec)a7);
+ %End
+ 
++%If (Qt_6_7_0 -)
++    // The resolve argument is not optional so that the overload with deprecated arguments continues to work.
++    QDateTime(QDate date, QTime time, QDateTime::TransitionResolution resolve) [(QDate date, QTime time, QDateTime::TransitionResolution resolve = QDateTime::TransitionResolution::LegacyBehavior)];
++%End
++    // The optional arguments are marked as deprecated in Qt v6.9.
+     QDateTime(QDate date, QTime time, Qt::TimeSpec spec = Qt::LocalTime, int offsetSeconds = 0);
++%If (Qt_6_7_0 -)
++    QDateTime(QDate date, QTime time, const QTimeZone &timeZone, QDateTime::TransitionResolution resolve = QDateTime::TransitionResolution::LegacyBehavior);
++%End
++%If (- Qt_6_7_0)
+     QDateTime(QDate date, QTime time, const QTimeZone &timeZone);
++%End
+     ~QDateTime();
+     SIP_PYOBJECT __repr__() const /TypeHint="str"/;
+ %MethodCode
+@@ -388,6 +421,8 @@ public:
+     QTime time() const;
+     Qt::TimeSpec timeSpec() const;
+     void setTimeSpec(Qt::TimeSpec spec);
++    // This was replaced with two overloads in Qt v6.7 but we need the optional keyword argument.
++    QString toString(const QString &format, QCalendar cal = QCalendar()) const;
+     QString toString(Qt::DateFormat format = Qt::TextDate) const;
+     QDateTime addDays(qint64 days) const;
+     QDateTime addMonths(int months) const;
+@@ -404,6 +439,12 @@ public:
+     static QDateTime currentDateTime(const QTimeZone &zone);
+ %End
+     static QDateTime fromString(const QString &string, Qt::DateFormat format = Qt::TextDate);
++    // Qt v6.7 replaced this with two overloads but we need to retain the optional keyword argument.
++    static QDateTime fromString(const QString &string, const QString &format, QCalendar cal = QCalendar());
++%If (Qt_6_7_0 -)
++    // This replaces two overloads added in Qy v6.7 designed to maintain compatibility regarding optional keyword arguments.
++    static QDateTime fromString(const QString &string, const QString &format, int baseYear, QCalendar cal = QCalendar());
++%End
+     qint64 toMSecsSinceEpoch() const;
+     void setMSecsSinceEpoch(qint64 msecs);
+     qint64 msecsTo(const QDateTime &) const;
+@@ -415,13 +456,20 @@ public:
+     QString timeZoneAbbreviation() const;
+     bool isDaylightTime() const;
+     void setOffsetFromUtc(int offsetSeconds);
++%If (Qt_6_7_0 -)
++    void setTimeZone(const QTimeZone &toZone, QDateTime::TransitionResolution resolve = QDateTime::TransitionResolution::LegacyBehavior);
++%End
++%If (- Qt_6_7_0)
+     void setTimeZone(const QTimeZone &toZone);
++%End
+     QDateTime toOffsetFromUtc(int offsetSeconds) const;
+     QDateTime toTimeZone(const QTimeZone &toZone) const;
+-    static QDateTime fromMSecsSinceEpoch(qint64 msecs, const QTimeZone &timeZone);
++    // The optional arguments are marked as deprecated in Qt v6.9.
+     static QDateTime fromMSecsSinceEpoch(qint64 msecs, Qt::TimeSpec spec = Qt::LocalTime, int offsetSeconds = 0);
++    static QDateTime fromMSecsSinceEpoch(qint64 msecs, const QTimeZone &timeZone);
+     qint64 toSecsSinceEpoch() const;
+     void setSecsSinceEpoch(qint64 secs);
++    // The optional arguments are marked as deprecated in Qt v6.9.
+     static QDateTime fromSecsSinceEpoch(qint64 secs, Qt::TimeSpec spec = Qt::LocalTime, int offsetSeconds = 0);
+     static QDateTime fromSecsSinceEpoch(qint64 secs, const QTimeZone &timeZone);
+     static qint64 currentSecsSinceEpoch();
+@@ -432,10 +480,18 @@ public:
+         Last,
+     };
+ 
++%If (Qt_6_7_0 -)
++    void setDate(QDate date, QDateTime::TransitionResolution resolve = QDateTime::TransitionResolution::LegacyBehavior);
++%End
++%If (- Qt_6_7_0)
+     void setDate(QDate date);
++%End
++%If (Qt_6_7_0 -)
++    void setTime(QTime time, QDateTime::TransitionResolution resolve = QDateTime::TransitionResolution::LegacyBehavior);
++%End
++%If (- Qt_6_7_0)
+     void setTime(QTime time);
+-    QString toString(const QString &format, QCalendar cal = QCalendar()) const;
+-    static QDateTime fromString(const QString &string, const QString &format, QCalendar cal = QCalendar());
++%End
+ %If (Qt_6_5_0 -)
+     QTimeZone timeRepresentation() const;
+ %End
+@@ -447,21 +503,81 @@ QDataStream &operator<<(QDataStream &, QTime) /ReleaseGIL/;
+ QDataStream &operator>>(QDataStream &, QTime & /Constrained/) /ReleaseGIL/;
+ QDataStream &operator<<(QDataStream &, const QDateTime &) /ReleaseGIL/;
+ QDataStream &operator>>(QDataStream &, QDateTime & /Constrained/) /ReleaseGIL/;
+-bool operator==(const QDateTime &lhs, const QDateTime &rhs);
+-bool operator==(QTime lhs, QTime rhs);
++%If (Qt_6_7_0 -)
++bool operator==(const QDate &lhs, const QDate &rhs);
++%End
++%If (- Qt_6_7_0)
+ bool operator==(QDate lhs, QDate rhs);
+-bool operator!=(const QDateTime &lhs, const QDateTime &rhs);
+-bool operator!=(QTime lhs, QTime rhs);
++%End
++%If (Qt_6_7_0 -)
++bool operator==(const QTime &lhs, const QTime &rhs);
++%End
++%If (- Qt_6_7_0)
++bool operator==(QTime lhs, QTime rhs);
++%End
++bool operator==(const QDateTime &lhs, const QDateTime &rhs);
++%If (Qt_6_7_0 -)
++bool operator!=(const QDate &lhs, const QDate &rhs);
++%End
++%If (- Qt_6_7_0)
+ bool operator!=(QDate lhs, QDate rhs);
+-bool operator<(const QDateTime &lhs, const QDateTime &rhs);
+-bool operator<(QTime lhs, QTime rhs);
++%End
++%If (Qt_6_7_0 -)
++bool operator!=(const QTime &lhs, const QTime &rhs);
++%End
++%If (- Qt_6_7_0)
++bool operator!=(QTime lhs, QTime rhs);
++%End
++bool operator!=(const QDateTime &lhs, const QDateTime &rhs);
++%If (Qt_6_7_0 -)
++bool operator<(const QDate &lhs, const QDate &rhs);
++%End
++%If (- Qt_6_7_0)
+ bool operator<(QDate lhs, QDate rhs);
+-bool operator<=(const QDateTime &lhs, const QDateTime &rhs);
+-bool operator<=(QTime lhs, QTime rhs);
++%End
++%If (Qt_6_7_0 -)
++bool operator<(const QTime &lhs, const QTime &rhs);
++%End
++%If (- Qt_6_7_0)
++bool operator<(QTime lhs, QTime rhs);
++%End
++bool operator<(const QDateTime &lhs, const QDateTime &rhs);
++%If (Qt_6_7_0 -)
++bool operator<=(const QDate &lhs, const QDate &rhs);
++%End
++%If (- Qt_6_7_0)
+ bool operator<=(QDate lhs, QDate rhs);
+-bool operator>(const QDateTime &lhs, const QDateTime &rhs);
+-bool operator>(QTime lhs, QTime rhs);
++%End
++%If (Qt_6_7_0 -)
++bool operator<=(const QTime &lhs, const QTime &rhs);
++%End
++%If (- Qt_6_7_0)
++bool operator<=(QTime lhs, QTime rhs);
++%End
++bool operator<=(const QDateTime &lhs, const QDateTime &rhs);
++%If (Qt_6_7_0 -)
++bool operator>(const QDate &lhs, const QDate &rhs);
++%End
++%If (- Qt_6_7_0)
+ bool operator>(QDate lhs, QDate rhs);
+-bool operator>=(const QDateTime &lhs, const QDateTime &rhs);
+-bool operator>=(QTime lhs, QTime rhs);
++%End
++%If (Qt_6_7_0 -)
++bool operator>(const QTime &lhs, const QTime &rhs);
++%End
++%If (- Qt_6_7_0)
++bool operator>(QTime lhs, QTime rhs);
++%End
++bool operator>(const QDateTime &lhs, const QDateTime &rhs);
++%If (Qt_6_7_0 -)
++bool operator>=(const QDate &lhs, const QDate &rhs);
++%End
++%If (- Qt_6_7_0)
+ bool operator>=(QDate lhs, QDate rhs);
++%End
++%If (Qt_6_7_0 -)
++bool operator>=(const QTime &lhs, const QTime &rhs);
++%End
++%If (- Qt_6_7_0)
++bool operator>=(QTime lhs, QTime rhs);
++%End
++bool operator>=(const QDateTime &lhs, const QDateTime &rhs);
+--- a/sip/QtCore/qeventloop.sip
++++ b/sip/QtCore/qeventloop.sip
+@@ -41,6 +41,9 @@ public:
+     typedef QFlags<QEventLoop::ProcessEventsFlag> ProcessEventsFlags;
+     bool processEvents(QEventLoop::ProcessEventsFlags flags = QEventLoop::AllEvents) /ReleaseGIL/;
+     void processEvents(QEventLoop::ProcessEventsFlags flags, int maximumTime) /ReleaseGIL/;
++%If (Qt_6_7_0 -)
++    void processEvents(QEventLoop::ProcessEventsFlags flags, QDeadlineTimer deadline) /ReleaseGIL/;
++%End
+     int exec(QEventLoop::ProcessEventsFlags flags = QEventLoop::AllEvents) /PostHook=__pyQtPostEventLoopHook__,PreHook=__pyQtPreEventLoopHook__,ReleaseGIL/;
+     void exit(int returnCode = 0);
+     bool isRunning() const;
+@@ -64,6 +67,9 @@ public:
+     explicit QEventLoopLocker(QEventLoop *loop) /ReleaseGIL/;
+     explicit QEventLoopLocker(QThread *thread) /ReleaseGIL/;
+     ~QEventLoopLocker();
++%If (Qt_6_7_0 -)
++    void swap(QEventLoopLocker &other);
++%End
+ 
+ private:
+     QEventLoopLocker(const QEventLoopLocker &);
+--- a/sip/QtCore/qlocale.sip
++++ b/sip/QtCore/qlocale.sip
+@@ -415,6 +415,15 @@ public:
+ %End
+ %If (Qt_6_6_0 -)
+         Torwali,
++%End
++%If (Qt_6_7_0 -)
++        Anii,
++%End
++%If (Qt_6_7_0 -)
++        Kangri,
++%End
++%If (Qt_6_7_0 -)
++        Venetian,
+ %End
+     };
+ 
+@@ -728,6 +737,15 @@ public:
+         RejectTrailingZeroesAfterDot,
+     };
+ 
++%If (Qt_6_7_0 -)
++
++    enum class TagSeparator
++    {
++        Dash,
++        Underscore,
++    };
++
++%End
+     typedef QFlags<QLocale::NumberOption> NumberOptions;
+     QLocale();
+     explicit QLocale(const QString &name);
+@@ -737,7 +755,12 @@ public:
+     ~QLocale();
+     QLocale::Language language() const;
+     QLocale::Country country() const;
++%If (Qt_6_7_0 -)
++    QString name(QLocale::TagSeparator separator = QLocale::TagSeparator::Underscore) const;
++%End
++%If (- Qt_6_7_0)
+     QString name() const;
++%End
+     short toShort(const QString &s, bool *ok = 0) const;
+     ushort toUShort(const QString &s, bool *ok = 0) const;
+     int toInt(const QString &s, bool *ok = 0) const;
+@@ -778,12 +801,56 @@ public:
+     QString dateFormat(QLocale::FormatType format = QLocale::LongFormat) const;
+     QString timeFormat(QLocale::FormatType format = QLocale::LongFormat) const;
+     QString dateTimeFormat(QLocale::FormatType format = QLocale::LongFormat) const;
+-    QDate toDate(const QString &string, QLocale::FormatType format = QLocale::LongFormat) const;
++%If (Qt_6_7_0 -)
++    QDate toDate(const QString &string, const QString &format, int baseYear = QLocale::DefaultTwoDigitBaseYear) const;
++%End
++%If (- Qt_6_7_0)
+     QDate toDate(const QString &string, const QString &format) const;
++%End
++%If (Qt_6_7_0 -)
++    QDate toDate(const QString &string, const QString &format, QCalendar cal, int baseYear = QLocale::DefaultTwoDigitBaseYear) const;
++%End
++%If (- Qt_6_7_0)
++    QDate toDate(const QString &string, const QString &format, QCalendar cal) const;
++%End
++%If (Qt_6_7_0 -)
++    QDate toDate(const QString &string, QLocale::FormatType format, QCalendar cal, int baseYear = QLocale::DefaultTwoDigitBaseYear) const;
++%End
++%If (- Qt_6_7_0)
++    QDate toDate(const QString &string, QLocale::FormatType format, QCalendar cal) const;
++%End
++%If (Qt_6_7_0 -)
++    QDate toDate(const QString &string, QLocale::FormatType = QLocale::LongFormat, int baseYear = QLocale::DefaultTwoDigitBaseYear) const;
++%End
++%If (- Qt_6_7_0)
++    QDate toDate(const QString &string, QLocale::FormatType format = QLocale::LongFormat) const;
++%End
+     QTime toTime(const QString &string, QLocale::FormatType format = QLocale::LongFormat) const;
+     QTime toTime(const QString &string, const QString &format) const;
+-    QDateTime toDateTime(const QString &string, QLocale::FormatType format = QLocale::LongFormat) const;
++%If (Qt_6_7_0 -)
++    QDateTime toDateTime(const QString &string, const QString &format, int baseYear = QLocale::DefaultTwoDigitBaseYear) const;
++%End
++%If (- Qt_6_7_0)
+     QDateTime toDateTime(const QString &string, const QString &format) const;
++%End
++%If (Qt_6_7_0 -)
++    QDateTime toDateTime(const QString &string, const QString &format, QCalendar cal, int baseYear = QLocale::DefaultTwoDigitBaseYear) const;
++%End
++%If (- Qt_6_7_0)
++    QDateTime toDateTime(const QString &string, const QString &format, QCalendar cal) const;
++%End
++%If (Qt_6_7_0 -)
++    QDateTime toDateTime(const QString &string, QLocale::FormatType format, QCalendar cal, int baseYear = QLocale::DefaultTwoDigitBaseYear) const;
++%End
++%If (- Qt_6_7_0)
++    QDateTime toDateTime(const QString &string, QLocale::FormatType format, QCalendar cal) const;
++%End
++%If (Qt_6_7_0 -)
++    QDateTime toDateTime(const QString &string, QLocale::FormatType format = QLocale::LongFormat, int baseYear = QLocale::DefaultTwoDigitBaseYear) const;
++%End
++%If (- Qt_6_7_0)
++    QDateTime toDateTime(const QString &string, QLocale::FormatType format = QLocale::LongFormat) const;
++%End
+     QString decimalPoint() const;
+     QString groupSeparator() const;
+     QString percent() const;
+@@ -973,7 +1040,12 @@ public:
+     };
+ 
+     QLocale::Script script() const;
++%If (Qt_6_7_0 -)
++    QString bcp47Name(QLocale::TagSeparator separator = QLocale::TagSeparator::Dash) const;
++%End
++%If (- Qt_6_7_0)
+     QString bcp47Name() const;
++%End
+     QString nativeLanguageName() const;
+     QString nativeCountryName() const;
+     Qt::DayOfWeek firstDayOfWeek() const;
+@@ -982,7 +1054,12 @@ public:
+     QString toLower(const QString &str) const;
+     QString currencySymbol(QLocale::CurrencySymbolFormat format = QLocale::CurrencySymbol) const;
+     QString toCurrencyString(double, const QString &symbol = QString(), int precision = -1) const;
++%If (Qt_6_7_0 -)
++    QStringList uiLanguages(QLocale::TagSeparator separator = QLocale::TagSeparator::Dash) const;
++%End
++%If (- Qt_6_7_0)
+     QStringList uiLanguages() const;
++%End
+     static QString scriptToString(QLocale::Script script);
+ %If (Qt_6_2_0 -)
+     static QList<QLocale> matchingLocales(QLocale::Language language, QLocale::Script script, QLocale::Territory territory);
+@@ -1109,10 +1186,6 @@ public:
+     QString formattedDataSize(qint64 bytes, int precision = 2, QLocale::DataSizeFormats format = QLocale::DataSizeIecFormat) const;
+     long toLong(const QString &s, bool *ok = 0) const;
+     ulong toULong(const QString &s, bool *ok = 0) const;
+-    QDate toDate(const QString &string, QLocale::FormatType format, QCalendar cal) const;
+-    QDateTime toDateTime(const QString &string, QLocale::FormatType format, QCalendar cal) const;
+-    QDate toDate(const QString &string, const QString &format, QCalendar cal) const;
+-    QDateTime toDateTime(const QString &string, const QString &format, QCalendar cal) const;
+     QLocale collation() const;
+ %If (Qt_6_3_0 -)
+     static QString languageToCode(QLocale::Language language, QLocale::LanguageCodeTypes codeTypes = QLocale::AnyLanguageCode);
+@@ -1176,6 +1249,9 @@ public:
+ %If (Qt_6_3_0 -)
+     typedef QFlags<QLocale::LanguageCodeType> LanguageCodeTypes;
+ %End
++%If (Qt_6_7_0 -)
++    static const int DefaultTwoDigitBaseYear;
++%End
+ };
+ 
+ QDataStream &operator<<(QDataStream &, const QLocale &) /ReleaseGIL/;
+--- a/sip/QtCore/qmetaobject.sip
++++ b/sip/QtCore/qmetaobject.sip
+@@ -133,6 +133,7 @@ public:
+ %End
+ 
+     int methodIndex() const;
++    int revision() const;
+     bool isValid() const;
+     QByteArray methodSignature() const;
+     QByteArray name() const;
+@@ -250,6 +251,7 @@ public:
+     int propertyIndex() const;
+     bool isConstant() const;
+     bool isFinal() const;
++    int revision() const;
+     int relativePropertyIndex() const;
+     bool isRequired() const;
+     QMetaType metaType() const;
+--- a/sip/QtCore/qnamespace.sip
++++ b/sip/QtCore/qnamespace.sip
+@@ -832,6 +832,9 @@ namespace Qt
+         Key_Dead_Aboveverticalline,
+         Key_Dead_Belowverticalline,
+         Key_Dead_Longsolidusoverlay,
++%If (Qt_6_7_0 -)
++        Key_micro,
++%End
+     };
+ 
+     enum ArrowType
+@@ -1236,6 +1239,9 @@ namespace Qt
+         AA_CompressTabletEvents,
+         AA_DisableSessionManager,
+         AA_DisableNativeVirtualKeyboard,
++%If (Qt_6_7_0 -)
++        AA_QtQuickUseDefaultSizePolicy,
++%End
+     };
+ 
+     enum ItemSelectionMode
+--- a/sip/QtCore/qobject.sip
++++ b/sip/QtCore/qobject.sip
+@@ -593,6 +593,9 @@ class QSignalBlocker
+ public:
+     explicit QSignalBlocker(QObject *o);
+     ~QSignalBlocker();
++%If (Qt_6_7_0 -)
++    void dismiss();
++%End
+     void reblock();
+     void unblock();
+     SIP_PYOBJECT __enter__();
+--- a/sip/QtCore/qoperatingsystemversion.sip
++++ b/sip/QtCore/qoperatingsystemversion.sip
+@@ -28,6 +28,14 @@ class QOperatingSystemVersionBase
+ #include <qoperatingsystemversion.h>
+ %End
+ 
++public:
++    QVersionNumber version() const;
++    int majorVersion() const;
++    int minorVersion() const;
++    int microVersion() const;
++    int segmentCount() const;
++    QString name() const;
++
+ protected:
+     QOperatingSystemVersionBase();
+ };
+@@ -115,13 +123,7 @@ public:
+     QOperatingSystemVersion(QOperatingSystemVersion::OSType osType, int vmajor, int vminor = -1, int vmicro = -1);
+     static QOperatingSystemVersion current();
+     static QOperatingSystemVersion::OSType currentType();
+-    QVersionNumber version() const;
+-    int majorVersion() const;
+-    int minorVersion() const;
+-    int microVersion() const;
+-    int segmentCount() const;
+     QOperatingSystemVersion::OSType type() const;
+-    QString name() const;
+ 
+ private:
+     QOperatingSystemVersion();
+--- a/sip/QtCore/qprocess.sip
++++ b/sip/QtCore/qprocess.sip
+@@ -207,6 +207,15 @@ public:
+         IgnoreSigPipe,
+         CloseFileDescriptors,
+         UseVFork,
++%If (Qt_6_7_0 -)
++        CreateNewSession,
++%End
++%If (Qt_6_7_0 -)
++        DisconnectControllingTerminal,
++%End
++%If (Qt_6_7_0 -)
++        ResetIds,
++%End
+     };
+ 
+ %End
+--- a/sip/QtCore/qpycore_qlist.sip
++++ b/sip/QtCore/qpycore_qlist.sip
+@@ -935,7 +935,7 @@ template<qreal, _TYPE_>
+ 
+     QList<unsigned> *qv = new QList<unsigned>;
+ 
+-    for (Py_ssize_t i = 0; ; ++i)
++    for (;;)
+     {
+         PyErr_Clear();
+         PyObject *itm = PyIter_Next(iter);
+@@ -1036,7 +1036,7 @@ template<qreal, _TYPE_>
+ 
+     QList<unsigned short> *qv = new QList<unsigned short>;
+ 
+-    for (Py_ssize_t i = 0; ; ++i)
++    for (;;)
+     {
+         PyErr_Clear();
+         PyObject *itm = PyIter_Next(iter);
+new file mode 100644
+--- /dev/null
++++ b/sip/QtCore/qpycore_std_optional.sip
+@@ -0,0 +1,52 @@
++// This is the SIP interface definition for the std::optional mapped type.
++//
++// Copyright (c) 2024 Riverbank Computing Limited <info@riverbankcomputing.com>
++// 
++// This file is part of PyQt6.
++// 
++// This file may be used under the terms of the GNU General Public License
++// version 3.0 as published by the Free Software Foundation and appearing in
++// the file LICENSE included in the packaging of this file.  Please review the
++// following information to ensure the GNU General Public License version 3.0
++// requirements will be met: http://www.gnu.org/copyleft/gpl.html.
++// 
++// If you do not wish to use this file under the terms of the GPL version 3.0
++// then you may purchase a commercial license.  For more information contact
++// info@riverbankcomputing.com.
++// 
++// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
++// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
++
++
++%If (Qt_6_7_0 -)
++
++template<_TYPE_>
++%MappedType std::optional<_TYPE_> /TypeHint="Optional[_TYPE_]"/
++{
++%TypeHeaderCode
++#include <optional>
++%End
++
++%ConvertFromTypeCode
++    if (!sipCpp->has_value())
++    {
++        Py_INCREF(Py_None);
++        return Py_None;
++    }
++
++    _TYPE_ *t = new _TYPE_(sipCpp->value());
++
++    PyObject *tobj = sipConvertFromNewType(t, sipType__TYPE_, sipTransferObj);
++
++    if (!tobj)
++    {
++        delete t;
++
++        return 0;
++    }
++
++    return tobj;
++%End
++};
++
++%End
+--- a/sip/QtCore/qstandardpaths.sip
++++ b/sip/QtCore/qstandardpaths.sip
+@@ -53,6 +53,12 @@ public:
+ %End
+ %If (Qt_6_4_0 -)
+         TemplatesLocation,
++%End
++%If (Qt_6_7_0 -)
++        StateLocation,
++%End
++%If (Qt_6_7_0 -)
++        GenericStateLocation,
+ %End
+     };
+ 
+--- a/sip/QtCore/qstringconverter_base.sip
++++ b/sip/QtCore/qstringconverter_base.sip
+@@ -80,6 +80,9 @@ public:
+     bool hasError() const;
+     const char *name() const;
+     static const char *nameForEncoding(QStringConverter::Encoding e);
++%If (Qt_6_7_0 -)
++    static QStringList availableCodecs();
++%End
+ 
+ private:
+     QStringConverter(const QStringConverter &);
+--- a/sip/QtCore/qtimezone.sip
++++ b/sip/QtCore/qtimezone.sip
+@@ -71,8 +71,12 @@ public:
+     QTimeZone();
+     ~QTimeZone();
+     void swap(QTimeZone &other /Constrained/);
++%If (- Qt_6_7_0)
+     bool operator==(const QTimeZone &other) const;
++%End
++%If (- Qt_6_7_0)
+     bool operator!=(const QTimeZone &other) const;
++%End
+     bool isValid() const;
+     QByteArray id() const;
+     QLocale::Country country() const;
+@@ -157,3 +161,9 @@ public:
+ 
+ QDataStream &operator<<(QDataStream &ds, const QTimeZone &tz) /ReleaseGIL/;
+ QDataStream &operator>>(QDataStream &ds, QTimeZone &tz /Constrained/) /ReleaseGIL/;
++%If (Qt_6_7_0 -)
++bool operator==(const QTimeZone &lhs, const QTimeZone &rhs);
++%End
++%If (Qt_6_7_0 -)
++bool operator!=(const QTimeZone &lhs, const QTimeZone &rhs);
++%End
+new file mode 100644
+--- /dev/null
++++ b/sip/QtCore/qtyperevision.sip
+@@ -0,0 +1,76 @@
++// qtyperevision.sip generated by MetaSIP
++//
++// This file is part of the QtCore Python extension module.
++//
++// Copyright (c) 2024 Riverbank Computing Limited <info@riverbankcomputing.com>
++// 
++// This file is part of PyQt6.
++// 
++// This file may be used under the terms of the GNU General Public License
++// version 3.0 as published by the Free Software Foundation and appearing in
++// the file LICENSE included in the packaging of this file.  Please review the
++// following information to ensure the GNU General Public License version 3.0
++// requirements will be met: http://www.gnu.org/copyleft/gpl.html.
++// 
++// If you do not wish to use this file under the terms of the GPL version 3.0
++// then you may purchase a commercial license.  For more information contact
++// info@riverbankcomputing.com.
++// 
++// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
++// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
++
++
++%If (Qt_6_7_0 -)
++
++class QTypeRevision
++{
++%TypeHeaderCode
++#include <qtyperevision.h>
++%End
++
++public:
++    QTypeRevision();
++    bool hasMajorVersion() const;
++    quint8 majorVersion() const;
++    bool hasMinorVersion() const;
++    quint8 minorVersion() const;
++    bool isValid() const;
++    unsigned short toEncodedVersion() const;
++%MethodCode
++        sipRes = sipCpp->toEncodedVersion<unsigned short>();
++%End
++
++    Py_hash_t __hash__() const;
++%MethodCode
++        sipRes = qHash(*sipCpp);
++%End
++
++    static QTypeRevision fromEncodedVersion(int value);
++    static QTypeRevision zero();
++};
++
++%End
++%If (Qt_6_7_0 -)
++bool operator==(QTypeRevision lhs, QTypeRevision rhs);
++%End
++%If (Qt_6_7_0 -)
++bool operator!=(QTypeRevision lhs, QTypeRevision rhs);
++%End
++%If (Qt_6_7_0 -)
++bool operator<(QTypeRevision lhs, QTypeRevision rhs);
++%End
++%If (Qt_6_7_0 -)
++bool operator>(QTypeRevision lhs, QTypeRevision rhs);
++%End
++%If (Qt_6_7_0 -)
++bool operator<=(QTypeRevision lhs, QTypeRevision rhs);
++%End
++%If (Qt_6_7_0 -)
++bool operator>=(QTypeRevision lhs, QTypeRevision rhs);
++%End
++%If (Qt_6_7_0 -)
++QDataStream &operator<<(QDataStream &out, const QTypeRevision &revision) /ReleaseGIL/;
++%End
++%If (Qt_6_7_0 -)
++QDataStream &operator>>(QDataStream &in, QTypeRevision &revision /Constrained/) /ReleaseGIL/;
++%End
+--- a/sip/QtCore/qurl.sip
++++ b/sip/QtCore/qurl.sip
+@@ -123,7 +123,12 @@ public:
+     QString toString(QUrl::ComponentFormattingOptions options) const;
+     QByteArray toEncoded(QUrl::FormattingOptions options = QUrl::FullyEncoded) const;
+     QByteArray toEncoded(QUrl::ComponentFormattingOptions options) const;
++%If (Qt_6_7_0 -)
++    static QUrl fromEncoded(QByteArrayView input, QUrl::ParsingMode mode = QUrl::TolerantMode);
++%End
++%If (- Qt_6_7_0)
+     static QUrl fromEncoded(const QByteArray &u, QUrl::ParsingMode mode = QUrl::TolerantMode);
++%End
+     void detach();
+     bool isDetached() const;
+     bool operator<(const QUrl &url) const;
+--- a/sip/QtCore/qversionnumber.sip
++++ b/sip/QtCore/qversionnumber.sip
+@@ -20,11 +20,6 @@
+ // WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ 
+ 
+-QDataStream &operator<<(QDataStream &out, const QTypeRevision &revision) /ReleaseGIL/;
+-QDataStream &operator<<(QDataStream &out, const QVersionNumber &version) /ReleaseGIL/;
+-QDataStream &operator>>(QDataStream &in, QTypeRevision &revision /Constrained/) /ReleaseGIL/;
+-QDataStream &operator>>(QDataStream &in, QVersionNumber &version /Constrained/) /ReleaseGIL/;
+-
+ class QVersionNumber
+ {
+ %TypeHeaderCode
+@@ -72,18 +67,15 @@ public:
+ %End
+ };
+ 
+-bool operator>(QTypeRevision lhs, QTypeRevision rhs);
+ bool operator>(const QVersionNumber &lhs, const QVersionNumber &rhs);
+-bool operator>=(QTypeRevision lhs, QTypeRevision rhs);
+ bool operator>=(const QVersionNumber &lhs, const QVersionNumber &rhs);
+-bool operator<(QTypeRevision lhs, QTypeRevision rhs);
+ bool operator<(const QVersionNumber &lhs, const QVersionNumber &rhs);
+-bool operator<=(QTypeRevision lhs, QTypeRevision rhs);
+ bool operator<=(const QVersionNumber &lhs, const QVersionNumber &rhs);
+-bool operator==(QTypeRevision lhs, QTypeRevision rhs);
+ bool operator==(const QVersionNumber &lhs, const QVersionNumber &rhs);
+-bool operator!=(QTypeRevision lhs, QTypeRevision rhs);
+ bool operator!=(const QVersionNumber &lhs, const QVersionNumber &rhs);
++QDataStream &operator<<(QDataStream &out, const QVersionNumber &version) /ReleaseGIL/;
++QDataStream &operator>>(QDataStream &in, QVersionNumber &version /Constrained/) /ReleaseGIL/;
++%If (- Qt_6_7_0)
+ 
+ class QTypeRevision
+ {
+@@ -92,7 +84,6 @@ class QTypeRevision
+ %End
+ 
+ public:
+-    static QTypeRevision zero();
+     QTypeRevision();
+     bool hasMajorVersion() const;
+     quint8 majorVersion() const;
+@@ -108,4 +99,33 @@ public:
+ %MethodCode
+         sipRes = qHash(*sipCpp);
+ %End
++
++    static QTypeRevision fromEncodedVersion(int value);
++    static QTypeRevision zero();
+ };
++
++%End
++%If (- Qt_6_7_0)
++bool operator>(QTypeRevision lhs, QTypeRevision rhs);
++%End
++%If (- Qt_6_7_0)
++bool operator>=(QTypeRevision lhs, QTypeRevision rhs);
++%End
++%If (- Qt_6_7_0)
++bool operator<(QTypeRevision lhs, QTypeRevision rhs);
++%End
++%If (- Qt_6_7_0)
++bool operator<=(QTypeRevision lhs, QTypeRevision rhs);
++%End
++%If (- Qt_6_7_0)
++bool operator==(QTypeRevision lhs, QTypeRevision rhs);
++%End
++%If (- Qt_6_7_0)
++bool operator!=(QTypeRevision lhs, QTypeRevision rhs);
++%End
++%If (- Qt_6_7_0)
++QDataStream &operator<<(QDataStream &out, const QTypeRevision &revision) /ReleaseGIL/;
++%End
++%If (- Qt_6_7_0)
++QDataStream &operator>>(QDataStream &in, QTypeRevision &revision /Constrained/) /ReleaseGIL/;
++%End
+new file mode 100644
+--- /dev/null
++++ b/sip/QtCore/qyieldcpu.sip
+@@ -0,0 +1,31 @@
++// qyieldcpu.sip generated by MetaSIP
++//
++// This file is part of the QtCore Python extension module.
++//
++// Copyright (c) 2024 Riverbank Computing Limited <info@riverbankcomputing.com>
++// 
++// This file is part of PyQt6.
++// 
++// This file may be used under the terms of the GNU General Public License
++// version 3.0 as published by the Free Software Foundation and appearing in
++// the file LICENSE included in the packaging of this file.  Please review the
++// following information to ensure the GNU General Public License version 3.0
++// requirements will be met: http://www.gnu.org/copyleft/gpl.html.
++// 
++// If you do not wish to use this file under the terms of the GPL version 3.0
++// then you may purchase a commercial license.  For more information contact
++// info@riverbankcomputing.com.
++// 
++// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
++// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
++
++
++%If (Qt_6_7_0 -)
++%ModuleCode
++#include <qyieldcpu.h>
++%End
++%End
++
++%If (Qt_6_7_0 -)
++void qYieldCpu();
++%End
+--- a/sip/QtDBus/qdbusabstractinterface.sip
++++ b/sip/QtDBus/qdbusabstractinterface.sip
+@@ -193,6 +193,14 @@ protected:
+     QDBusAbstractInterface(const QString &service, const QString &path, const char *interface, const QDBusConnection &connection, QObject *parent /TransferThis/);
+     virtual void connectNotify(const QMetaMethod &signal);
+     virtual void disconnectNotify(const QMetaMethod &signal);
++
++public:
++%If (Qt_6_7_0 -)
++    void setInteractiveAuthorizationAllowed(bool enable);
++%End
++%If (Qt_6_7_0 -)
++    bool isInteractiveAuthorizationAllowed() const;
++%End
+ };
+ 
+ %ModuleHeaderCode
+--- a/sip/QtGui/qevent.sip
++++ b/sip/QtGui/qevent.sip
+@@ -183,6 +183,13 @@ class QInputEvent : QEvent /NoDefaultCtors/
+         sipType = sipType_QPlatformSurfaceEvent;
+         break;
+     
++    #if QT_VERSION >= 0x060700
++    case QEvent::ChildWindowAdded:
++    case QEvent::ChildWindowRemoved:
++        sipType = sipType_QChildWindowEvent;
++        break;
++    #endif
++    
+     default:
+         sipType = 0;
+     }
+@@ -848,3 +855,20 @@ public:
+     virtual bool isEndEvent() const;
+     virtual QTouchEvent *clone() const /Factory/;
+ };
++
++%If (Qt_6_7_0 -)
++
++class QChildWindowEvent : QEvent /NoDefaultCtors/
++{
++%TypeHeaderCode
++#include <qevent.h>
++%End
++
++public:
++    QChildWindowEvent(QEvent::Type type, QWindow *childWindow);
++    virtual ~QChildWindowEvent();
++    QWindow *child() const;
++    virtual QChildWindowEvent *clone() const /Factory/;
++};
++
++%End
+--- a/sip/QtGui/qfont.sip
++++ b/sip/QtGui/qfont.sip
+@@ -208,37 +208,126 @@ public:
+ 
+     QStringList families() const;
+     void setFamilies(const QStringList &);
+-%If (Qt_6_6_0 -)
++%If (Qt_6_7_0 -)
++    void setFeature(QFont::Tag tag, quint32 value);
++%End
++%If (Qt_6_6_0 - Qt_6_7_0)
+     void setFeature(quint32 tag, quint32 value);
+ %End
+-%If (Qt_6_6_0 -)
++%If (Qt_6_6_0 - Qt_6_7_0)
+     void setFeature(const char *feature /Encoding="None"/, quint32 value);
+ %End
+-%If (Qt_6_6_0 -)
++%If (Qt_6_7_0 -)
++    void unsetFeature(QFont::Tag tag);
++%End
++%If (Qt_6_6_0 - Qt_6_7_0)
+     void unsetFeature(const char *feature /Encoding="None"/);
+ %End
+-%If (Qt_6_6_0 -)
++%If (Qt_6_6_0 - Qt_6_7_0)
+     void unsetFeature(quint32 tag);
+ %End
+-%If (Qt_6_6_0 -)
++%If (Qt_6_7_0 -)
++    quint32 featureValue(QFont::Tag tag) const;
++%End
++%If (Qt_6_6_0 - Qt_6_7_0)
+     quint32 featureValue(quint32 tag) const;
+ %End
+-%If (Qt_6_6_0 -)
++%If (Qt_6_7_0 -)
++    bool isFeatureSet(QFont::Tag tag) const;
++%End
++%If (Qt_6_6_0 - Qt_6_7_0)
+     bool isFeatureSet(quint32 tag) const;
+ %End
+-%If (Qt_6_6_0 -)
++%If (Qt_6_7_0 -)
++    QList<QFont::Tag> featureTags() const;
++%End
++%If (Qt_6_6_0 - Qt_6_7_0)
+     QList<unsigned int> featureTags() const;
+ %End
+ %If (Qt_6_6_0 -)
+     void clearFeatures();
+ %End
+-%If (Qt_6_6_0 -)
++%If (Qt_6_6_0 - Qt_6_7_0)
+     static QByteArray tagToString(quint32 tag);
+ %End
+-%If (Qt_6_6_0 -)
++%If (Qt_6_6_0 - Qt_6_7_0)
+     static quint32 stringToTag(const char *tagString /Encoding="None"/);
+ %End
++%If (Qt_6_7_0 -)
++
++    struct Tag
++    {
++%TypeHeaderCode
++#include <qfont.h>
++%End
++
++        Tag();
++        Tag(QAnyStringView view);
++%MethodCode
++            // This is the easiest way to implement this ctor.
++            std::optional<::QFont::Tag> opt_tag = ::QFont::Tag::fromString(*a0);
++            
++            if (opt_tag.has_value())
++                sipCpp = new ::QFont::Tag(opt_tag.value());
++            else
++                sipCpp = new ::QFont::Tag;
++%End
++
++        bool isValid() const;
++        quint32 value() const;
++        QByteArray toString() const;
++        static std::optional<QFont::Tag> fromValue(quint32 value);
++        static std::optional<QFont::Tag> fromString(QAnyStringView view);
++        Py_hash_t __hash__() const;
++%MethodCode
++            sipRes = qHash(*sipCpp);
++%End
++    };
++
++%End
++%If (Qt_6_7_0 -)
++    void setVariableAxis(QFont::Tag tag, float value);
++%End
++%If (Qt_6_7_0 -)
++    void unsetVariableAxis(QFont::Tag tag);
++%End
++%If (Qt_6_7_0 -)
++    bool isVariableAxisSet(QFont::Tag tag) const;
++%End
++%If (Qt_6_7_0 -)
++    float variableAxisValue(QFont::Tag tag) const;
++%End
++%If (Qt_6_7_0 -)
++    void clearVariableAxes();
++%End
++%If (Qt_6_7_0 -)
++    QList<QFont::Tag> variableAxisTags() const;
++%End
+ };
+ 
+ QDataStream &operator<<(QDataStream &, const QFont &) /ReleaseGIL/;
+ QDataStream &operator>>(QDataStream &, QFont & /Constrained/) /ReleaseGIL/;
++%If (Qt_6_7_0 -)
++QDataStream &operator<<(QDataStream &, QFont::Tag) /ReleaseGIL/;
++%End
++%If (Qt_6_7_0 -)
++QDataStream &operator>>(QDataStream &, QFont::Tag & /Constrained/) /ReleaseGIL/;
++%End
++%If (Qt_6_7_0 -)
++bool operator>=(const QFont::Tag &lhs, const QFont::Tag &rhs);
++%End
++%If (Qt_6_7_0 -)
++bool operator<=(const QFont::Tag &lhs, const QFont::Tag &rhs);
++%End
++%If (Qt_6_7_0 -)
++bool operator>(const QFont::Tag &lhs, const QFont::Tag &rhs);
++%End
++%If (Qt_6_7_0 -)
++bool operator<(const QFont::Tag &lhs, const QFont::Tag &rhs);
++%End
++%If (Qt_6_7_0 -)
++bool operator!=(const QFont::Tag &lhs, const QFont::Tag &rhs);
++%End
++%If (Qt_6_7_0 -)
++bool operator==(const QFont::Tag &lhs, const QFont::Tag &rhs);
++%End
+--- a/sip/QtGui/qicon.sip
++++ b/sip/QtGui/qicon.sip
+@@ -41,6 +41,163 @@ public:
+         Off,
+     };
+ 
++%If (Qt_6_7_0 -)
++
++    enum class ThemeIcon
++    {
++        AddressBookNew,
++        ApplicationExit,
++        AppointmentNew,
++        CallStart,
++        CallStop,
++        ContactNew,
++        DocumentNew,
++        DocumentOpen,
++        DocumentOpenRecent,
++        DocumentPageSetup,
++        DocumentPrint,
++        DocumentPrintPreview,
++        DocumentProperties,
++        DocumentRevert,
++        DocumentSave,
++        DocumentSaveAs,
++        DocumentSend,
++        EditClear,
++        EditCopy,
++        EditCut,
++        EditDelete,
++        EditFind,
++        EditPaste,
++        EditRedo,
++        EditSelectAll,
++        EditUndo,
++        FolderNew,
++        FormatIndentLess,
++        FormatIndentMore,
++        FormatJustifyCenter,
++        FormatJustifyFill,
++        FormatJustifyLeft,
++        FormatJustifyRight,
++        FormatTextDirectionLtr,
++        FormatTextDirectionRtl,
++        FormatTextBold,
++        FormatTextItalic,
++        FormatTextUnderline,
++        FormatTextStrikethrough,
++        GoDown,
++        GoHome,
++        GoNext,
++        GoPrevious,
++        GoUp,
++        HelpAbout,
++        HelpFaq,
++        InsertImage,
++        InsertLink,
++        InsertText,
++        ListAdd,
++        ListRemove,
++        MailForward,
++        MailMarkImportant,
++        MailMarkRead,
++        MailMarkUnread,
++        MailMessageNew,
++        MailReplyAll,
++        MailReplySender,
++        MailSend,
++        MediaEject,
++        MediaPlaybackPause,
++        MediaPlaybackStart,
++        MediaPlaybackStop,
++        MediaRecord,
++        MediaSeekBackward,
++        MediaSeekForward,
++        MediaSkipBackward,
++        MediaSkipForward,
++        ObjectRotateLeft,
++        ObjectRotateRight,
++        ProcessStop,
++        SystemLockScreen,
++        SystemLogOut,
++        SystemSearch,
++        SystemReboot,
++        SystemShutdown,
++        ToolsCheckSpelling,
++        ViewFullscreen,
++        ViewRefresh,
++        ViewRestore,
++        WindowClose,
++        WindowNew,
++        ZoomFitBest,
++        ZoomIn,
++        ZoomOut,
++        AudioCard,
++        AudioInputMicrophone,
++        Battery,
++        CameraPhoto,
++        CameraVideo,
++        CameraWeb,
++        Computer,
++        DriveHarddisk,
++        DriveOptical,
++        InputGaming,
++        InputKeyboard,
++        InputMouse,
++        InputTablet,
++        MediaFlash,
++        MediaOptical,
++        MediaTape,
++        MultimediaPlayer,
++        NetworkWired,
++        NetworkWireless,
++        Phone,
++        Printer,
++        Scanner,
++        VideoDisplay,
++        AppointmentMissed,
++        AppointmentSoon,
++        AudioVolumeHigh,
++        AudioVolumeLow,
++        AudioVolumeMedium,
++        AudioVolumeMuted,
++        BatteryCaution,
++        BatteryLow,
++        DialogError,
++        DialogInformation,
++        DialogPassword,
++        DialogQuestion,
++        DialogWarning,
++        FolderDragAccept,
++        FolderOpen,
++        FolderVisiting,
++        ImageLoading,
++        ImageMissing,
++        MailAttachment,
++        MailUnread,
++        MailRead,
++        MailReplied,
++        MediaPlaylistRepeat,
++        MediaPlaylistShuffle,
++        NetworkOffline,
++        PrinterPrinting,
++        SecurityHigh,
++        SecurityLow,
++        SoftwareUpdateAvailable,
++        SoftwareUpdateUrgent,
++        SyncError,
++        SyncSynchronizing,
++        UserAvailable,
++        UserOffline,
++        WeatherClear,
++        WeatherClearNight,
++        WeatherFewClouds,
++        WeatherFewCloudsNight,
++        WeatherFog,
++        WeatherShowers,
++        WeatherSnow,
++        WeatherStorm,
++    };
++
++%End
+     QIcon();
+     QIcon(const QPixmap &pixmap);
+     QIcon(const QIcon &other);
+@@ -80,7 +237,16 @@ public:
+     qint64 cacheKey() const;
+     static QIcon fromTheme(const QString &name);
+     static QIcon fromTheme(const QString &name, const QIcon &fallback);
++%If (Qt_6_7_0 -)
++    static QIcon fromTheme(QIcon::ThemeIcon icon);
++%End
++%If (Qt_6_7_0 -)
++    static QIcon fromTheme(QIcon::ThemeIcon icon, const QIcon &fallback);
++%End
+     static bool hasThemeIcon(const QString &name);
++%If (Qt_6_7_0 -)
++    static bool hasThemeIcon(QIcon::ThemeIcon icon);
++%End
+     static QStringList themeSearchPaths();
+     static void setThemeSearchPaths(const QStringList &searchpath);
+     static QString themeName();
+--- a/sip/QtGui/qquaternion.sip
++++ b/sip/QtGui/qquaternion.sip
+@@ -102,16 +102,51 @@ public:
+     static QQuaternion fromEulerAngles(const QVector3D &eulerAngles);
+ };
+ 
+-const QQuaternion operator*(const QQuaternion &q1, const QQuaternion &q2);
+ bool operator==(const QQuaternion &q1, const QQuaternion &q2);
+ bool operator!=(const QQuaternion &q1, const QQuaternion &q2);
+-const QQuaternion operator+(const QQuaternion &q1, const QQuaternion &q2);
+-const QQuaternion operator-(const QQuaternion &q1, const QQuaternion &q2);
+-const QQuaternion operator*(float factor, const QQuaternion &quaternion);
++%If (Qt_6_7_0 -)
++QQuaternion operator*(const QQuaternion &q1, const QQuaternion &q2);
++%End
++%If (- Qt_6_7_0)
++const QQuaternion operator*(const QQuaternion &q1, const QQuaternion &q2);
++%End
++%If (Qt_6_7_0 -)
++QQuaternion operator*(const QQuaternion &quaternion, float factor);
++%End
++%If (- Qt_6_7_0)
+ const QQuaternion operator*(const QQuaternion &quaternion, float factor);
++%End
++%If (Qt_6_7_0 -)
++QQuaternion operator*(float factor, const QQuaternion &quaternion);
++%End
++%If (- Qt_6_7_0)
++const QQuaternion operator*(float factor, const QQuaternion &quaternion);
++%End
++QVector3D operator*(const QQuaternion &quaternion, const QVector3D &vec);
++%If (Qt_6_7_0 -)
++QQuaternion operator+(const QQuaternion &q1, const QQuaternion &q2);
++%End
++%If (- Qt_6_7_0)
++const QQuaternion operator+(const QQuaternion &q1, const QQuaternion &q2);
++%End
++%If (Qt_6_7_0 -)
++QQuaternion operator-(const QQuaternion &quaternion);
++%End
++%If (- Qt_6_7_0)
+ const QQuaternion operator-(const QQuaternion &quaternion);
++%End
++%If (Qt_6_7_0 -)
++QQuaternion operator-(const QQuaternion &q1, const QQuaternion &q2);
++%End
++%If (- Qt_6_7_0)
++const QQuaternion operator-(const QQuaternion &q1, const QQuaternion &q2);
++%End
++%If (Qt_6_7_0 -)
++QQuaternion operator/(const QQuaternion &quaternion, float divisor);
++%End
++%If (- Qt_6_7_0)
+ const QQuaternion operator/(const QQuaternion &quaternion, float divisor);
++%End
+ bool qFuzzyCompare(const QQuaternion &q1, const QQuaternion &q2);
+ QDataStream &operator<<(QDataStream &, const QQuaternion &) /ReleaseGIL/;
+ QDataStream &operator>>(QDataStream &, QQuaternion & /Constrained/) /ReleaseGIL/;
+-QVector3D operator*(const QQuaternion &quaternion, const QVector3D &vec);
+--- a/sip/QtGui/qrasterwindow.sip
++++ b/sip/QtGui/qrasterwindow.sip
+@@ -32,4 +32,7 @@ public:
+ 
+ protected:
+     virtual int metric(QPaintDevice::PaintDeviceMetric metric) const;
++%If (Qt_6_7_0 -)
++    virtual void resizeEvent(QResizeEvent *event);
++%End
+ };
+--- a/sip/QtGui/qrawfont.sip
++++ b/sip/QtGui/qrawfont.sip
+@@ -68,6 +68,9 @@ public:
+     bool supportsCharacter(QChar character) const;
+     QList<QFontDatabase::WritingSystem> supportedWritingSystems() const;
+     QByteArray fontTable(const char *tagName) const;
++%If (Qt_6_7_0 -)
++    QByteArray fontTable(QFont::Tag tag) const;
++%End
+     static QRawFont fromFont(const QFont &font, QFontDatabase::WritingSystem writingSystem = QFontDatabase::Any);
+     QRectF boundingRect(quint32 glyphIndex) const;
+     qreal lineThickness() const;
+--- a/sip/QtGui/qtextdocument.sip
++++ b/sip/QtGui/qtextdocument.sip
+@@ -26,7 +26,12 @@ namespace Qt
+ #include <qtextdocument.h>
+ %End
+ 
++%If (Qt_6_7_0 -)
++    bool mightBeRichText(QAnyStringView);
++%End
++%If (- Qt_6_7_0)
+     bool mightBeRichText(const QString &);
++%End
+     QString convertFromPlainText(const QString &plain, Qt::WhiteSpaceMode mode = Qt::WhiteSpacePre);
+ };
+ 
+--- a/sip/QtMultimedia/QtMultimediamod.sip
++++ b/sip/QtMultimedia/QtMultimediamod.sip
+@@ -47,6 +47,7 @@ WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ 
+ %DefaultSupertype PyQt6.sip.simplewrapper
+ 
++%Include qtvideo.sip
+ %Include qaudio.sip
+ %Include qaudiobuffer.sip
+ %Include qaudiodecoder.sip
+--- a/sip/QtMultimedia/qcameradevice.sip
++++ b/sip/QtMultimedia/qcameradevice.sip
+@@ -71,6 +71,9 @@ public:
+     QCameraDevice::Position position() const;
+     QList<QSize> photoResolutions() const;
+     QList<QCameraFormat> videoFormats() const;
++%If (Qt_6_7_0 -)
++    QtVideo::Rotation correctionAngle() const;
++%End
+ };
+ 
+ %End
+new file mode 100644
+--- /dev/null
++++ b/sip/QtMultimedia/qtvideo.sip
+@@ -0,0 +1,40 @@
++// qtvideo.sip generated by MetaSIP
++//
++// This file is part of the QtMultimedia Python extension module.
++//
++// Copyright (c) 2024 Riverbank Computing Limited <info@riverbankcomputing.com>
++// 
++// This file is part of PyQt6.
++// 
++// This file may be used under the terms of the GNU General Public License
++// version 3.0 as published by the Free Software Foundation and appearing in
++// the file LICENSE included in the packaging of this file.  Please review the
++// following information to ensure the GNU General Public License version 3.0
++// requirements will be met: http://www.gnu.org/copyleft/gpl.html.
++// 
++// If you do not wish to use this file under the terms of the GPL version 3.0
++// then you may purchase a commercial license.  For more information contact
++// info@riverbankcomputing.com.
++// 
++// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
++// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
++
++
++%If (Qt_6_7_0 -)
++
++namespace QtVideo
++{
++%TypeHeaderCode
++#include <qtvideo.h>
++%End
++
++    enum class Rotation
++    {
++        None,
++        Clockwise90,
++        Clockwise180,
++        Clockwise270,
++    };
++};
++
++%End
+--- a/sip/QtMultimedia/qvideoframe.sip
++++ b/sip/QtMultimedia/qvideoframe.sip
+@@ -117,6 +117,12 @@ public:
+ %If (Qt_6_3_0 -)
+     bool mirrored() const;
+ %End
++%If (Qt_6_7_0 -)
++    void setRotation(QtVideo::Rotation angle);
++%End
++%If (Qt_6_7_0 -)
++    QtVideo::Rotation rotation() const;
++%End
+ };
+ 
+ %End
+--- a/sip/QtNetwork/QtNetworkmod.sip
++++ b/sip/QtNetwork/QtNetworkmod.sip
+@@ -54,6 +54,7 @@ WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ %Include qhstspolicy.sip
+ %Include qhttp1configuration.sip
+ %Include qhttp2configuration.sip
++%Include qhttpheaders.sip
+ %Include qhttpmultipart.sip
+ %Include qlocalserver.sip
+ %Include qlocalsocket.sip
+new file mode 100644
+--- /dev/null
++++ b/sip/QtNetwork/qhttpheaders.sip
+@@ -0,0 +1,245 @@
++// qhttpheaders.sip generated by MetaSIP
++//
++// This file is part of the QtNetwork Python extension module.
++//
++// Copyright (c) 2024 Riverbank Computing Limited <info@riverbankcomputing.com>
++// 
++// This file is part of PyQt6.
++// 
++// This file may be used under the terms of the GNU General Public License
++// version 3.0 as published by the Free Software Foundation and appearing in
++// the file LICENSE included in the packaging of this file.  Please review the
++// following information to ensure the GNU General Public License version 3.0
++// requirements will be met: http://www.gnu.org/copyleft/gpl.html.
++// 
++// If you do not wish to use this file under the terms of the GPL version 3.0
++// then you may purchase a commercial license.  For more information contact
++// info@riverbankcomputing.com.
++// 
++// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
++// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
++
++
++%If (Qt_6_7_0 -)
++
++class QHttpHeaders
++{
++%TypeHeaderCode
++#include <qhttpheaders.h>
++%End
++
++public:
++    enum class WellKnownHeader
++    {
++        AIM,
++        Accept,
++        AcceptAdditions,
++        AcceptCH,
++        AcceptDatetime,
++        AcceptEncoding,
++        AcceptFeatures,
++        AcceptLanguage,
++        AcceptPatch,
++        AcceptPost,
++        AcceptRanges,
++        AcceptSignature,
++        AccessControlAllowCredentials,
++        AccessControlAllowHeaders,
++        AccessControlAllowMethods,
++        AccessControlAllowOrigin,
++        AccessControlExposeHeaders,
++        AccessControlMaxAge,
++        AccessControlRequestHeaders,
++        AccessControlRequestMethod,
++        Age,
++        Allow,
++        ALPN,
++        AltSvc,
++        AltUsed,
++        Alternates,
++        ApplyToRedirectRef,
++        AuthenticationControl,
++        AuthenticationInfo,
++        Authorization,
++        CacheControl,
++        CacheStatus,
++        CalManagedID,
++        CalDAVTimezones,
++        CapsuleProtocol,
++        CDNCacheControl,
++        CDNLoop,
++        CertNotAfter,
++        CertNotBefore,
++        ClearSiteData,
++        ClientCert,
++        ClientCertChain,
++        Close,
++        Connection,
++        ContentDigest,
++        ContentDisposition,
++        ContentEncoding,
++        ContentID,
++        ContentLanguage,
++        ContentLength,
++        ContentLocation,
++        ContentRange,
++        ContentSecurityPolicy,
++        ContentSecurityPolicyReportOnly,
++        ContentType,
++        Cookie,
++        CrossOriginEmbedderPolicy,
++        CrossOriginEmbedderPolicyReportOnly,
++        CrossOriginOpenerPolicy,
++        CrossOriginOpenerPolicyReportOnly,
++        CrossOriginResourcePolicy,
++        DASL,
++        Date,
++        DAV,
++        DeltaBase,
++        Depth,
++        Destination,
++        DifferentialID,
++        DPoP,
++        DPoPNonce,
++        EarlyData,
++        ETag,
++        Expect,
++        ExpectCT,
++        Expires,
++        Forwarded,
++        From,
++        Hobareg,
++        Host,
++        If,
++        IfMatch,
++        IfModifiedSince,
++        IfNoneMatch,
++        IfRange,
++        IfScheduleTagMatch,
++        IfUnmodifiedSince,
++        IM,
++        IncludeReferredTokenBindingID,
++        KeepAlive,
++        Label,
++        LastEventID,
++        LastModified,
++        Link,
++        Location,
++        LockToken,
++        MaxForwards,
++        MementoDatetime,
++        Meter,
++        MIMEVersion,
++        Negotiate,
++        NEL,
++        ODataEntityId,
++        ODataIsolation,
++        ODataMaxVersion,
++        ODataVersion,
++        OptionalWWWAuthenticate,
++        OrderingType,
++        Origin,
++        OriginAgentCluster,
++        OSCORE,
++        OSLCCoreVersion,
++        Overwrite,
++        PingFrom,
++        PingTo,
++        Position,
++        Prefer,
++        PreferenceApplied,
++        Priority,
++        ProxyAuthenticate,
++        ProxyAuthenticationInfo,
++        ProxyAuthorization,
++        ProxyStatus,
++        PublicKeyPins,
++        PublicKeyPinsReportOnly,
++        Range,
++        RedirectRef,
++        Referer,
++        Refresh,
++        ReplayNonce,
++        ReprDigest,
++        RetryAfter,
++        ScheduleReply,
++        ScheduleTag,
++        SecPurpose,
++        SecTokenBinding,
++        SecWebSocketAccept,
++        SecWebSocketExtensions,
++        SecWebSocketKey,
++        SecWebSocketProtocol,
++        SecWebSocketVersion,
++        Server,
++        ServerTiming,
++        SetCookie,
++        Signature,
++        SignatureInput,
++        SLUG,
++        SoapAction,
++        StatusURI,
++        StrictTransportSecurity,
++        Sunset,
++        SurrogateCapability,
++        SurrogateControl,
++        TCN,
++        TE,
++        Timeout,
++        Topic,
++        Traceparent,
++        Tracestate,
++        Trailer,
++        TransferEncoding,
++        TTL,
++        Upgrade,
++        Urgency,
++        UserAgent,
++        VariantVary,
++        Vary,
++        Via,
++        WantContentDigest,
++        WantReprDigest,
++        WWWAuthenticate,
++        XContentTypeOptions,
++        XFrameOptions,
++        AcceptCharset,
++        CPEPInfo,
++        Pragma,
++        ProtocolInfo,
++        ProtocolQuery,
++    };
++
++    QHttpHeaders();
++    QHttpHeaders(const QHttpHeaders &other);
++    ~QHttpHeaders();
++    void swap(QHttpHeaders &other /Constrained/);
++    bool append(QAnyStringView name, QAnyStringView value);
++    bool append(QHttpHeaders::WellKnownHeader name, QAnyStringView value);
++    bool insert(qsizetype i, QAnyStringView name, QAnyStringView value);
++    bool insert(qsizetype i, QHttpHeaders::WellKnownHeader name, QAnyStringView value);
++    bool replace(qsizetype i, QAnyStringView name, QAnyStringView newValue);
++    bool replace(qsizetype i, QHttpHeaders::WellKnownHeader name, QAnyStringView newValue);
++    bool contains(QAnyStringView name) const;
++    bool contains(QHttpHeaders::WellKnownHeader name) const;
++    void clear();
++    void removeAll(QAnyStringView name);
++    void removeAll(QHttpHeaders::WellKnownHeader name);
++    void removeAt(qsizetype i);
++    QByteArrayView value(QAnyStringView name, QByteArrayView defaultValue = {}) const;
++    QByteArrayView value(QHttpHeaders::WellKnownHeader name, QByteArrayView defaultValue = {}) const;
++    QList<QByteArray> values(QAnyStringView name) const;
++    QList<QByteArray> values(QHttpHeaders::WellKnownHeader name) const;
++    QByteArrayView valueAt(qsizetype i) const;
++    QString nameAt(qsizetype i) const [QLatin1StringView (qsizetype i)];
++    QByteArray combinedValue(QAnyStringView name) const;
++    QByteArray combinedValue(QHttpHeaders::WellKnownHeader name) const;
++    qsizetype size() const;
++    void reserve(qsizetype size);
++    bool isEmpty() const;
++    static QByteArrayView wellKnownHeaderName(QHttpHeaders::WellKnownHeader name);
++    static QHttpHeaders fromListOfPairs(const QList<std::pair<QByteArray, QByteArray>> &headers);
++    QList<std::pair<QByteArray, QByteArray>> toListOfPairs() const;
++};
++
++%End
+--- a/sip/QtNetwork/qnetworkaccessmanager.sip
++++ b/sip/QtNetwork/qnetworkaccessmanager.sip
+@@ -45,6 +45,12 @@ public:
+     void setCookieJar(QNetworkCookieJar *cookieJar /Transfer/);
+     QNetworkReply *head(const QNetworkRequest &request);
+     QNetworkReply *get(const QNetworkRequest &request);
++%If (Qt_6_7_0 -)
++    QNetworkReply *get(const QNetworkRequest &request, const QByteArray &data);
++%End
++%If (Qt_6_7_0 -)
++    QNetworkReply *get(const QNetworkRequest &request, QIODevice *data);
++%End
+     QNetworkReply *post(const QNetworkRequest &request, QIODevice *data);
+     QNetworkReply *post(const QNetworkRequest &request, const QByteArray &data);
+     QNetworkReply *post(const QNetworkRequest &request, QHttpMultiPart *multiPart);
+--- a/sip/QtNetwork/qnetworkcookie.sip
++++ b/sip/QtNetwork/qnetworkcookie.sip
+@@ -50,7 +50,12 @@ public:
+     QByteArray value() const;
+     void setValue(const QByteArray &value);
+     QByteArray toRawForm(QNetworkCookie::RawForm form = QNetworkCookie::Full) const;
++%If (Qt_6_7_0 -)
++    static QList<QNetworkCookie> parseCookies(QByteArrayView cookieString);
++%End
++%If (- Qt_6_7_0)
+     static QList<QNetworkCookie> parseCookies(const QByteArray &cookieString);
++%End
+     bool operator==(const QNetworkCookie &other) const;
+     bool operator!=(const QNetworkCookie &other) const;
+     bool isHttpOnly() const;
+--- a/sip/QtNetwork/qnetworkreply.sip
++++ b/sip/QtNetwork/qnetworkreply.sip
+@@ -77,9 +77,19 @@ public:
+     QNetworkReply::NetworkError error() const;
+     QUrl url() const;
+     QVariant header(QNetworkRequest::KnownHeaders header) const;
++%If (Qt_6_7_0 -)
++    bool hasRawHeader(QAnyStringView headerName) const;
++%End
++%If (- Qt_6_7_0)
+     bool hasRawHeader(const QByteArray &headerName) const;
++%End
+     QList<QByteArray> rawHeaderList() const;
++%If (Qt_6_7_0 -)
++    QByteArray rawHeader(QAnyStringView headerName) const;
++%End
++%If (- Qt_6_7_0)
+     QByteArray rawHeader(const QByteArray &headerName) const;
++%End
+     QVariant attribute(QNetworkRequest::Attribute code) const;
+ %If (PyQt_SSL)
+     QSslConfiguration sslConfiguration() const;
+--- a/sip/QtNetwork/qnetworkrequest.sip
++++ b/sip/QtNetwork/qnetworkrequest.sip
+@@ -110,9 +110,19 @@ public:
+     void setUrl(const QUrl &url);
+     QVariant header(QNetworkRequest::KnownHeaders header) const;
+     void setHeader(QNetworkRequest::KnownHeaders header, const QVariant &value);
++%If (Qt_6_7_0 -)
++    bool hasRawHeader(QAnyStringView headerName) const;
++%End
++%If (- Qt_6_7_0)
+     bool hasRawHeader(const QByteArray &headerName) const;
++%End
+     QList<QByteArray> rawHeaderList() const;
++%If (Qt_6_7_0 -)
++    QByteArray rawHeader(QAnyStringView headerName) const;
++%End
++%If (- Qt_6_7_0)
+     QByteArray rawHeader(const QByteArray &headerName) const;
++%End
+     void setRawHeader(const QByteArray &headerName, const QByteArray &value);
+     QVariant attribute(QNetworkRequest::Attribute code, const QVariant &defaultValue = QVariant()) const;
+     void setAttribute(QNetworkRequest::Attribute code, const QVariant &value);
+--- a/sip/QtQuick/QtQuickmod.sip
++++ b/sip/QtQuick/QtQuickmod.sip
+@@ -71,6 +71,7 @@ WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ %Include qsgrendernode.sip
+ %Include qsgsimplerectnode.sip
+ %Include qsgsimpletexturenode.sip
++%Include qsgtextnode.sip
+ %Include qsgtexture.sip
+ %Include qsgtexture_platform.sip
+ %Include qsgtexturematerial.sip
+--- a/sip/QtQuick/qquickitem.sip
++++ b/sip/QtQuick/qquickitem.sip
+@@ -317,4 +317,15 @@ public:
+ %If (Qt_6_3_0 -)
+     void dumpItemTree() const;
+ %End
++%If (Qt_6_7_0 -)
++    Qt::FocusPolicy focusPolicy() const;
++%End
++%If (Qt_6_7_0 -)
++    void setFocusPolicy(Qt::FocusPolicy policy);
++%End
++
++signals:
++%If (Qt_6_7_0 -)
++    void focusPolicyChanged(Qt::FocusPolicy);
++%End
+ };
+--- a/sip/QtQuick/qquicktextdocument.sip
++++ b/sip/QtQuick/qquicktextdocument.sip
+@@ -27,6 +27,65 @@ class QQuickTextDocument : QObject
+ %End
+ 
+ public:
++%If (Qt_6_7_0 -)
++
++    enum class Status
++    {
++        Null,
++        Loading,
++        Loaded,
++        Saving,
++        Saved,
++        ReadError,
++        WriteError,
++        NonLocalFileError,
++    };
++
++%End
+     QQuickTextDocument(QQuickItem *parent /TransferThis/);
+     QTextDocument *textDocument() const;
++%If (Qt_6_7_0 -)
++    QUrl source() const;
++%End
++%If (Qt_6_7_0 -)
++    void setSource(const QUrl &url);
++%End
++%If (Qt_6_7_0 -)
++    bool isModified() const;
++%End
++%If (Qt_6_7_0 -)
++    void setModified(bool modified);
++%End
++%If (Qt_6_7_0 -)
++    void setTextDocument(QTextDocument *document);
++%End
++%If (Qt_6_7_0 -)
++    void save() /ReleaseGIL/;
++%End
++%If (Qt_6_7_0 -)
++    void saveAs(const QUrl &url) /ReleaseGIL/;
++%End
++%If (Qt_6_7_0 -)
++    QQuickTextDocument::Status status() const;
++%End
++%If (Qt_6_7_0 -)
++    QString errorString() const;
++%End
++
++signals:
++%If (Qt_6_7_0 -)
++    void textDocumentChanged();
++%End
++%If (Qt_6_7_0 -)
++    void sourceChanged();
++%End
++%If (Qt_6_7_0 -)
++    void modifiedChanged();
++%End
++%If (Qt_6_7_0 -)
++    void statusChanged();
++%End
++%If (Qt_6_7_0 -)
++    void errorStringChanged();
++%End
+ };
+--- a/sip/QtQuick/qquickview.sip
++++ b/sip/QtQuick/qquickview.sip
+@@ -30,6 +30,9 @@ public:
+     explicit QQuickView(QWindow *parent /TransferThis/ = 0);
+     QQuickView(QQmlEngine *engine, QWindow *parent /TransferThis/);
+     QQuickView(const QUrl &source, QWindow *parent /TransferThis/ = 0);
++%If (Qt_6_7_0 -)
++    QQuickView(QAnyStringView uri, QAnyStringView typeName, QWindow *parent /TransferThis/ = 0);
++%End
+     virtual ~QQuickView() /ReleaseGIL/;
+     QUrl source() const;
+     QQmlEngine *engine() const;
+@@ -60,6 +63,9 @@ public:
+ public slots:
+     void setSource(const QUrl &) /ReleaseGIL/;
+     void setInitialProperties(const QVariantMap &initialProperties);
++%If (Qt_6_7_0 -)
++    void loadFromModule(QAnyStringView uri, QAnyStringView typeName);
++%End
+ 
+ signals:
+     void statusChanged(QQuickView::Status);
+--- a/sip/QtQuick/qquickwindow.sip
++++ b/sip/QtQuick/qquickwindow.sip
+@@ -89,6 +89,9 @@ public:
+     void setRenderTarget(const QQuickRenderTarget &target);
+     QQuickRenderTarget renderTarget() const;
+     QQmlIncubationController *incubationController() const;
++%If (Qt_6_7_0 -)
++    QSGTextNode *createTextNode() const /Factory/;
++%End
+     QSGTexture *createTextureFromImage(const QImage &image) const /Factory/;
+     QSGTexture *createTextureFromImage(const QImage &image, QQuickWindow::CreateTextureOptions options) const /Factory/;
+     void setColor(const QColor &color);
+@@ -171,6 +174,9 @@ public:
+     {
+         QtTextRendering,
+         NativeTextRendering,
++%If (Qt_6_7_0 -)
++        CurveTextRendering,
++%End
+     };
+ 
+     static QQuickWindow::TextRenderType textRenderType();
+new file mode 100644
+--- /dev/null
++++ b/sip/QtQuick/qsgtextnode.sip
+@@ -0,0 +1,73 @@
++// qsgtextnode.sip generated by MetaSIP
++//
++// This file is part of the QtQuick Python extension module.
++//
++// Copyright (c) 2024 Riverbank Computing Limited <info@riverbankcomputing.com>
++// 
++// This file is part of PyQt6.
++// 
++// This file may be used under the terms of the GNU General Public License
++// version 3.0 as published by the Free Software Foundation and appearing in
++// the file LICENSE included in the packaging of this file.  Please review the
++// following information to ensure the GNU General Public License version 3.0
++// requirements will be met: http://www.gnu.org/copyleft/gpl.html.
++// 
++// If you do not wish to use this file under the terms of the GPL version 3.0
++// then you may purchase a commercial license.  For more information contact
++// info@riverbankcomputing.com.
++// 
++// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
++// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
++
++
++%If (Qt_6_7_0 -)
++
++class QSGTextNode : QSGTransformNode /NoDefaultCtors/
++{
++%TypeHeaderCode
++#include <qsgtextnode.h>
++%End
++
++public:
++    enum RenderType
++    {
++        QtRendering,
++        NativeRendering,
++        CurveRendering,
++    };
++
++    enum TextStyle
++    {
++        Normal,
++        Outline,
++        Raised,
++        Sunken,
++    };
++
++    virtual ~QSGTextNode();
++    void addTextDocument(QPointF position, QTextDocument *document, int selectionStart = -1, int selectionCount = -1);
++    void addTextLayout(QPointF position, QTextLayout *layout, int selectionStart = -1, int selectionCount = -1, int lineStart = 0, int lineCount = -1);
++    virtual void setColor(QColor color) = 0;
++    virtual QColor color() const = 0;
++    virtual void setTextStyle(QSGTextNode::TextStyle textStyle) = 0;
++    virtual QSGTextNode::TextStyle textStyle() = 0;
++    virtual void setStyleColor(QColor styleColor) = 0;
++    virtual QColor styleColor() const = 0;
++    virtual void setLinkColor(QColor linkColor) = 0;
++    virtual QColor linkColor() const = 0;
++    virtual void setSelectionColor(QColor selectionColor) = 0;
++    virtual QColor selectionColor() const = 0;
++    virtual void setSelectionTextColor(QColor selectionTextColor) = 0;
++    virtual QColor selectionTextColor() const = 0;
++    virtual void setRenderType(QSGTextNode::RenderType renderType) = 0;
++    virtual QSGTextNode::RenderType renderType() const = 0;
++    virtual void setRenderTypeQuality(int renderTypeQuality) = 0;
++    virtual int renderTypeQuality() const = 0;
++    virtual void setFiltering(QSGTexture::Filtering) = 0;
++    virtual QSGTexture::Filtering filtering() const = 0;
++    virtual void clear() = 0;
++    virtual void setViewport(const QRectF &viewport) = 0;
++    virtual QRectF viewport() const = 0;
++};
++
++%End
+--- a/sip/QtRemoteObjects/QtRemoteObjectsmod.sip
++++ b/sip/QtRemoteObjects/QtRemoteObjectsmod.sip
+@@ -23,6 +23,7 @@
+ %Module(name=PyQt6.QtRemoteObjects, keyword_arguments="Optional", use_limited_api=True)
+ 
+ %Import QtCore/QtCoremod.sip
++%Import QtNetwork/QtNetworkmod.sip
+ 
+ %Copying
+ Copyright (c) 2023 Riverbank Computing Limited <info@riverbankcomputing.com>
+--- a/sip/QtRemoteObjects/qremoteobjectnode.sip
++++ b/sip/QtRemoteObjects/qremoteobjectnode.sip
+@@ -95,6 +95,9 @@ public:
+         HostUrlInvalid,
+         ProtocolMismatch,
+         ListenFailed,
++%If (Qt_6_7_0 -)
++        SocketAccessError,
++%End
+     };
+ 
+     QRemoteObjectNode(QObject *parent /TransferThis/ = 0);
+@@ -171,6 +174,11 @@ public:
+ 
+ signals:
+     void hostUrlChanged();
++
++public:
++%If (Qt_6_7_0 -)
++    static void setLocalServerOptions(QLocalServer::SocketOptions options);
++%End
+ };
+ 
+ %End
+--- a/sip/QtSql/qsqlquery.sip
++++ b/sip/QtSql/qsqlquery.sip
+@@ -86,4 +86,10 @@ public:
+ %If (Qt_6_6_0 -)
+     QString boundValueName(int pos) const;
+ %End
++%If (Qt_6_7_0 -)
++    void setPositionalBindingEnabled(bool enable);
++%End
++%If (Qt_6_7_0 -)
++    bool isPositionalBindingEnabled() const;
++%End
+ };
+--- a/sip/QtSql/qsqlresult.sip
++++ b/sip/QtSql/qsqlresult.sip
+@@ -97,6 +97,12 @@ protected:
+ %If (Qt_6_6_0 -)
+     QStringList boundValueNames() const;
+ %End
++%If (Qt_6_7_0 -)
++    void setPositionalBindingEnabled(bool enable);
++%End
++%If (Qt_6_7_0 -)
++    bool isPositionalBindingEnabled() const;
++%End
+ 
+ private:
+     QSqlResult(const QSqlResult &);
+--- a/sip/QtSvg/QtSvgmod.sip
++++ b/sip/QtSvg/QtSvgmod.sip
+@@ -46,5 +46,6 @@ WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ 
+ %DefaultSupertype PyQt6.sip.simplewrapper
+ 
++%Include qtsvgglobal.sip
+ %Include qsvggenerator.sip
+ %Include qsvgrenderer.sip
+--- a/sip/QtSvg/qsvgrenderer.sip
++++ b/sip/QtSvg/qsvgrenderer.sip
+@@ -90,4 +90,16 @@ public:
+     Qt::AspectRatioMode aspectRatioMode() const;
+     void setAspectRatioMode(Qt::AspectRatioMode mode);
+     QTransform transformForElement(const QString &id) const;
++%If (Qt_6_7_0 -)
++    QtSvg::Options options() const;
++%End
++%If (Qt_6_7_0 -)
++    void setOptions(QtSvg::Options flags);
++%End
++%If (Qt_6_7_0 -)
++    bool isAnimationEnabled() const;
++%End
++%If (Qt_6_7_0 -)
++    void setAnimationEnabled(bool enable);
++%End
+ };
+new file mode 100644
+--- /dev/null
++++ b/sip/QtSvg/qtsvgglobal.sip
+@@ -0,0 +1,40 @@
++// qtsvgglobal.sip generated by MetaSIP
++//
++// This file is part of the QtSvg Python extension module.
++//
++// Copyright (c) 2024 Riverbank Computing Limited <info@riverbankcomputing.com>
++// 
++// This file is part of PyQt6.
++// 
++// This file may be used under the terms of the GNU General Public License
++// version 3.0 as published by the Free Software Foundation and appearing in
++// the file LICENSE included in the packaging of this file.  Please review the
++// following information to ensure the GNU General Public License version 3.0
++// requirements will be met: http://www.gnu.org/copyleft/gpl.html.
++// 
++// If you do not wish to use this file under the terms of the GPL version 3.0
++// then you may purchase a commercial license.  For more information contact
++// info@riverbankcomputing.com.
++// 
++// This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
++// WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
++
++
++%If (Qt_6_7_0 -)
++
++namespace QtSvg
++{
++%TypeHeaderCode
++#include <qtsvgglobal.h>
++%End
++
++    enum Option
++    {
++        NoOption,
++        Tiny12FeaturesOnly,
++    };
++
++    typedef QFlags<QtSvg::Option> Options;
++};
++
++%End
+--- a/sip/QtSvgWidgets/qsvgwidget.sip
++++ b/sip/QtSvgWidgets/qsvgwidget.sip
+@@ -68,4 +68,12 @@ public slots:
+ 
+ protected:
+     virtual void paintEvent(QPaintEvent *event);
++
++public:
++%If (Qt_6_7_0 -)
++    QtSvg::Options options() const;
++%End
++%If (Qt_6_7_0 -)
++    void setOptions(QtSvg::Options options);
++%End
+ };
+--- a/sip/QtWidgets/qcheckbox.sip
++++ b/sip/QtWidgets/qcheckbox.sip
+@@ -39,6 +39,9 @@ public:
+ 
+ signals:
+     void stateChanged(int);
++%If (Qt_6_7_0 -)
++    void checkStateChanged(Qt::CheckState);
++%End
+ 
+ protected:
+     virtual bool hitButton(const QPoint &pos) const;
+--- a/sip/QtWidgets/qcolordialog.sip
++++ b/sip/QtWidgets/qcolordialog.sip
+@@ -32,6 +32,9 @@ public:
+         ShowAlphaChannel,
+         NoButtons,
+         DontUseNativeDialog,
++%If (Qt_6_7_0 -)
++        NoEyeDropperButton,
++%End
+     };
+ 
+     typedef QFlags<QColorDialog::ColorDialogOption> ColorDialogOptions;
+--- a/sip/QtWidgets/qdatetimeedit.sip
++++ b/sip/QtWidgets/qdatetimeedit.sip
+@@ -121,6 +121,12 @@ public:
+     void setTimeSpec(Qt::TimeSpec spec);
+     QCalendar calendar() const;
+     void setCalendar(QCalendar calendar);
++%If (Qt_6_7_0 -)
++    QTimeZone timeZone() const;
++%End
++%If (Qt_6_7_0 -)
++    void setTimeZone(const QTimeZone &zone);
++%End
+ };
+ 
+ class QTimeEdit : QDateTimeEdit
+--- a/sip/QtWidgets/qdrawutil.sip
++++ b/sip/QtWidgets/qdrawutil.sip
+@@ -37,3 +37,9 @@ void qDrawWinPanel(QPainter *p, const QRect &r, const QPalette &pal, bool sunken
+ void qDrawPlainRect(QPainter *p, int x, int y, int w, int h, const QColor &, int lineWidth = 1, const QBrush *fill = 0);
+ void qDrawPlainRect(QPainter *p, const QRect &r, const QColor &, int lineWidth = 1, const QBrush *fill = 0);
+ void qDrawBorderPixmap(QPainter *painter, const QRect &target, const QMargins &margins, const QPixmap &pixmap);
++%If (Qt_6_7_0 -)
++void qDrawPlainRoundedRect(QPainter *painter, const QRect &rect, qreal rx, qreal ry, const QColor &lineColor, int lineWidth = 1, const QBrush *fill = 0);
++%End
++%If (Qt_6_7_0 -)
++void qDrawPlainRoundedRect(QPainter *p, int x, int y, int w, int h, qreal rx, qreal ry, const QColor &, int lineWidth = 1, const QBrush *fill = 0);
++%End
+--- a/sip/QtWidgets/qfiledialog.sip
++++ b/sip/QtWidgets/qfiledialog.sip
+@@ -308,4 +308,7 @@ public:
+     QStringList supportedSchemes() const;
+     QString selectedMimeTypeFilter() const;
+     static void saveFileContent(const QByteArray &fileContent, const QString &fileNameHint = QString()) /ReleaseGIL/;
++%If (Qt_6_7_0 -)
++    static void saveFileContent(const QByteArray &fileContent, const QString &fileNameHint, QWidget *parent = 0);
++%End
+ };
+--- a/uic/Compiler/qtproxies.py
++++ b/uic/Compiler/qtproxies.py
+@@ -298,9 +298,9 @@ class QtGui(ProxyNamespace):
+ 
+ 
+ # These sub-class QWidget but aren't themselves sub-classed.
+-_qwidgets = ("QCalendarWidget", "QDialogButtonBox", "QDockWidget", "QGroupBox",
+-        "QLineEdit", "QMainWindow", "QMenuBar", "QOpenGLWidget",
+-        "QProgressBar", "QStatusBar", "QToolBar", "QWizardPage")
++_qwidgets = ('QCalendarWidget', 'QDialogButtonBox', 'QDockWidget', 'QGroupBox',
++        'QLineEdit', 'QMainWindow', 'QMenuBar', 'QProgressBar', 'QStatusBar',
++        'QToolBar', 'QWizardPage')
+ 
+ class QtWidgets(ProxyNamespace):
+     class QApplication(QtCore.QObject):
+new file mode 100644
+--- /dev/null
++++ b/uic/widget-plugins/qtopenglwidgets.py
+@@ -0,0 +1,33 @@
++#############################################################################
++##
++## Copyright (c) 2024 Riverbank Computing Limited <info@riverbankcomputing.com>
++## 
++## This file is part of PyQt6.
++## 
++## This file may be used under the terms of the GNU General Public License
++## version 3.0 as published by the Free Software Foundation and appearing in
++## the file LICENSE included in the packaging of this file.  Please review the
++## following information to ensure the GNU General Public License version 3.0
++## requirements will be met: http://www.gnu.org/copyleft/gpl.html.
++## 
++## If you do not wish to use this file under the terms of the GPL version 3.0
++## then you may purchase a commercial license.  For more information contact
++## info@riverbankcomputing.com.
++## 
++## This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
++## WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
++##
++#############################################################################
++
++
++# If pluginType is MODULE, the plugin loader will call moduleInformation.  The
++# variable MODULE is inserted into the local namespace by the plugin loader.
++pluginType = MODULE
++
++
++# moduleInformation() must return a tuple (module, widget_list).  If "module"
++# is "A" and any widget from this module is used, the code generator will write
++# "import A".  If "module" is "A[.B].C", the code generator will write
++# "from A[.B] import C".  Each entry in "widget_list" must be unique.
++def moduleInformation():
++    return 'PyQt6.QtOpenGLWidgets', ('QOpenGLWidget', )


### PR DESCRIPTION
Dropped some metadata modifications, public inheritance changes, and version number modification.

---

Needed for Homebrew/homebrew-core#169109 which should unblock LLVM PR.

---

Generated using PyQt6 stable source and https://www.riverbankcomputing.com/pypi/packages/PyQt6/PyQt6-6.7.0.dev2404171245.tar.gz (linked from https://www.riverbankcomputing.com/software/pyqt/download)

It might be possible to pare down patch to only incompatible API and drop new API, but didn't seem worth time to do this.

Tested a local run with patch applied from branch on ARM macOS, e.g.
```diff
diff --git a/Formula/p/pyqt.rb b/Formula/p/pyqt.rb
index c98f9cfb4d0..974248ade23 100644
--- a/Formula/p/pyqt.rb
+++ b/Formula/p/pyqt.rb
@@ -53,6 +53,12 @@ class Pyqt < Formula
     sha256 "d50b984c3f85e409e692b156132721522d4e8cf9b6c25e0cf927eea2dfb39487"
   end
 
+  # Backport support for `qt` 6.7.0 API changes
+  patch do
+    url "https://raw.githubusercontent.com/Homebrew/formula-patches/d2fe147767b6eb46cd11dfc9d4f16b18e0d2997f/pyqt/qt-6.7.0.patch"
+    sha256 "2e1df66b5d6ad338269368bc3778f27ed77f66be891613f7c567fbdac2197f6d"
+  end
+
   def python3
     "python3.12"
   end
@@ -66,6 +72,7 @@ class Pyqt < Formula
       --target-dir #{site_packages}
       --scripts-dir #{bin}
       --confirm-license
+      --verbose
     ]
     system "sip-install", *args
 
```

No guarantee other platforms so may need to be tweaked after CI run.