### PR TITLE
sqlite: add macos linker patch for 3.49.0 release

### DIFF
--- a/sqlite/3.49.0-macos-linker.patch
+++ b/sqlite/3.49.0-macos-linker.patch
@@ -1,0 +1,226 @@
+From 58ef3022afe3e67eac22f65f14fb5fe7a02fa2f7 Mon Sep 17 00:00:00 2001
+From: Rui Chen <rui@chenrui.dev>
+Date: Fri, 7 Feb 2025 12:18:33 -0500
+Subject: [PATCH] chore: patch
+
+Signed-off-by: Rui Chen <rui@chenrui.dev>
+---
+ Makefile.in                 | 55 ++++++++++++++++++++++++++-----------
+ auto.def                    |  3 +-
+ autosetup/sqlite-config.tcl | 46 ++++++++++++++++++++++++++++++-
+ 3 files changed, 85 insertions(+), 19 deletions(-)
+
+diff --git a/Makefile.in b/Makefile.in
+index 0c97f16..2f6d15e 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -1,8 +1,17 @@
+ ########################################################################
+ # This is a main makefile for the "autoconf" bundle of SQLite. This is
+ # a trimmed-down version of the canonical makefile, devoid of most
+-# documentation. For the full docs, see 'main.mk' in the canonical
++# documentation. For the full docs, see /main.mk in the canonical
+ # source tree.
++#
++# Maintenance reminders:
++#
++# - To keep this working with an out-of-tree build, be sure to prefix
++#   input file names with $(TOP)/ where appropriate (which is most
++#   places).
++#
++# - The original/canonical recipes can be found in /main.mk in the
++#   canonical source tree.
+ all:
+ 
+ TOP = @abs_top_srcdir@
+@@ -60,7 +69,6 @@ LDFLAGS.readline = @LDFLAGS_READLINE@
+ CFLAGS.readline = @CFLAGS_READLINE@
+ LDFLAGS.icu = @LDFLAGS_ICU@
+ CFLAGS.icu = @CFLAGS_ICU@
+-LDFLAGS.libsqlite3.soname = @LDFLAGS_LIBSQLITE3_SONAME@
+ 
+ # When cross-compiling, we need to avoid the -s flag because it only
+ # works on the build host's platform.
+@@ -78,7 +86,7 @@ install-dir.all = $(install-dir.bin) $(install-dir.include) \
+   $(install-dir.lib) $(install-dir.man1) \
+   $(install-dir.pkgconfig)
+ $(install-dir.all):
+-	$(INSTALL) -d "$@"
++	@if [ ! -d "$@" ]; then $(INSTALL) -d "$@"; fi
+ 
+ 
+ #
+@@ -115,23 +123,28 @@ SHELL_OPT ?= @OPT_SHELL@
+ #
+ OPT_FEATURE_FLAGS = @OPT_FEATURE_FLAGS@
+ 
++LDFLAGS.libsqlite3.soname = @LDFLAGS_LIBSQLITE3_SONAME@
++# soname: see https://sqlite.org/src/forumpost/5a3b44f510df8ded
++LDFLAGS.libsqlite3.os-specific = @LDFLAGS_MAC_CVERSION@
++# os-specific: see https://sqlite.org/forum/forumpost/9dfd5b8fd525a5d7
++
+ LDFLAGS.libsqlite3 = \
+   $(LDFLAGS.rpath) $(LDFLAGS.pthread) \
+   $(LDFLAGS.math) $(LDFLAGS.dlopen) \
+   $(LDFLAGS.zlib) $(LDFLAGS.icu) \
+   $(LDFLAGS.configure)
+-LDFLAGS.libsqlite3.soname = @LDFLAGS_LIBSQLITE3_SONAME@
+ CFLAGS.libsqlite3 = -I. $(CFLAGS.core) $(CFLAGS.icu) $(OPT_FEATURE_FLAGS)
+ 
+-sqlite3.o:	sqlite3.h sqlite3.c
+-	$(CC) -c sqlite3.c -o $@ $(CFLAGS) $(CFLAGS.libsqlite3)
++sqlite3.o: $(TOP)/sqlite3.h $(TOP)/sqlite3.c
++	$(CC) -c $(TOP)/sqlite3.c -o $@ $(CFLAGS) $(CFLAGS.libsqlite3)
+ 
+ libsqlite3.LIB = libsqlite3$(T.lib)
+ libsqlite3.SO = libsqlite3$(T.dll)
+ 
+ $(libsqlite3.SO): sqlite3.o
+ 	$(CC) -o $@  sqlite3.o $(LDFLAGS.shlib) \
+-		$(LDFLAGS) $(LDFLAGS.libsqlite3) $(LDFLAGS.libsqlite3.soname)
++		$(LDFLAGS) $(LDFLAGS.libsqlite3) \
++		$(LDFLAGS.libsqlite3.os-specific) $(LDFLAGS.libsqlite3.soname)
+ all: $(libsqlite3.SO)
+ 
+ $(libsqlite3.LIB): sqlite3.o
+@@ -140,8 +153,16 @@ all: $(libsqlite3.LIB)
+ 
+ install-so-1: $(install-dir.lib) $(libsqlite3.SO)
+ 	$(INSTALL) $(libsqlite3.SO) "$(install-dir.lib)"
+-	@echo "Setting up $(libsqlite3.SO) symlinks..."; \
+-		cd "$(install-dir.lib)" || exit $$?; \
++	@echo "Setting up $(libsqlite3.SO) version symlinks..."; \
++	cd "$(install-dir.lib)" || exit $$?; \
++	if [ x.dylib = x$(T.dll) ]; then \
++		rm -f libsqlite3.0$(T.dll) libsqlite3.$(PACKAGE_VERSION)$(T.dll) || exit $$?; \
++		dllname=libsqlite3.$(PACKAGE_VERSION)$(T.dll); \
++		mv $(libsqlite3.SO) $$dllname || exit $$?; \
++		ln -s $$dllname $(libsqlite3.SO) || exit $$?; \
++		ln -s $$dllname libsqlite3.0$(T.dll) || exit $$?; \
++		ls -la $$dllname $(libsqlite3.SO) libsqlite3.0$(T.dll); \
++	else \
+ 		rm -f $(libsqlite3.SO).0 $(libsqlite3.SO).$(PACKAGE_VERSION) || exit $$?; \
+ 		mv $(libsqlite3.SO) $(libsqlite3.SO).$(PACKAGE_VERSION) || exit $$?; \
+ 		ln -s $(libsqlite3.SO).$(PACKAGE_VERSION) $(libsqlite3.SO) || exit $$?; \
+@@ -157,7 +178,9 @@ install-so-1: $(install-dir.lib) $(libsqlite3.SO)
+ 			rm -f libsqlite3.la $(libsqlite3.SO).0.8.6 || exit $$?; \
+ 			ln -s $(libsqlite3.SO).$(PACKAGE_VERSION) $(libsqlite3.SO).0.8.6 || exit $$?; \
+ 			ls -la $(libsqlite3.SO).0.8.6; \
+-		fi
++		fi; \
++	fi
++
+ install-so-0 install-so-:
+ install-so: install-so-$(ENABLE_LIB_SHARED)
+ install: install-so
+@@ -169,9 +192,9 @@ install-lib: install-lib-$(ENABLE_LIB_STATIC)
+ install: install-lib
+ 
+ 
+-sqlite3$(T.exe):	shell.c sqlite3.c
++sqlite3$(T.exe): $(TOP)/shell.c $(TOP)/sqlite3.c
+ 	$(CC) -o $@ \
+-		shell.c sqlite3.c \
++		$(TOP)/shell.c $(TOP)/sqlite3.c \
+ 		-I. $(OPT_FEATURE_FLAGS) $(SHELL_OPT) \
+ 		$(CFLAGS) $(CFLAGS.readline) $(CFLAGS.icu) \
+ 		$(LDFLAGS) $(LDFLAGS.libsqlite3) $(LDFLAGS.readline)
+@@ -181,16 +204,16 @@ install-shell: sqlite3$(T.exe) $(install-dir.bin)
+ 	$(INSTALL.strip) sqlite3$(T.exe) "$(install-dir.bin)"
+ install: install-shell
+ 
+-install-headers: sqlite3.h $(install-dir.include)
+-	$(INSTALL.noexec) sqlite3.h sqlite3ext.h "$(install-dir.include)"
++install-headers: $(TOP)/sqlite3.h $(install-dir.include)
++	$(INSTALL.noexec) $(TOP)/sqlite3.h $(TOP)/sqlite3ext.h "$(install-dir.include)"
+ install: install-headers
+ 
+ install-pc: sqlite3.pc $(install-dir.pkgconfig)
+ 	$(INSTALL.noexec) sqlite3.pc "$(install-dir.pkgconfig)"
+ install: install-pc
+ 
+-install-man1: sqlite3.1 $(install-dir.man1)
+-	$(INSTALL.noexec) sqlite3.1 "$(install-dir.man1)"
++install-man1: $(TOP)/sqlite3.1 $(install-dir.man1)
++	$(INSTALL.noexec) $(TOP)/sqlite3.1 "$(install-dir.man1)"
+ install: install-man1
+ 
+ clean:
+diff --git a/auto.def b/auto.def
+index 12eb3d7..72f5009 100644
+--- a/auto.def
++++ b/auto.def
+@@ -94,5 +94,4 @@ sqlite-handle-icu
+ define ENABLE_LIB_SHARED [opt-bool shared]
+ define ENABLE_LIB_STATIC [opt-bool static]
+ 
+-sqlite-process-dot-in-files
+-sqlite-post-config-validation
++sqlite-common-late-stage-config
+diff --git a/autosetup/sqlite-config.tcl b/autosetup/sqlite-config.tcl
+index 9f300e3..cabb32a 100644
+--- a/autosetup/sqlite-config.tcl
++++ b/autosetup/sqlite-config.tcl
+@@ -43,7 +43,10 @@ set sqliteConfig(is-cross-compiling) [proj-is-cross-compiling]
+ 
+ ########################################################################
+ # Runs some common initialization which must happen immediately after
+-# autosetup's [options] function is called.
++# autosetup's [options] function is called. This is also a convenient
++# place to put some generic pieces common to both the canonical
++# top-level build and the "autoconf" build, but it's not intended to
++# be a catch-all dumping ground for such.
+ proc sqlite-post-options-init {} {
+   #
+   # Carry values from hidden --flag aliases over to their canonical
+@@ -861,6 +864,47 @@ proc sqlite-handle-math {} {
+   }
+ }
+ 
++########################################################################
++# If this OS looks like a Mac, checks for the Mac-specific
++# -current_version and -compatibility_version linker flags. Defines
++# LDFLAGS_MAC_CVERSION to an empty string and returns 0 if they're not
++# supported, else defines that to the linker flags and returns 1.
++#
++# We don't check this on non-Macs because this whole thing is a
++# libtool compatibility kludge to account for a version stamp which
++# libtool applied only on Mac platforms.
++#
++# Based on https://sqlite.org/forum/forumpost/9dfd5b8fd525a5d7.
++proc sqlite-check-mac-cversion {} {
++  define LDFLAGS_MAC_CVERSION ""
++  set rc 0
++  if {[proj-looks-like-mac]} {
++    cc-with {} {
++      # These version numbers are historical libtool-defined values, not
++      # library-defined ones
++      if {[cc-check-flags "-Wl,-current_version,9.6.0"]
++          && [cc-check-flags "-Wl,-compatibility_version,9.0.0"]} {
++        define LDFLAGS_MAC_CVERSION "-Wl,-compatibility_version,9.0.0 -Wl,-current_version,9.6.0"
++        set rc 1
++      } elseif {[cc-check-flags "-compatibility_version 9.0.0"]
++                && [cc-check-flags "-current_version 9.6.0"]} {
++        define LDFLAGS_MAC_CVERSION "-compatibility_version 9.0.0 -current_version 9.6.0"
++        set rc 1
++      }
++    }
++  }
++  return $rc
++}
++
++########################################################################
++# Performs late-stage config steps common to both the canonical and
++# autoconf bundle builds.
++proc sqlite-common-late-stage-config {} {
++  sqlite-check-mac-cversion
++  sqlite-process-dot-in-files
++  sqlite-post-config-validation
++}
++
+ ########################################################################
+ # Perform some late-stage work and generate the configure-process
+ # output file(s).
+-- 
+2.48.1
+


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-core/pull/206808
upstream discussion, https://sqlite.org/forum/forumpost/a179331cbb

## before patch

```
    ├── lib
    │   ├── libsqlite3.a
    │   ├── libsqlite3.dylib -> libsqlite3.dylib.3.49.0
    │   ├── libsqlite3.dylib.0 -> libsqlite3.dylib.3.49.0
    │   ├── libsqlite3.dylib.3.49.0
    │   └── pkgconfig
    │       └── sqlite3.pc
```

## after patch

```
    ├── lib
    │   ├── libsqlite3.0.dylib -> libsqlite3.3.49.1.dylib
    │   ├── libsqlite3.3.49.1.dylib
    │   ├── libsqlite3.a
    │   ├── libsqlite3.dylib -> libsqlite3.3.49.1.dylib
    │   └── pkgconfig
    │       └── sqlite3.pc
```
