### PR TITLE
Add backported patch for glibc@2.17

### DIFF
--- a/glibc/2.17-aarch64-dl-machine.diff
+++ b/glibc/2.17-aarch64-dl-machine.diff
@@ -1,0 +1,78 @@
+commit f6610cf4ec687bd37da8c7ea2664df6545e79bf5
+Author: Fangrui Song <maskray@google.com>
+Commit: Ruoyu Zhong <zhongruoyu@outlook.com>
+
+    aarch64: Make elf_machine_{load_address,dynamic} robust [BZ #28203]
+    
+    The AArch64 ABI is largely platform agnostic and does not specify
+    _GLOBAL_OFFSET_TABLE_[0] ([1]). glibc ld.so turns out to be probably the
+    only user of _GLOBAL_OFFSET_TABLE_[0] and GNU ld defines the value
+    to the link-time address _DYNAMIC. [2]
+    
+    In 2012, __ehdr_start was implemented in GNU ld and gold in binutils
+    2.23.  Using adrp+add / (-mcmodel=tiny) adr to access
+    __ehdr_start/_DYNAMIC gives us a robust way to get the load address and
+    the link-time address of _DYNAMIC.
+    
+    [1]: From a psABI maintainer, https://bugs.llvm.org/show_bug.cgi?id=49672#c2
+    [2]: LLD's aarch64 port does not set _GLOBAL_OFFSET_TABLE_[0] to the
+    link-time address _DYNAMIC.
+    LLD is widely used on aarch64 Android and ChromeOS devices.  Software
+    just works without the need for _GLOBAL_OFFSET_TABLE_[0].
+    
+    Reviewed-by: Szabolcs Nagy <szabolcs.nagy@arm.com>
+
+diff --git a/ports/sysdeps/aarch64/dl-machine.h b/ports/sysdeps/aarch64/dl-machine.h
+index 94f1108e15..3e4fa7f900 100644
+--- a/ports/sysdeps/aarch64/dl-machine.h
++++ b/ports/sysdeps/aarch64/dl-machine.h
+@@ -31,40 +31,22 @@ elf_machine_matches_host (const ElfW(Ehdr) *ehdr)
+   return ehdr->e_machine == EM_AARCH64;
+ }
+ 
+-/* Return the link-time address of _DYNAMIC.  Conveniently, this is the
+-   first element of the GOT. */
++/* Return the run-time load address of the shared object.  */
++
+ static inline ElfW(Addr) __attribute__ ((unused))
+-elf_machine_dynamic (void)
++elf_machine_load_address (void)
+ {
+-  ElfW(Addr) addr = (ElfW(Addr)) &_DYNAMIC;
+-  return addr;
++  extern const ElfW(Ehdr) __ehdr_start attribute_hidden;
++  return (ElfW(Addr)) &__ehdr_start;
+ }
+ 
+-/* Return the run-time load address of the shared object.  */
++/* Return the link-time address of _DYNAMIC.  */
+ 
+ static inline ElfW(Addr) __attribute__ ((unused))
+-elf_machine_load_address (void)
++elf_machine_dynamic (void)
+ {
+-  /* To figure out the load address we use the definition that for any symbol:
+-     dynamic_addr(symbol) = static_addr(symbol) + load_addr
+-
+-     The choice of symbol is arbitrary. The static address we obtain
+-     by constructing a non GOT reference to the symbol, the dynamic
+-     address of the symbol we compute using adrp/add to compute the
+-     symbol's address relative to the PC. */
+-
+-  ElfW(Addr) static_addr;
+-  ElfW(Addr) dynamic_addr;
+-
+-  asm ("					\n\
+-	adrp	%1, _dl_start;			\n\
+-        add	%1, %1, #:lo12:_dl_start        \n\
+-        ldr	%w0, 1f				\n\
+-	b	2f				\n\
+-1:	.word	_dl_start			\n\
+-2:						\n\
+-       " : "=r" (static_addr),  "=r" (dynamic_addr));
+-  return dynamic_addr - static_addr;
++  extern ElfW(Dyn) _DYNAMIC[] attribute_hidden;
++  return (ElfW(Addr)) _DYNAMIC - elf_machine_load_address ();
+ }
+ 
+ /* Set up the loaded object described by L so its unrelocated PLT


### PR DESCRIPTION
This patch is a backport of [^1]. Along with [^2] (backport of [^3]), it allows glibc@2.17 to be built with the latest GNU ld.

Without this patch, build fails with:

<details>
<summary> Build error </summary>

```
gcc-11   -nostdlib -nostartfiles -shared -o /tmp/glibcA2.17-20241116-69269-z0jgov/glibc-2.17/build/elf/ld.so			\
    -Wl,-z,combreloc -Wl,-z,relro -Wl,--hash-style=both -Wl,-z,defs 	\
    /tmp/glibcA2.17-20241116-69269-z0jgov/glibc-2.17/build/elf/librtld.os -Wl,--version-script=/tmp/glibcA2.17-20241116-69269-z0jgov/glibc-2.17/build/ld.map		\
    -Wl,-soname=ld-linux-aarch64.so.1			\
    -Wl,-defsym=_begin=0
/usr/bin/ld: /tmp/glibcA2.17-20241116-69269-z0jgov/glibc-2.17/build/elf/librtld.os: relocation R_AARCH64_ABS32 against `a local symbol' can not be used when making a shared object
/usr/bin/ld: BFD (GNU Binutils for Ubuntu) 2.38 assertion fail elfnn-aarch64.c:4852
/usr/bin/ld: BFD (GNU Binutils for Ubuntu) 2.38 assertion fail elfnn-aarch64.c:4852
/tmp/glibcA2.17-20241116-69269-z0jgov/glibc-2.17/build/elf/librtld.os: in function `do_lookup_x':
dl-lookup.c:(.text+0x7ff0): relocation truncated to fit: R_AARCH64_LD64_GOT_LO12_NC against symbol `free' defined in .text section in /tmp/glibcA2.17-20241116-69269-z0jgov/glibc-2.17/build/elf/librtld.os
/usr/bin/ld: BFD (GNU Binutils for Ubuntu) 2.38 assertion fail elfnn-aarch64.c:4852
/usr/bin/ld: BFD (GNU Binutils for Ubuntu) 2.38 assertion fail elfnn-aarch64.c:4852
dl-lookup.c:(.text+0x8188): relocation truncated to fit: R_AARCH64_LD64_GOT_LO12_NC against symbol `free' defined in .text section in /tmp/glibcA2.17-20241116-69269-z0jgov/glibc-2.17/build/elf/librtld.os
/usr/bin/ld: BFD (GNU Binutils for Ubuntu) 2.38 assertion fail elfnn-aarch64.c:4852
/usr/bin/ld: BFD (GNU Binutils for Ubuntu) 2.38 assertion fail elfnn-aarch64.c:4852
/tmp/glibcA2.17-20241116-69269-z0jgov/glibc-2.17/build/elf/librtld.os: in function `_dl_relocate_object':
(.text+0x9a90): relocation truncated to fit: R_AARCH64_LD64_GOT_LO12_NC against symbol `_dl_runtime_profile' defined in .text section in /tmp/glibcA2.17-20241116-69269-z0jgov/glibc-2.17/build/elf/librtld.os
/usr/bin/ld: BFD (GNU Binutils for Ubuntu) 2.38 assertion fail elfnn-aarch64.c:4852
/usr/bin/ld: BFD (GNU Binutils for Ubuntu) 2.38 assertion fail elfnn-aarch64.c:4852
(.text+0xa0e8): relocation truncated to fit: R_AARCH64_LD64_GOT_LO12_NC against symbol `_dl_runtime_resolve' defined in .text section in /tmp/glibcA2.17-20241116-69269-z0jgov/glibc-2.17/build/elf/librtld.os
/usr/bin/ld: BFD (GNU Binutils for Ubuntu) 2.38 assertion fail elfnn-aarch64.c:4852
/usr/bin/ld: BFD (GNU Binutils for Ubuntu) 2.38 assertion fail elfnn-aarch64.c:4852
/tmp/glibcA2.17-20241116-69269-z0jgov/glibc-2.17/build/elf/librtld.os: in function `_dl_debug_initialize':
(.text+0xd550): relocation truncated to fit: R_AARCH64_LD64_GOT_LO12_NC against symbol `_r_debug' defined in .bss section in /tmp/glibcA2.17-20241116-69269-z0jgov/glibc-2.17/build/elf/librtld.os
/usr/bin/ld: BFD (GNU Binutils for Ubuntu) 2.38 assertion fail elfnn-aarch64.c:4852
/usr/bin/ld: BFD (GNU Binutils for Ubuntu) 2.38 assertion fail elfnn-aarch64.c:4852
(.text+0xd56c): relocation truncated to fit: R_AARCH64_LD64_GOT_LO12_NC against symbol `_r_debug' defined in .bss section in /tmp/glibcA2.17-20241116-69269-z0jgov/glibc-2.17/build/elf/librtld.os
/usr/bin/ld: BFD (GNU Binutils for Ubuntu) 2.38 assertion fail elfnn-aarch64.c:4852
/usr/bin/ld: BFD (GNU Binutils for Ubuntu) 2.38 assertion fail elfnn-aarch64.c:4852
/tmp/glibcA2.17-20241116-69269-z0jgov/glibc-2.17/build/elf/librtld.os: in function `_dl_make_tlsdesc_dynamic':
(.text+0x14718): relocation truncated to fit: R_AARCH64_LD64_GOT_LO12_NC against symbol `free' defined in .text section in /tmp/glibcA2.17-20241116-69269-z0jgov/glibc-2.17/build/elf/librtld.os
/usr/bin/ld: BFD (GNU Binutils for Ubuntu) 2.38 assertion fail elfnn-aarch64.c:4852
/usr/bin/ld: BFD (GNU Binutils for Ubuntu) 2.38 assertion fail elfnn-aarch64.c:4852
(.text+0x14754): relocation truncated to fit: R_AARCH64_LD64_GOT_LO12_NC against symbol `free' defined in .text section in /tmp/glibcA2.17-20241116-69269-z0jgov/glibc-2.17/build/elf/librtld.os
/tmp/glibcA2.17-20241116-69269-z0jgov/glibc-2.17/build/elf/librtld.os:(.data.rel.ro+0x170): dangerous relocation: unsupported relocation
/tmp/glibcA2.17-20241116-69269-z0jgov/glibc-2.17/build/elf/librtld.os:(.data.rel.ro+0x178): dangerous relocation: unsupported relocation
/tmp/glibcA2.17-20241116-69269-z0jgov/glibc-2.17/build/elf/librtld.os:(.data.rel.ro+0x180): dangerous relocation: unsupported relocation
/tmp/glibcA2.17-20241116-69269-z0jgov/glibc-2.17/build/elf/librtld.os:(.data.rel.ro+0x188): dangerous relocation: unsupported relocation
/tmp/glibcA2.17-20241116-69269-z0jgov/glibc-2.17/build/elf/librtld.os:(.data.rel.ro+0x190): dangerous relocation: unsupported relocation
/tmp/glibcA2.17-20241116-69269-z0jgov/glibc-2.17/build/elf/librtld.os:(.data.rel.ro+0x198): dangerous relocation: unsupported relocation
/tmp/glibcA2.17-20241116-69269-z0jgov/glibc-2.17/build/elf/librtld.os:(.data.rel.ro+0x1a0): dangerous relocation: unsupported relocation
/tmp/glibcA2.17-20241116-69269-z0jgov/glibc-2.17/build/elf/librtld.os:(.data.rel.ro+0x1a8): dangerous relocation: unsupported relocation
/tmp/glibcA2.17-20241116-69269-z0jgov/glibc-2.17/build/elf/librtld.os:(.data.rel.ro+0x1b0): dangerous relocation: unsupported relocation
/tmp/glibcA2.17-20241116-69269-z0jgov/glibc-2.17/build/elf/librtld.os:(.data.rel.ro+0x1b8): dangerous relocation: unsupported relocation
collect2: error: ld returned 1 exit status
make[2]: *** [Makefile:334: /tmp/glibcA2.17-20241116-69269-z0jgov/glibc-2.17/build/elf/ld.so] Error 1
make[2]: Leaving directory '/tmp/glibcA2.17-20241116-69269-z0jgov/glibc-2.17/elf'
make[1]: *** [Makefile:233: elf/subdir_lib] Error 2
make[1]: Leaving directory '/tmp/glibcA2.17-20241116-69269-z0jgov/glibc-2.17'
make: *** [Makefile:9: all] Error 2
```
</details>

Needed for https://github.com/Homebrew/homebrew-core/pull/197951.

[^1]: https://sourceware.org/git/?p=glibc.git;a=commit;h=43d06ed218fc8be58987bdfd00e21e5720f0b862
[^2]: https://git.centos.org/rpms/glibc/raw/ca483cc5b0e3e6a595a2c103755dee4d72f14f25/f/SOURCES/glibc-rh1500908.patch
[^3]: https://sourceware.org/git/?p=glibc.git;a=commit;h=e9177fba13549a8e2a6232f46080e5c6d3e467b1
