### PR TITLE
musepack: upstream patches

### DIFF
--- a/musepack/r479.patch
+++ b/musepack/r479.patch
@@ -1,0 +1,17 @@
+Index: libmpcdec/requant.h
+===================================================================
+--- libmpcdec/requant.h	(revision 478)
++++ libmpcdec/requant.h	(revision 479)
+@@ -47,9 +47,9 @@
+ 
+ 
+ /* C O N S T A N T S */
+-const mpc_uint8_t      Res_bit [18];     ///< Bits per sample for chosen quantizer
+-const MPC_SAMPLE_FORMAT __Cc    [1 + 18]; ///< Requantization coefficients
+-const mpc_int16_t       __Dc    [1 + 18]; ///< Requantization offset
++extern const mpc_uint8_t      Res_bit [18];     ///< Bits per sample for chosen quantizer
++extern const MPC_SAMPLE_FORMAT __Cc    [1 + 18]; ///< Requantization coefficients
++extern const mpc_int16_t       __Dc    [1 + 18]; ///< Requantization offset
+ 
+ #define Cc (__Cc + 1)
+ #define Dc (__Dc + 1)

--- a/musepack/r482.patch
+++ b/musepack/r482.patch
@@ -1,0 +1,53 @@
+Index: include/CMakeLists.txt
+===================================================================
+--- include/CMakeLists.txt	(revision 481)
++++ include/CMakeLists.txt	(nonexistent)
+@@ -1 +0,0 @@
+-INSTALL(DIRECTORY mpc DESTINATION include)
+Index: libmpcdec/Makefile.am
+===================================================================
+--- libmpcdec/Makefile.am	(revision 481)
++++ libmpcdec/Makefile.am	(revision 482)
+@@ -16,4 +16,5 @@
+ 	mpc_bits_reader.h huffman.h decoder.h internal.h requant.h mpcdec_math.h \
+ 	$(common_sources)
+ 
++# version info shoud match the one in CMakeLists.txt
+ libmpcdec_la_LDFLAGS = -no-undefined -version-info 7:0:1
+Index: libmpcdec/CMakeLists.txt
+===================================================================
+--- libmpcdec/CMakeLists.txt	(revision 481)
++++ libmpcdec/CMakeLists.txt	(revision 482)
+@@ -1,7 +1,23 @@
++SET(mpcdec_VERSION_MAJOR 7)
++SET(mpcdec_VERSION_MINOR 0)
++SET(mpcdec_VERSION_PATCH 1)
++
++set(mpcdec_VERSION ${mpcdec_VERSION_MAJOR}.${mpcdec_VERSION_MINOR}.${mpcdec_VERSION_PATCH})
++
+ include_directories(${libmpc_SOURCE_DIR}/include)
++install(FILES
++	${libmpc_SOURCE_DIR}/include/mpc/mpcdec.h
++	${libmpc_SOURCE_DIR}/include/mpc/reader.h
++	${libmpc_SOURCE_DIR}/include/mpc/streaminfo.h
++	${libmpc_SOURCE_DIR}/include/mpc/mpc_types.h
++	DESTINATION include/mpc COMPONENT headers)
++
+ if(SHARED)
+   add_library(mpcdec SHARED huffman mpc_decoder mpc_reader streaminfo mpc_bits_reader mpc_demux requant synth_filter ${libmpc_SOURCE_DIR}/common/crc32)
++  set_target_properties(mpcdec PROPERTIES VERSION ${mpcdec_VERSION} SOVERSION ${mpcdec_VERSION_MAJOR})
++  install(TARGETS mpcdec LIBRARY DESTINATION "lib" COMPONENT libraries)
+ else(SHARED)
+   add_library(mpcdec_static STATIC huffman mpc_decoder mpc_reader streaminfo mpc_bits_reader mpc_demux requant synth_filter ${libmpc_SOURCE_DIR}/common/crc32)
++  install(TARGETS mpcdec_static ARCHIVE DESTINATION "lib/static" COMPONENT libraries)
+ endif(SHARED)
+ 
+Index: CMakeLists.txt
+===================================================================
+--- CMakeLists.txt	(revision 481)
++++ CMakeLists.txt	(revision 482)
+@@ -30,4 +30,3 @@
+ add_subdirectory(mpccut)
+ add_subdirectory(mpcchap)
+ add_subdirectory(wavcmp)
+-add_subdirectory(include)

--- a/musepack/r491.patch
+++ b/musepack/r491.patch
@@ -1,0 +1,33 @@
+Index: libmpcdec/CMakeLists.txt
+===================================================================
+--- libmpcdec/CMakeLists.txt	(revision 490)
++++ libmpcdec/CMakeLists.txt	(revision 491)
+@@ -4,7 +4,6 @@
+ 
+ set(mpcdec_VERSION ${mpcdec_VERSION_MAJOR}.${mpcdec_VERSION_MINOR}.${mpcdec_VERSION_PATCH})
+ 
+-include_directories(${libmpc_SOURCE_DIR}/include)
+ install(FILES
+ 	${libmpc_SOURCE_DIR}/include/mpc/mpcdec.h
+ 	${libmpc_SOURCE_DIR}/include/mpc/reader.h
+@@ -12,12 +11,16 @@
+ 	${libmpc_SOURCE_DIR}/include/mpc/mpc_types.h
+ 	DESTINATION include/mpc COMPONENT headers)
+ 
++include_directories(${libmpc_SOURCE_DIR}/include)
+ if(SHARED)
+-  add_library(mpcdec SHARED huffman mpc_decoder mpc_reader streaminfo mpc_bits_reader mpc_demux requant synth_filter ${libmpc_SOURCE_DIR}/common/crc32)
+-  set_target_properties(mpcdec PROPERTIES VERSION ${mpcdec_VERSION} SOVERSION ${mpcdec_VERSION_MAJOR})
+-  install(TARGETS mpcdec LIBRARY DESTINATION "lib" COMPONENT libraries)
++  add_library(mpcdec_shared SHARED huffman mpc_decoder mpc_reader streaminfo mpc_bits_reader mpc_demux requant synth_filter ${libmpc_SOURCE_DIR}/common/crc32)
++  set_target_properties(mpcdec_shared PROPERTIES OUTPUT_NAME mpcdec CLEAN_DIRECT_OUTPUT 1 VERSION ${mpcdec_VERSION} SOVERSION ${mpcdec_VERSION_MAJOR})
++  install(TARGETS mpcdec_shared LIBRARY DESTINATION "lib${LIB_SUFFIX}" ARCHIVE DESTINATION "lib${LIB_SUFFIX}" COMPONENT libraries)
++  target_link_libraries(mpcdec_shared m)
+ else(SHARED)
+   add_library(mpcdec_static STATIC huffman mpc_decoder mpc_reader streaminfo mpc_bits_reader mpc_demux requant synth_filter ${libmpc_SOURCE_DIR}/common/crc32)
+-  install(TARGETS mpcdec_static ARCHIVE DESTINATION "lib/static" COMPONENT libraries)
++  set_target_properties(mpcdec_static PROPERTIES OUTPUT_NAME mpcdec CLEAN_DIRECT_OUTPUT 1)
++  install(TARGETS mpcdec_static LIBRARY DESTINATION "lib${LIB_SUFFIX}" ARCHIVE DESTINATION "lib${LIB_SUFFIX}" COMPONENT libraries)
++  target_link_libraries(mpcdec_static m)
+ endif(SHARED)
+ 


### PR DESCRIPTION
Work in progress. Trying to find which patches are needed to build among the upstream SVN revisions that haven't been released and some patches other distros are carrying.

482 and 491 allow installing shared library
```
r482 | r2d | 2013-10-21 16:34:18 -0400 (Mon, 21 Oct 2013) | 1 line

libmpcdec : added install and soversion
```
```
r491 | r2d | 2016-02-14 17:07:10 -0500 (Sun, 14 Feb 2016) | 9 lines

adapted patch 0001-shared.patch from buildroot:
https://git.busybox.net/buildroot/tree/package/musepack/0001-shared.patch
original changelog :

Fixup installation of shared mpcdec library.
Based on gentoo patch.
```

---

479 is part of `-fno-common` fixes
```
r479 | r2d | 2012-03-30 16:03:53 -0400 (Fri, 30 Mar 2012) | 1 line

add extern keyword to global variable declaration (don't know it worked without ... thanks Dmitry)
```

---

Will apply 2 more patches from Gentoo separately
* https://gitweb.gentoo.org/repo/gentoo.git/tree/media-sound/musepack-tools/files/musepack-tools-495-incompatible-pointers.patch
* https://gitweb.gentoo.org/repo/gentoo.git/tree/media-sound/musepack-tools/files/musepack-tools-495-fixup-link-depends.patch