### PR TITLE
pypy: add patch for brew `tcl-tk` on Linux

### DIFF
--- a/pypy/tcl-tk.diff
+++ b/pypy/tcl-tk.diff
@@ -1,0 +1,20 @@
+--- a/lib_pypy/_tkinter/tklib_build.py
++++ b/lib_pypy/_tkinter/tklib_build.py
+@@ -17,7 +17,7 @@ elif sys.platform == 'win32':
+     incdirs = []
+     linklibs = ['tcl86t', 'tk86t']
+     libdirs = []
+-elif sys.platform == 'darwin':
++else:
+     # homebrew
+     homebrew = os.environ.get('HOMEBREW_PREFIX', '')
+     incdirs = ['/usr/local/opt/tcl-tk/include']
+@@ -26,7 +26,7 @@ elif sys.platform == 'darwin':
+     if homebrew:
+         incdirs.append(homebrew + '/include')
+         libdirs.append(homebrew + '/opt/tcl-tk/lib')
+-else:
++if False: # disable Linux system tcl-tk detection
+     # On some Linux distributions, the tcl and tk libraries are
+     # stored in /usr/include, so we must check this case also
+     libdirs = []


### PR DESCRIPTION
Moving embedded patch from pypy formulae to here to avoid `HOMEBREW_PREFIX` inreplace.

* https://github.com/Homebrew/homebrew-core/blob/main/Formula/p/pypy.rb#L220-L239
* https://github.com/Homebrew/homebrew-core/blob/main/Formula/p/pypy3.10.rb#L231-L250