### PR TITLE
glib: add $HOMEBREW/lib/girepository-1.0 to girepository search path

### DIFF
--- a/glib/hardcoded-paths.diff
+++ b/glib/hardcoded-paths.diff
@@ -1,8 +1,8 @@
 diff --git a/gio/xdgmime/xdgmime.c b/gio/xdgmime/xdgmime.c
-index 2446d38..1042df2 100644
+index 0909581eb..04518ad88 100644
 --- a/gio/xdgmime/xdgmime.c
 +++ b/gio/xdgmime/xdgmime.c
-@@ -235,7 +235,7 @@ xdg_init_dirs (void)
+@@ -228,7 +228,7 @@ xdg_init_dirs (void)
    xdg_data_dirs = getenv ("XDG_DATA_DIRS");
  
    if (xdg_data_dirs == NULL)
@@ -11,11 +11,24 @@ index 2446d38..1042df2 100644
  
    /* Work out how many dirs we’re dealing with. */
    if (xdg_data_home != NULL || home != NULL)
+diff --git a/girepository/girepository.c b/girepository/girepository.c
+index a6a81716d..63bf2ec9e 100644
+--- a/girepository/girepository.c
++++ b/girepository/girepository.c
+@@ -300,6 +300,8 @@ gi_repository_init (GIRepository *repository)
+       typelib_dir = g_build_filename (libdir, "girepository-1.0", NULL);
+ 
+       g_ptr_array_add (repository->typelib_search_path, g_steal_pointer (&typelib_dir));
++
++      g_ptr_array_add (repository->typelib_search_path, g_strdup ("@@HOMEBREW_PREFIX@@/lib/girepository-1.0"));
+     }
+ 
+   repository->library_paths = g_ptr_array_new_null_terminated (1, g_free, TRUE);
 diff --git a/glib/gutils.c b/glib/gutils.c
-index 2e2d457..c97259b 100644
+index 8628a568d..6d54f3c7f 100644
 --- a/glib/gutils.c
 +++ b/glib/gutils.c
-@@ -2080,7 +2080,7 @@ g_build_system_data_dirs (void)
+@@ -2698,7 +2698,7 @@ g_build_system_data_dirs (void)
     */
  #ifndef G_OS_WIN32
    if (!data_dirs || !data_dirs[0])
@@ -24,4 +37,3 @@ index 2e2d457..c97259b 100644
  
    data_dir_vector = g_strsplit (data_dirs, G_SEARCHPATH_SEPARATOR_S, 0);
  #else
-


### PR DESCRIPTION
The new girepository library (part of GLib 1.80+) is replacing gobject-introspection.

GObject-introspection has a patch that makes it work nicely with Homebrews `/opt/homebrew/lib/girepository-1.0` folder.

See https://github.com/Homebrew/homebrew-core/blob/master/Formula/g/gobject-introspection.rb#L52-L58 for the gobject-introspection patch.

CC @tschoonj 