### PR TITLE
openssh: update patches for 7.8p1

### DIFF
--- a/openssh/patch-sshd.c-apple-sandbox-named-external.diff
+++ b/openssh/patch-sshd.c-apple-sandbox-named-external.diff
@@ -1,0 +1,23 @@
+diff --git a/sshd-session.c b/sshd-session.c
+index fe6ae7f..683cf01 100644
+--- a/sshd-session.c
++++ b/sshd-session.c
+@@ -376,10 +376,18 @@ privsep_preauth(struct ssh *ssh)
+ 		/* Arrange for logging to be sent to the monitor */
+ 		set_log_handler(mm_log_handler, pmonitor);
+ 
++#ifdef __APPLE_SANDBOX_NAMED_EXTERNAL__
++		/* We need to do this before we chroot() so we can read sshd.sb */
++		if (box != NULL)
++			ssh_sandbox_child(box);
++#endif
++
+ 		privsep_preauth_child();
+ 		setproctitle("%s", "[net]");
++#ifndef __APPLE_SANDBOX_NAMED_EXTERNAL__
+ 		if (box != NULL)
+ 			ssh_sandbox_child(box);
++#endif
+ 
+ 		return 0;
+ 	}


### PR DESCRIPTION
Original patch: https://raw.githubusercontent.com/Homebrew/patches/d8b2d8c2612fd251ac6de17bf0cc5174c3aab94c/openssh/patch-sshd.c-apple-sandbox-named-external.diff

The code we're patching was moved from sshd.c to sshd-session.c: https://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.bin/ssh/sshd-session.c