### PR TITLE
glibc: add CVE rollup patch

### DIFF
--- a/glibc/2.35-cve-rollup-sep2025.patch
+++ b/glibc/2.35-cve-rollup-sep2025.patch
@@ -1,0 +1,7763 @@
+From 6e867146ee01de3ed1e94e777372093812a578e9 Mon Sep 17 00:00:00 2001
+From: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Date: Thu, 17 Mar 2022 11:44:34 +0530
+Subject: [PATCH] Simplify allocations and fix merge and continue actions [BZ
+ #28931]
+
+Allocations for address tuples is currently a bit confusing because of
+the pointer chasing through PAT, making it hard to observe the sequence
+in which allocations have been made.  Narrow scope of the pointer
+chasing through PAT so that it is only used where necessary.
+
+This also tightens actions behaviour with the hosts database in
+getaddrinfo to comply with the manual text.  The "continue" action
+discards previous results and the "merge" action results in an immedate
+lookup failure.  Consequently, chaining of allocations across modules is
+no longer necessary, thus opening up cleanup opportunities.
+
+A test has been added that checks some combinations to ensure that they
+work correctly.
+
+Resolves: BZ #28931
+
+Signed-off-by: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Reviewed-by: DJ Delorie <dj@redhat.com>
+(cherry picked from commit 1c37b8022e8763fedbb3f79c02e05c6acfe5a215)
+---
+ nss/Makefile                               |   3 +-
+ nss/tst-nss-gai-actions.c                  | 149 ++++++
+ nss/tst-nss-gai-actions.root/etc/host.conf |   1 +
+ nss/tst-nss-gai-actions.root/etc/hosts     | 508 +++++++++++++++++++++
+ sysdeps/posix/getaddrinfo.c                | 143 +++---
+ 5 files changed, 751 insertions(+), 53 deletions(-)
+ create mode 100644 nss/tst-nss-gai-actions.c
+ create mode 100644 nss/tst-nss-gai-actions.root/etc/host.conf
+ create mode 100644 nss/tst-nss-gai-actions.root/etc/hosts
+
+diff --git a/nss/Makefile b/nss/Makefile
+index de439d4911..b2301c4cd7 100644
+--- a/nss/Makefile
++++ b/nss/Makefile
+@@ -70,7 +70,8 @@ tests-container = \
+ 			  tst-nss-files-hosts-long \
+ 			  tst-nss-db-endpwent \
+ 			  tst-nss-db-endgrent \
+-			  tst-reload1 tst-reload2
++			  tst-reload1 tst-reload2 \
++			  tst-nss-gai-actions
+
+ # Tests which need libdl
+ ifeq (yes,$(build-shared))
+diff --git a/nss/tst-nss-gai-actions.c b/nss/tst-nss-gai-actions.c
+new file mode 100644
+index 0000000000..efca6cd183
+--- /dev/null
++++ b/nss/tst-nss-gai-actions.c
+@@ -0,0 +1,149 @@
++/* Test continue and merge NSS actions for getaddrinfo.
++   Copyright The GNU Toolchain Authors.
++   This file is part of the GNU C Library.
++
++   The GNU C Library is free software; you can redistribute it and/or
++   modify it under the terms of the GNU Lesser General Public
++   License as published by the Free Software Foundation; either
++   version 2.1 of the License, or (at your option) any later version.
++
++   The GNU C Library is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   Lesser General Public License for more details.
++
++   You should have received a copy of the GNU Lesser General Public
++   License along with the GNU C Library; if not, see
++   <https://www.gnu.org/licenses/>.  */
++
++#include <dlfcn.h>
++#include <gnu/lib-names.h>
++#include <nss.h>
++#include <stdio.h>
++#include <stdlib.h>
++#include <string.h>
++
++#include <support/check.h>
++#include <support/format_nss.h>
++#include <support/support.h>
++#include <support/xstdio.h>
++#include <support/xunistd.h>
++
++enum
++{
++  ACTION_MERGE = 0,
++  ACTION_CONTINUE,
++};
++
++static const char *
++family_str (int family)
++{
++  switch (family)
++    {
++    case AF_UNSPEC:
++      return "AF_UNSPEC";
++    case AF_INET:
++      return "AF_INET";
++    default:
++      __builtin_unreachable ();
++    }
++}
++
++static const char *
++action_str (int action)
++{
++  switch (action)
++    {
++    case ACTION_MERGE:
++      return "merge";
++    case ACTION_CONTINUE:
++      return "continue";
++    default:
++      __builtin_unreachable ();
++    }
++}
++
++static void
++do_one_test (int action, int family, bool canon)
++{
++  struct addrinfo hints =
++    {
++      .ai_family = family,
++    };
++
++  struct addrinfo *ai;
++
++  if (canon)
++    hints.ai_flags = AI_CANONNAME;
++
++  printf ("***** Testing \"files [SUCCESS=%s] files\" for family %s, %s\n",
++	  action_str (action), family_str (family),
++	  canon ? "AI_CANONNAME" : "");
++
++  int ret = getaddrinfo ("example.org", "80", &hints, &ai);
++
++  switch (action)
++    {
++    case ACTION_MERGE:
++      if (ret == 0)
++	{
++	  char *formatted = support_format_addrinfo (ai, ret);
++
++	  printf ("merge unexpectedly succeeded:\n %s\n", formatted);
++	  support_record_failure ();
++	  free (formatted);
++	}
++      else
++	return;
++    case ACTION_CONTINUE:
++	{
++	  char *formatted = support_format_addrinfo (ai, ret);
++
++	  /* Verify that the result appears exactly once.  */
++	  const char *expected = "address: STREAM/TCP 192.0.0.1 80\n"
++	    "address: DGRAM/UDP 192.0.0.1 80\n"
++	    "address: RAW/IP 192.0.0.1 80\n";
++
++	  const char *contains = strstr (formatted, expected);
++	  const char *contains2 = NULL;
++
++	  if (contains != NULL)
++	    contains2 = strstr (contains + strlen (expected), expected);
++
++	  if (contains == NULL || contains2 != NULL)
++	    {
++	      printf ("continue failed:\n%s\n", formatted);
++	      support_record_failure ();
++	    }
++
++	  free (formatted);
++	  break;
++	}
++    default:
++      __builtin_unreachable ();
++    }
++}
++
++static void
++do_one_test_set (int action)
++{
++  char buf[32];
++
++  snprintf (buf, sizeof (buf), "files [SUCCESS=%s] files",
++	    action_str (action));
++  __nss_configure_lookup ("hosts", buf);
++
++  do_one_test (action, AF_UNSPEC, false);
++  do_one_test (action, AF_INET, false);
++  do_one_test (action, AF_INET, true);
++}
++
++static int
++do_test (void)
++{
++  do_one_test_set (ACTION_CONTINUE);
++  do_one_test_set (ACTION_MERGE);
++  return 0;
++}
++
++#include <support/test-driver.c>
+diff --git a/nss/tst-nss-gai-actions.root/etc/host.conf b/nss/tst-nss-gai-actions.root/etc/host.conf
+new file mode 100644
+index 0000000000..d1a59f73a9
+--- /dev/null
++++ b/nss/tst-nss-gai-actions.root/etc/host.conf
+@@ -0,0 +1 @@
++multi on
+diff --git a/nss/tst-nss-gai-actions.root/etc/hosts b/nss/tst-nss-gai-actions.root/etc/hosts
+new file mode 100644
+index 0000000000..50ce9774dc
+--- /dev/null
++++ b/nss/tst-nss-gai-actions.root/etc/hosts
+@@ -0,0 +1,508 @@
++192.0.0.1	example.org
++192.0.0.2	example.org
++192.0.0.3	example.org
++192.0.0.4	example.org
++192.0.0.5	example.org
++192.0.0.6	example.org
++192.0.0.7	example.org
++192.0.0.8	example.org
++192.0.0.9	example.org
++192.0.0.10	example.org
++192.0.0.11	example.org
++192.0.0.12	example.org
++192.0.0.13	example.org
++192.0.0.14	example.org
++192.0.0.15	example.org
++192.0.0.16	example.org
++192.0.0.17	example.org
++192.0.0.18	example.org
++192.0.0.19	example.org
++192.0.0.20	example.org
++192.0.0.21	example.org
++192.0.0.22	example.org
++192.0.0.23	example.org
++192.0.0.24	example.org
++192.0.0.25	example.org
++192.0.0.26	example.org
++192.0.0.27	example.org
++192.0.0.28	example.org
++192.0.0.29	example.org
++192.0.0.30	example.org
++192.0.0.31	example.org
++192.0.0.32	example.org
++192.0.0.33	example.org
++192.0.0.34	example.org
++192.0.0.35	example.org
++192.0.0.36	example.org
++192.0.0.37	example.org
++192.0.0.38	example.org
++192.0.0.39	example.org
++192.0.0.40	example.org
++192.0.0.41	example.org
++192.0.0.42	example.org
++192.0.0.43	example.org
++192.0.0.44	example.org
++192.0.0.45	example.org
++192.0.0.46	example.org
++192.0.0.47	example.org
++192.0.0.48	example.org
++192.0.0.49	example.org
++192.0.0.50	example.org
++192.0.0.51	example.org
++192.0.0.52	example.org
++192.0.0.53	example.org
++192.0.0.54	example.org
++192.0.0.55	example.org
++192.0.0.56	example.org
++192.0.0.57	example.org
++192.0.0.58	example.org
++192.0.0.59	example.org
++192.0.0.60	example.org
++192.0.0.61	example.org
++192.0.0.62	example.org
++192.0.0.63	example.org
++192.0.0.64	example.org
++192.0.0.65	example.org
++192.0.0.66	example.org
++192.0.0.67	example.org
++192.0.0.68	example.org
++192.0.0.69	example.org
++192.0.0.70	example.org
++192.0.0.71	example.org
++192.0.0.72	example.org
++192.0.0.73	example.org
++192.0.0.74	example.org
++192.0.0.75	example.org
++192.0.0.76	example.org
++192.0.0.77	example.org
++192.0.0.78	example.org
++192.0.0.79	example.org
++192.0.0.80	example.org
++192.0.0.81	example.org
++192.0.0.82	example.org
++192.0.0.83	example.org
++192.0.0.84	example.org
++192.0.0.85	example.org
++192.0.0.86	example.org
++192.0.0.87	example.org
++192.0.0.88	example.org
++192.0.0.89	example.org
++192.0.0.90	example.org
++192.0.0.91	example.org
++192.0.0.92	example.org
++192.0.0.93	example.org
++192.0.0.94	example.org
++192.0.0.95	example.org
++192.0.0.96	example.org
++192.0.0.97	example.org
++192.0.0.98	example.org
++192.0.0.99	example.org
++192.0.0.100	example.org
++192.0.0.101	example.org
++192.0.0.102	example.org
++192.0.0.103	example.org
++192.0.0.104	example.org
++192.0.0.105	example.org
++192.0.0.106	example.org
++192.0.0.107	example.org
++192.0.0.108	example.org
++192.0.0.109	example.org
++192.0.0.110	example.org
++192.0.0.111	example.org
++192.0.0.112	example.org
++192.0.0.113	example.org
++192.0.0.114	example.org
++192.0.0.115	example.org
++192.0.0.116	example.org
++192.0.0.117	example.org
++192.0.0.118	example.org
++192.0.0.119	example.org
++192.0.0.120	example.org
++192.0.0.121	example.org
++192.0.0.122	example.org
++192.0.0.123	example.org
++192.0.0.124	example.org
++192.0.0.125	example.org
++192.0.0.126	example.org
++192.0.0.127	example.org
++192.0.0.128	example.org
++192.0.0.129	example.org
++192.0.0.130	example.org
++192.0.0.131	example.org
++192.0.0.132	example.org
++192.0.0.133	example.org
++192.0.0.134	example.org
++192.0.0.135	example.org
++192.0.0.136	example.org
++192.0.0.137	example.org
++192.0.0.138	example.org
++192.0.0.139	example.org
++192.0.0.140	example.org
++192.0.0.141	example.org
++192.0.0.142	example.org
++192.0.0.143	example.org
++192.0.0.144	example.org
++192.0.0.145	example.org
++192.0.0.146	example.org
++192.0.0.147	example.org
++192.0.0.148	example.org
++192.0.0.149	example.org
++192.0.0.150	example.org
++192.0.0.151	example.org
++192.0.0.152	example.org
++192.0.0.153	example.org
++192.0.0.154	example.org
++192.0.0.155	example.org
++192.0.0.156	example.org
++192.0.0.157	example.org
++192.0.0.158	example.org
++192.0.0.159	example.org
++192.0.0.160	example.org
++192.0.0.161	example.org
++192.0.0.162	example.org
++192.0.0.163	example.org
++192.0.0.164	example.org
++192.0.0.165	example.org
++192.0.0.166	example.org
++192.0.0.167	example.org
++192.0.0.168	example.org
++192.0.0.169	example.org
++192.0.0.170	example.org
++192.0.0.171	example.org
++192.0.0.172	example.org
++192.0.0.173	example.org
++192.0.0.174	example.org
++192.0.0.175	example.org
++192.0.0.176	example.org
++192.0.0.177	example.org
++192.0.0.178	example.org
++192.0.0.179	example.org
++192.0.0.180	example.org
++192.0.0.181	example.org
++192.0.0.182	example.org
++192.0.0.183	example.org
++192.0.0.184	example.org
++192.0.0.185	example.org
++192.0.0.186	example.org
++192.0.0.187	example.org
++192.0.0.188	example.org
++192.0.0.189	example.org
++192.0.0.190	example.org
++192.0.0.191	example.org
++192.0.0.192	example.org
++192.0.0.193	example.org
++192.0.0.194	example.org
++192.0.0.195	example.org
++192.0.0.196	example.org
++192.0.0.197	example.org
++192.0.0.198	example.org
++192.0.0.199	example.org
++192.0.0.200	example.org
++192.0.0.201	example.org
++192.0.0.202	example.org
++192.0.0.203	example.org
++192.0.0.204	example.org
++192.0.0.205	example.org
++192.0.0.206	example.org
++192.0.0.207	example.org
++192.0.0.208	example.org
++192.0.0.209	example.org
++192.0.0.210	example.org
++192.0.0.211	example.org
++192.0.0.212	example.org
++192.0.0.213	example.org
++192.0.0.214	example.org
++192.0.0.215	example.org
++192.0.0.216	example.org
++192.0.0.217	example.org
++192.0.0.218	example.org
++192.0.0.219	example.org
++192.0.0.220	example.org
++192.0.0.221	example.org
++192.0.0.222	example.org
++192.0.0.223	example.org
++192.0.0.224	example.org
++192.0.0.225	example.org
++192.0.0.226	example.org
++192.0.0.227	example.org
++192.0.0.228	example.org
++192.0.0.229	example.org
++192.0.0.230	example.org
++192.0.0.231	example.org
++192.0.0.232	example.org
++192.0.0.233	example.org
++192.0.0.234	example.org
++192.0.0.235	example.org
++192.0.0.236	example.org
++192.0.0.237	example.org
++192.0.0.238	example.org
++192.0.0.239	example.org
++192.0.0.240	example.org
++192.0.0.241	example.org
++192.0.0.242	example.org
++192.0.0.243	example.org
++192.0.0.244	example.org
++192.0.0.245	example.org
++192.0.0.246	example.org
++192.0.0.247	example.org
++192.0.0.248	example.org
++192.0.0.249	example.org
++192.0.0.250	example.org
++192.0.0.251	example.org
++192.0.0.252	example.org
++192.0.0.253	example.org
++192.0.0.254	example.org
++192.0.1.1	example.org
++192.0.1.2	example.org
++192.0.1.3	example.org
++192.0.1.4	example.org
++192.0.1.5	example.org
++192.0.1.6	example.org
++192.0.1.7	example.org
++192.0.1.8	example.org
++192.0.1.9	example.org
++192.0.1.10	example.org
++192.0.1.11	example.org
++192.0.1.12	example.org
++192.0.1.13	example.org
++192.0.1.14	example.org
++192.0.1.15	example.org
++192.0.1.16	example.org
++192.0.1.17	example.org
++192.0.1.18	example.org
++192.0.1.19	example.org
++192.0.1.20	example.org
++192.0.1.21	example.org
++192.0.1.22	example.org
++192.0.1.23	example.org
++192.0.1.24	example.org
++192.0.1.25	example.org
++192.0.1.26	example.org
++192.0.1.27	example.org
++192.0.1.28	example.org
++192.0.1.29	example.org
++192.0.1.30	example.org
++192.0.1.31	example.org
++192.0.1.32	example.org
++192.0.1.33	example.org
++192.0.1.34	example.org
++192.0.1.35	example.org
++192.0.1.36	example.org
++192.0.1.37	example.org
++192.0.1.38	example.org
++192.0.1.39	example.org
++192.0.1.40	example.org
++192.0.1.41	example.org
++192.0.1.42	example.org
++192.0.1.43	example.org
++192.0.1.44	example.org
++192.0.1.45	example.org
++192.0.1.46	example.org
++192.0.1.47	example.org
++192.0.1.48	example.org
++192.0.1.49	example.org
++192.0.1.50	example.org
++192.0.1.51	example.org
++192.0.1.52	example.org
++192.0.1.53	example.org
++192.0.1.54	example.org
++192.0.1.55	example.org
++192.0.1.56	example.org
++192.0.1.57	example.org
++192.0.1.58	example.org
++192.0.1.59	example.org
++192.0.1.60	example.org
++192.0.1.61	example.org
++192.0.1.62	example.org
++192.0.1.63	example.org
++192.0.1.64	example.org
++192.0.1.65	example.org
++192.0.1.66	example.org
++192.0.1.67	example.org
++192.0.1.68	example.org
++192.0.1.69	example.org
++192.0.1.70	example.org
++192.0.1.71	example.org
++192.0.1.72	example.org
++192.0.1.73	example.org
++192.0.1.74	example.org
++192.0.1.75	example.org
++192.0.1.76	example.org
++192.0.1.77	example.org
++192.0.1.78	example.org
++192.0.1.79	example.org
++192.0.1.80	example.org
++192.0.1.81	example.org
++192.0.1.82	example.org
++192.0.1.83	example.org
++192.0.1.84	example.org
++192.0.1.85	example.org
++192.0.1.86	example.org
++192.0.1.87	example.org
++192.0.1.88	example.org
++192.0.1.89	example.org
++192.0.1.90	example.org
++192.0.1.91	example.org
++192.0.1.92	example.org
++192.0.1.93	example.org
++192.0.1.94	example.org
++192.0.1.95	example.org
++192.0.1.96	example.org
++192.0.1.97	example.org
++192.0.1.98	example.org
++192.0.1.99	example.org
++192.0.1.100	example.org
++192.0.1.101	example.org
++192.0.1.102	example.org
++192.0.1.103	example.org
++192.0.1.104	example.org
++192.0.1.105	example.org
++192.0.1.106	example.org
++192.0.1.107	example.org
++192.0.1.108	example.org
++192.0.1.109	example.org
++192.0.1.110	example.org
++192.0.1.111	example.org
++192.0.1.112	example.org
++192.0.1.113	example.org
++192.0.1.114	example.org
++192.0.1.115	example.org
++192.0.1.116	example.org
++192.0.1.117	example.org
++192.0.1.118	example.org
++192.0.1.119	example.org
++192.0.1.120	example.org
++192.0.1.121	example.org
++192.0.1.122	example.org
++192.0.1.123	example.org
++192.0.1.124	example.org
++192.0.1.125	example.org
++192.0.1.126	example.org
++192.0.1.127	example.org
++192.0.1.128	example.org
++192.0.1.129	example.org
++192.0.1.130	example.org
++192.0.1.131	example.org
++192.0.1.132	example.org
++192.0.1.133	example.org
++192.0.1.134	example.org
++192.0.1.135	example.org
++192.0.1.136	example.org
++192.0.1.137	example.org
++192.0.1.138	example.org
++192.0.1.139	example.org
++192.0.1.140	example.org
++192.0.1.141	example.org
++192.0.1.142	example.org
++192.0.1.143	example.org
++192.0.1.144	example.org
++192.0.1.145	example.org
++192.0.1.146	example.org
++192.0.1.147	example.org
++192.0.1.148	example.org
++192.0.1.149	example.org
++192.0.1.150	example.org
++192.0.1.151	example.org
++192.0.1.152	example.org
++192.0.1.153	example.org
++192.0.1.154	example.org
++192.0.1.155	example.org
++192.0.1.156	example.org
++192.0.1.157	example.org
++192.0.1.158	example.org
++192.0.1.159	example.org
++192.0.1.160	example.org
++192.0.1.161	example.org
++192.0.1.162	example.org
++192.0.1.163	example.org
++192.0.1.164	example.org
++192.0.1.165	example.org
++192.0.1.166	example.org
++192.0.1.167	example.org
++192.0.1.168	example.org
++192.0.1.169	example.org
++192.0.1.170	example.org
++192.0.1.171	example.org
++192.0.1.172	example.org
++192.0.1.173	example.org
++192.0.1.174	example.org
++192.0.1.175	example.org
++192.0.1.176	example.org
++192.0.1.177	example.org
++192.0.1.178	example.org
++192.0.1.179	example.org
++192.0.1.180	example.org
++192.0.1.181	example.org
++192.0.1.182	example.org
++192.0.1.183	example.org
++192.0.1.184	example.org
++192.0.1.185	example.org
++192.0.1.186	example.org
++192.0.1.187	example.org
++192.0.1.188	example.org
++192.0.1.189	example.org
++192.0.1.190	example.org
++192.0.1.191	example.org
++192.0.1.192	example.org
++192.0.1.193	example.org
++192.0.1.194	example.org
++192.0.1.195	example.org
++192.0.1.196	example.org
++192.0.1.197	example.org
++192.0.1.198	example.org
++192.0.1.199	example.org
++192.0.1.200	example.org
++192.0.1.201	example.org
++192.0.1.202	example.org
++192.0.1.203	example.org
++192.0.1.204	example.org
++192.0.1.205	example.org
++192.0.1.206	example.org
++192.0.1.207	example.org
++192.0.1.208	example.org
++192.0.1.209	example.org
++192.0.1.210	example.org
++192.0.1.211	example.org
++192.0.1.212	example.org
++192.0.1.213	example.org
++192.0.1.214	example.org
++192.0.1.215	example.org
++192.0.1.216	example.org
++192.0.1.217	example.org
++192.0.1.218	example.org
++192.0.1.219	example.org
++192.0.1.220	example.org
++192.0.1.221	example.org
++192.0.1.222	example.org
++192.0.1.223	example.org
++192.0.1.224	example.org
++192.0.1.225	example.org
++192.0.1.226	example.org
++192.0.1.227	example.org
++192.0.1.228	example.org
++192.0.1.229	example.org
++192.0.1.230	example.org
++192.0.1.231	example.org
++192.0.1.232	example.org
++192.0.1.233	example.org
++192.0.1.234	example.org
++192.0.1.235	example.org
++192.0.1.236	example.org
++192.0.1.237	example.org
++192.0.1.238	example.org
++192.0.1.239	example.org
++192.0.1.240	example.org
++192.0.1.241	example.org
++192.0.1.242	example.org
++192.0.1.243	example.org
++192.0.1.244	example.org
++192.0.1.245	example.org
++192.0.1.246	example.org
++192.0.1.247	example.org
++192.0.1.248	example.org
++192.0.1.249	example.org
++192.0.1.250	example.org
++192.0.1.251	example.org
++192.0.1.252	example.org
++192.0.1.253	example.org
++192.0.1.254	example.org
+diff --git a/sysdeps/posix/getaddrinfo.c b/sysdeps/posix/getaddrinfo.c
+index 18dccd5924..3d9bea60c6 100644
+--- a/sysdeps/posix/getaddrinfo.c
++++ b/sysdeps/posix/getaddrinfo.c
+@@ -458,11 +458,6 @@ gaih_inet (const char *name, const struct gaih_service *service,
+
+   if (name != NULL)
+     {
+-      at = alloca_account (sizeof (struct gaih_addrtuple), alloca_used);
+-      at->family = AF_UNSPEC;
+-      at->scopeid = 0;
+-      at->next = NULL;
+-
+       if (req->ai_flags & AI_IDN)
+ 	{
+ 	  char *out;
+@@ -473,13 +468,21 @@ gaih_inet (const char *name, const struct gaih_service *service,
+ 	  malloc_name = true;
+ 	}
+
+-      if (__inet_aton_exact (name, (struct in_addr *) at->addr) != 0)
++      uint32_t addr[4];
++      if (__inet_aton_exact (name, (struct in_addr *) addr) != 0)
+ 	{
++	  at = alloca_account (sizeof (struct gaih_addrtuple), alloca_used);
++	  at->scopeid = 0;
++	  at->next = NULL;
++
+ 	  if (req->ai_family == AF_UNSPEC || req->ai_family == AF_INET)
+-	    at->family = AF_INET;
++	    {
++	      memcpy (at->addr, addr, sizeof (at->addr));
++	      at->family = AF_INET;
++	    }
+ 	  else if (req->ai_family == AF_INET6 && (req->ai_flags & AI_V4MAPPED))
+ 	    {
+-	      at->addr[3] = at->addr[0];
++	      at->addr[3] = addr[0];
+ 	      at->addr[2] = htonl (0xffff);
+ 	      at->addr[1] = 0;
+ 	      at->addr[0] = 0;
+@@ -493,49 +496,62 @@ gaih_inet (const char *name, const struct gaih_service *service,
+
+ 	  if (req->ai_flags & AI_CANONNAME)
+ 	    canon = name;
++
++	  goto process_list;
+ 	}
+-      else if (at->family == AF_UNSPEC)
++
++      char *scope_delim = strchr (name, SCOPE_DELIMITER);
++      int e;
++
++      if (scope_delim == NULL)
++	e = inet_pton (AF_INET6, name, addr);
++      else
++	e = __inet_pton_length (AF_INET6, name, scope_delim - name, addr);
++
++      if (e > 0)
+ 	{
+-	  char *scope_delim = strchr (name, SCOPE_DELIMITER);
+-	  int e;
+-	  if (scope_delim == NULL)
+-	    e = inet_pton (AF_INET6, name, at->addr);
++	  at = alloca_account (sizeof (struct gaih_addrtuple),
++			       alloca_used);
++	  at->scopeid = 0;
++	  at->next = NULL;
++
++	  if (req->ai_family == AF_UNSPEC || req->ai_family == AF_INET6)
++	    {
++	      memcpy (at->addr, addr, sizeof (at->addr));
++	      at->family = AF_INET6;
++	    }
++	  else if (req->ai_family == AF_INET
++		   && IN6_IS_ADDR_V4MAPPED (addr))
++	    {
++	      at->addr[0] = addr[3];
++	      at->addr[1] = addr[1];
++	      at->addr[2] = addr[2];
++	      at->addr[3] = addr[3];
++	      at->family = AF_INET;
++	    }
+ 	  else
+-	    e = __inet_pton_length (AF_INET6, name, scope_delim - name,
+-				    at->addr);
+-	  if (e > 0)
+ 	    {
+-	      if (req->ai_family == AF_UNSPEC || req->ai_family == AF_INET6)
+-		at->family = AF_INET6;
+-	      else if (req->ai_family == AF_INET
+-		       && IN6_IS_ADDR_V4MAPPED (at->addr))
+-		{
+-		  at->addr[0] = at->addr[3];
+-		  at->family = AF_INET;
+-		}
+-	      else
+-		{
+-		  result = -EAI_ADDRFAMILY;
+-		  goto free_and_return;
+-		}
+-
+-	      if (scope_delim != NULL
+-		  && __inet6_scopeid_pton ((struct in6_addr *) at->addr,
+-					   scope_delim + 1,
+-					   &at->scopeid) != 0)
+-		{
+-		  result = -EAI_NONAME;
+-		  goto free_and_return;
+-		}
++	      result = -EAI_ADDRFAMILY;
++	      goto free_and_return;
++	    }
+
+-	      if (req->ai_flags & AI_CANONNAME)
+-		canon = name;
++	  if (scope_delim != NULL
++	      && __inet6_scopeid_pton ((struct in6_addr *) at->addr,
++				       scope_delim + 1,
++				       &at->scopeid) != 0)
++	    {
++	      result = -EAI_NONAME;
++	      goto free_and_return;
+ 	    }
++
++	  if (req->ai_flags & AI_CANONNAME)
++	    canon = name;
++
++	  goto process_list;
+ 	}
+
+-      if (at->family == AF_UNSPEC && (req->ai_flags & AI_NUMERICHOST) == 0)
++      if ((req->ai_flags & AI_NUMERICHOST) == 0)
+ 	{
+-	  struct gaih_addrtuple **pat = &at;
+ 	  int no_data = 0;
+ 	  int no_inet6_data = 0;
+ 	  nss_action_list nip;
+@@ -543,6 +559,7 @@ gaih_inet (const char *name, const struct gaih_service *service,
+ 	  enum nss_status status = NSS_STATUS_UNAVAIL;
+ 	  int no_more;
+ 	  struct resolv_context *res_ctx = NULL;
++	  bool do_merge = false;
+
+ 	  /* If we do not have to look for IPv6 addresses or the canonical
+ 	     name, use the simple, old functions, which do not support
+@@ -579,7 +596,7 @@ gaih_inet (const char *name, const struct gaih_service *service,
+ 			  result = -EAI_MEMORY;
+ 			  goto free_and_return;
+ 			}
+-		      *pat = addrmem;
++		      at = addrmem;
+ 		    }
+ 		  else
+ 		    {
+@@ -632,6 +649,8 @@ gaih_inet (const char *name, const struct gaih_service *service,
+ 		    }
+
+ 		  struct gaih_addrtuple *addrfree = addrmem;
++		  struct gaih_addrtuple **pat = &at;
++
+ 		  for (int i = 0; i < air->naddrs; ++i)
+ 		    {
+ 		      socklen_t size = (air->family[i] == AF_INET
+@@ -695,12 +714,6 @@ gaih_inet (const char *name, const struct gaih_service *service,
+
+ 		  free (air);
+
+-		  if (at->family == AF_UNSPEC)
+-		    {
+-		      result = -EAI_NONAME;
+-		      goto free_and_return;
+-		    }
+-
+ 		  goto process_list;
+ 		}
+ 	      else if (err == 0)
+@@ -732,6 +745,22 @@ gaih_inet (const char *name, const struct gaih_service *service,
+
+ 	  while (!no_more)
+ 	    {
++	      /* Always start afresh; continue should discard previous results
++		 and the hosts database does not support merge.  */
++	      at = NULL;
++	      free (canonbuf);
++	      free (addrmem);
++	      canon = canonbuf = NULL;
++	      addrmem = NULL;
++	      got_ipv6 = false;
++
++	      if (do_merge)
++		{
++		  __set_h_errno (NETDB_INTERNAL);
++		  __set_errno (EBUSY);
++		  break;
++		}
++
+ 	      no_data = 0;
+ 	      nss_gethostbyname4_r *fct4 = NULL;
+
+@@ -744,12 +773,14 @@ gaih_inet (const char *name, const struct gaih_service *service,
+ 		{
+ 		  while (1)
+ 		    {
+-		      status = DL_CALL_FCT (fct4, (name, pat,
++		      status = DL_CALL_FCT (fct4, (name, &at,
+ 						   tmpbuf->data, tmpbuf->length,
+ 						   &errno, &h_errno,
+ 						   NULL));
+ 		      if (status == NSS_STATUS_SUCCESS)
+ 			break;
++		      /* gethostbyname4_r may write into AT, so reset it.  */
++		      at = NULL;
+ 		      if (status != NSS_STATUS_TRYAGAIN
+ 			  || errno != ERANGE || h_errno != NETDB_INTERNAL)
+ 			{
+@@ -774,7 +805,9 @@ gaih_inet (const char *name, const struct gaih_service *service,
+ 		      no_data = 1;
+
+ 		      if ((req->ai_flags & AI_CANONNAME) != 0 && canon == NULL)
+-			canon = (*pat)->name;
++			canon = at->name;
++
++		      struct gaih_addrtuple **pat = &at;
+
+ 		      while (*pat != NULL)
+ 			{
+@@ -826,6 +859,8 @@ gaih_inet (const char *name, const struct gaih_service *service,
+
+ 		  if (fct != NULL)
+ 		    {
++		      struct gaih_addrtuple **pat = &at;
++
+ 		      if (req->ai_family == AF_INET6
+ 			  || req->ai_family == AF_UNSPEC)
+ 			{
+@@ -899,6 +934,10 @@ gaih_inet (const char *name, const struct gaih_service *service,
+ 	      if (nss_next_action (nip, status) == NSS_ACTION_RETURN)
+ 		break;
+
++	      /* The hosts database does not support MERGE.  */
++	      if (nss_next_action (nip, status) == NSS_ACTION_MERGE)
++		do_merge = true;
++
+ 	      nip++;
+ 	      if (nip->module == NULL)
+ 		no_more = -1;
+@@ -930,7 +969,7 @@ gaih_inet (const char *name, const struct gaih_service *service,
+ 	}
+
+     process_list:
+-      if (at->family == AF_UNSPEC)
++      if (at == NULL)
+ 	{
+ 	  result = -EAI_NONAME;
+ 	  goto free_and_return;
+
+From c54c5cd8e30ef82041b525ca4880685c673357ee Mon Sep 17 00:00:00 2001
+From: Florian Weimer <fweimer@redhat.com>
+Date: Fri, 11 Mar 2022 08:23:56 +0100
+Subject: [PATCH] nss: Do not mention NSS test modules in <gnu/lib-names.h>
+
+They are not actually installed.  Use the nss_files version instead
+in nss/Makefile, similar to how __nss_shlib_revision is derived
+from LIBNSS_FILES_SO.
+
+Reviewed-by: Carlos O'Donell <carlos@redhat.com>
+(cherry picked from commit aefc79ab5ad4bb9feea2876720cec70dca7cd8ed)
+---
+ nss/Makefile   | 13 +++++--------
+ shlib-versions |  5 -----
+ 2 files changed, 5 insertions(+), 13 deletions(-)
+
+diff --git a/nss/Makefile b/nss/Makefile
+index 552e5d03e1..74e2c2426c 100644
+--- a/nss/Makefile
++++ b/nss/Makefile
+@@ -171,17 +171,14 @@ $(objpfx)/libnss_test1.so: $(objpfx)nss_test1.os $(link-libc-deps)
+ $(objpfx)/libnss_test2.so: $(objpfx)nss_test2.os $(link-libc-deps)
+ 	$(build-module)
+ $(objpfx)nss_test2.os : nss_test1.c
+-ifdef libnss_test1.so-version
+-$(objpfx)/libnss_test1.so$(libnss_test1.so-version): $(objpfx)/libnss_test1.so
++# Use the nss_files suffix for these objects as well.
++$(objpfx)/libnss_test1.so$(libnss_files.so-version): $(objpfx)/libnss_test1.so
+ 	$(make-link)
+-endif
+-ifdef libnss_test2.so-version
+-$(objpfx)/libnss_test2.so$(libnss_test2.so-version): $(objpfx)/libnss_test2.so
++$(objpfx)/libnss_test2.so$(libnss_files.so-version): $(objpfx)/libnss_test2.so
+ 	$(make-link)
+-endif
+ $(patsubst %,$(objpfx)%.out,$(tests) $(tests-container)) : \
+-	$(objpfx)/libnss_test1.so$(libnss_test1.so-version) \
+-	$(objpfx)/libnss_test2.so$(libnss_test2.so-version)
++	$(objpfx)/libnss_test1.so$(libnss_files.so-version) \
++	$(objpfx)/libnss_test2.so$(libnss_files.so-version)
+
+ ifeq (yes,$(have-thread-library))
+ $(objpfx)tst-cancel-getpwuid_r: $(shared-thread-library)
+diff --git a/shlib-versions b/shlib-versions
+index df6603e699..b87ab50c59 100644
+--- a/shlib-versions
++++ b/shlib-versions
+@@ -47,11 +47,6 @@ libnss_ldap=2
+ libnss_hesiod=2
+ libnss_db=2
+
+-# Tests for NSS.  They must have the same NSS_SHLIB_REVISION number as
+-# the rest.
+-libnss_test1=2
+-libnss_test2=2
+-
+ # Version for libnsl with YP and NIS+ functions.
+ libnsl=1
+
+
+From 123bd1ec66d2d7ea4683e9563bd94adc67f41544 Mon Sep 17 00:00:00 2001
+From: Florian Weimer <fweimer@redhat.com>
+Date: Fri, 11 Mar 2022 08:23:56 +0100
+Subject: [PATCH] nss: Protect against errno changes in function lookup (bug
+ 28953)
+
+dlopen may clobber errno.  The nss_test_errno module uses an ELF
+constructor to achieve that, but there could be internal errors
+during dlopen that cause this, too.  Therefore, the NSS framework
+has to guard against such errno clobbers.
+
+__nss_module_get_function is currently the only function that calls
+__nss_module_load, so it is sufficient to save and restore errno
+around this call.
+
+Reviewed-by: Carlos O'Donell <carlos@redhat.com>
+(cherry picked from commit 9bdf92c79d63b42f931101bb6df87129c408b0c4)
+---
+ nss/Makefile             | 15 ++++++++--
+ nss/nss_module.c         | 12 +++++++-
+ nss/nss_test_errno.c     | 58 ++++++++++++++++++++++++++++++++++++++
+ nss/tst-nss-test_errno.c | 61 ++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 142 insertions(+), 4 deletions(-)
+ create mode 100644 nss/nss_test_errno.c
+ create mode 100644 nss/tst-nss-test_errno.c
+
+diff --git a/nss/Makefile b/nss/Makefile
+index 74e2c2426c..de439d4911 100644
+--- a/nss/Makefile
++++ b/nss/Makefile
+@@ -60,7 +60,8 @@ tests			= test-netdb test-digits-dots tst-nss-getpwent bug17079 \
+ 			  tst-nss-test1 \
+ 			  tst-nss-test2 \
+ 			  tst-nss-test4 \
+-			  tst-nss-test5
++			  tst-nss-test5 \
++			  tst-nss-test_errno
+ xtests			= bug-erange
+
+ tests-container = \
+@@ -132,7 +133,7 @@ libnss_compat-inhibit-o	= $(filter-out .os,$(object-suffixes))
+ ifeq ($(build-static-nss),yes)
+ tests-static		+= tst-nss-static
+ endif
+-extra-test-objs		+= nss_test1.os nss_test2.os
++extra-test-objs		+= nss_test1.os nss_test2.os nss_test_errno.os
+
+ include ../Rules
+
+@@ -166,19 +167,26 @@ rtld-tests-LDFLAGS += -Wl,--dynamic-list=nss_test.ver
+
+ libof-nss_test1 = extramodules
+ libof-nss_test2 = extramodules
++libof-nss_test_errno = extramodules
+ $(objpfx)/libnss_test1.so: $(objpfx)nss_test1.os $(link-libc-deps)
+ 	$(build-module)
+ $(objpfx)/libnss_test2.so: $(objpfx)nss_test2.os $(link-libc-deps)
+ 	$(build-module)
++$(objpfx)/libnss_test_errno.so: $(objpfx)nss_test_errno.os $(link-libc-deps)
++	$(build-module)
+ $(objpfx)nss_test2.os : nss_test1.c
+ # Use the nss_files suffix for these objects as well.
+ $(objpfx)/libnss_test1.so$(libnss_files.so-version): $(objpfx)/libnss_test1.so
+ 	$(make-link)
+ $(objpfx)/libnss_test2.so$(libnss_files.so-version): $(objpfx)/libnss_test2.so
+ 	$(make-link)
++$(objpfx)/libnss_test_errno.so$(libnss_files.so-version): \
++  $(objpfx)/libnss_test_errno.so
++	$(make-link)
+ $(patsubst %,$(objpfx)%.out,$(tests) $(tests-container)) : \
+ 	$(objpfx)/libnss_test1.so$(libnss_files.so-version) \
+-	$(objpfx)/libnss_test2.so$(libnss_files.so-version)
++	$(objpfx)/libnss_test2.so$(libnss_files.so-version) \
++	$(objpfx)/libnss_test_errno.so$(libnss_files.so-version)
+
+ ifeq (yes,$(have-thread-library))
+ $(objpfx)tst-cancel-getpwuid_r: $(shared-thread-library)
+@@ -194,3 +202,4 @@ LDFLAGS-tst-nss-test2 = -Wl,--disable-new-dtags
+ LDFLAGS-tst-nss-test3 = -Wl,--disable-new-dtags
+ LDFLAGS-tst-nss-test4 = -Wl,--disable-new-dtags
+ LDFLAGS-tst-nss-test5 = -Wl,--disable-new-dtags
++LDFLAGS-tst-nss-test_errno = -Wl,--disable-new-dtags
+diff --git a/nss/nss_module.c b/nss/nss_module.c
+index f9a1263e5a..f00bbd9e1a 100644
+--- a/nss/nss_module.c
++++ b/nss/nss_module.c
+@@ -330,8 +330,18 @@ name_search (const void *left, const void *right)
+ void *
+ __nss_module_get_function (struct nss_module *module, const char *name)
+ {
++  /* A successful dlopen might clobber errno.   */
++  int saved_errno = errno;
++
+   if (!__nss_module_load (module))
+-    return NULL;
++    {
++      /* Reporting module load failure is currently inaccurate.  See
++	 bug 22041.  Not changing errno is the conservative choice.  */
++      __set_errno (saved_errno);
++      return NULL;
++    }
++
++  __set_errno (saved_errno);
+
+   function_name *name_entry = bsearch (name, nss_function_name_array,
+                                        array_length (nss_function_name_array),
+diff --git a/nss/nss_test_errno.c b/nss/nss_test_errno.c
+new file mode 100644
+index 0000000000..680f8a07b9
+--- /dev/null
++++ b/nss/nss_test_errno.c
+@@ -0,0 +1,58 @@
++/* NSS service provider with errno clobber.
++   Copyright (C) 2022 Free Software Foundation, Inc.
++   This file is part of the GNU C Library.
++
++   The GNU C Library is free software; you can redistribute it and/or
++   modify it under the terms of the GNU Lesser General Public
++   License as published by the Free Software Foundation; either
++   version 2.1 of the License, or (at your option) any later version.
++
++   The GNU C Library is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   Lesser General Public License for more details.
++
++   You should have received a copy of the GNU Lesser General Public
++   License along with the GNU C Library; if not, see
++   <https://www.gnu.org/licenses/>.  */
++
++#include <errno.h>
++#include <nss.h>
++#include <stdlib.h>
++
++/* Catch misnamed and functions.  */
++#pragma GCC diagnostic error "-Wmissing-prototypes"
++NSS_DECLARE_MODULE_FUNCTIONS (test_errno)
++
++static void __attribute__ ((constructor))
++init (void)
++{
++  /* An arbitrary error code which is otherwise not used.  */
++  errno = ELIBBAD;
++}
++
++/* Lookup functions for pwd follow that do not return any data.  */
++
++/* Catch misnamed function definitions.  */
++
++enum nss_status
++_nss_test_errno_setpwent (int stayopen)
++{
++  setenv ("_nss_test_errno_setpwent", "yes", 1);
++  return NSS_STATUS_SUCCESS;
++}
++
++enum nss_status
++_nss_test_errno_getpwent_r (struct passwd *result,
++                            char *buffer, size_t size, int *errnop)
++{
++  setenv ("_nss_test_errno_getpwent_r", "yes", 1);
++  return NSS_STATUS_NOTFOUND;
++}
++
++enum nss_status
++_nss_test_errno_endpwent (void)
++{
++  setenv ("_nss_test_errno_endpwent", "yes", 1);
++  return NSS_STATUS_SUCCESS;
++}
+diff --git a/nss/tst-nss-test_errno.c b/nss/tst-nss-test_errno.c
+new file mode 100644
+index 0000000000..d2c42dd363
+--- /dev/null
++++ b/nss/tst-nss-test_errno.c
+@@ -0,0 +1,61 @@
++/* getpwent failure when dlopen clobbers errno (bug 28953).
++   Copyright (C) 2022 Free Software Foundation, Inc.
++   This file is part of the GNU C Library.
++
++   The GNU C Library is free software; you can redistribute it and/or
++   modify it under the terms of the GNU Lesser General Public
++   License as published by the Free Software Foundation; either
++   version 2.1 of the License, or (at your option) any later version.
++
++   The GNU C Library is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   Lesser General Public License for more details.
++
++   You should have received a copy of the GNU Lesser General Public
++   License along with the GNU C Library; if not, see
++   <https://www.gnu.org/licenses/>.  */
++
++#include <nss.h>
++#include <support/check.h>
++#include <stdlib.h>
++#include <errno.h>
++#include <stdbool.h>
++#include <pwd.h>
++#include <string.h>
++
++static int
++do_test (void)
++{
++  __nss_configure_lookup ("passwd", "files test_errno");
++
++  errno = 0;
++  setpwent ();
++  TEST_COMPARE (errno, 0);
++
++  bool root_seen = false;
++  while (true)
++    {
++      errno = 0;
++      struct passwd *e = getpwent ();
++      if (e == NULL)
++        break;
++      if (strcmp (e->pw_name, "root"))
++        root_seen = true;
++    }
++
++  TEST_COMPARE (errno, 0);
++  TEST_VERIFY (root_seen);
++
++  errno = 0;
++  endpwent ();
++  TEST_COMPARE (errno, 0);
++
++  TEST_COMPARE_STRING (getenv ("_nss_test_errno_setpwent"), "yes");
++  TEST_COMPARE_STRING (getenv ("_nss_test_errno_getpwent_r"), "yes");
++  TEST_COMPARE_STRING (getenv ("_nss_test_errno_endpwent"), "yes");
++
++  return 0;
++}
++
++#include <support/test-driver.c>
+
+From b126325fc77f65862cddbef024b96dc1e9bb3104 Mon Sep 17 00:00:00 2001
+From: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Date: Thu, 17 Mar 2022 11:16:57 +0530
+Subject: [PATCH] nss: Sort tests and tests-container and put one test per line
+
+Signed-off-by: Siddhesh Poyarekar <siddhesh@sourceware.org>
+(cherry picked from commit e2f68b54e8052da14680074fc5df03153216f218)
+---
+ nss/Makefile | 41 +++++++++++++++++++++++++----------------
+ 1 file changed, 25 insertions(+), 16 deletions(-)
+
+diff --git a/nss/Makefile b/nss/Makefile
+index b2301c4cd7..d8b06b44fb 100644
+--- a/nss/Makefile
++++ b/nss/Makefile
+@@ -56,22 +56,31 @@ extra-objs		+= $(makedb-modules:=.o)
+
+ tests-static            = tst-field
+ tests-internal		= tst-field
+-tests			= test-netdb test-digits-dots tst-nss-getpwent bug17079 \
+-			  tst-nss-test1 \
+-			  tst-nss-test2 \
+-			  tst-nss-test4 \
+-			  tst-nss-test5 \
+-			  tst-nss-test_errno
+-xtests			= bug-erange
+-
+-tests-container = \
+-			  tst-nss-compat1 \
+-			  tst-nss-test3 \
+-			  tst-nss-files-hosts-long \
+-			  tst-nss-db-endpwent \
+-			  tst-nss-db-endgrent \
+-			  tst-reload1 tst-reload2 \
+-			  tst-nss-gai-actions
++
++tests := \
++  bug17079 \
++  test-digits-dots \
++  test-netdb \
++  tst-nss-getpwent \
++  tst-nss-test1 \
++  tst-nss-test2 \
++  tst-nss-test4 \
++  tst-nss-test5 \
++  tst-nss-test_errno \
++# tests
++
++xtests = bug-erange
++
++tests-container := \
++  tst-nss-compat1 \
++  tst-nss-db-endgrent \
++  tst-nss-db-endpwent \
++  tst-nss-files-hosts-long \
++  tst-nss-gai-actions \
++  tst-nss-test3 \
++  tst-reload1 \
++  tst-reload2 \
++# tests-container
+
+ # Tests which need libdl
+ ifeq (yes,$(build-shared))
+
+From f366eaa60819f49e4dbc0792ba136bfda7ada035 Mon Sep 17 00:00:00 2001
+From: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Date: Mon, 7 Mar 2022 22:17:36 +0530
+Subject: [PATCH] gaih_inet: Simplify canon name resolution
+
+Simplify logic for allocation of canon to remove the canonbuf variable;
+canon now always points to an allocated block.  Also pull the canon name
+set into a separate function.
+
+Signed-off-by: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Reviewed-by: DJ Delorie <dj@redhat.com>
+(cherry picked from commit d01411f6bc61429fc027c38827bf3103b48eef2e)
+---
+ sysdeps/posix/getaddrinfo.c | 130 +++++++++++++++++++++---------------
+ 1 file changed, 75 insertions(+), 55 deletions(-)
+
+diff --git a/sysdeps/posix/getaddrinfo.c b/sysdeps/posix/getaddrinfo.c
+index 3d9bea60c6..0629fd147b 100644
+--- a/sysdeps/posix/getaddrinfo.c
++++ b/sysdeps/posix/getaddrinfo.c
+@@ -285,7 +285,7 @@ convert_hostent_to_gaih_addrtuple (const struct addrinfo *req,
+ 									      \
+       if (localcanon != NULL && canon == NULL)				      \
+ 	{								      \
+-	  canonbuf = __strdup (localcanon);				      \
++	  char *canonbuf = __strdup (localcanon);			      \
+ 	  if (canonbuf == NULL)						      \
+ 	    {								      \
+ 	      __resolv_context_put (res_ctx);				      \
+@@ -323,6 +323,41 @@ getcanonname (nss_action_list nip, struct gaih_addrtuple *at, const char *name)
+   return __strdup (name);
+ }
+
++/* Process looked up canonical name and if necessary, decode to IDNA.  Result
++   is a new string written to CANONP and the earlier string is freed.  */
++
++static int
++process_canonname (const struct addrinfo *req, const char *orig_name,
++		   char **canonp)
++{
++  char *canon = *canonp;
++
++  if ((req->ai_flags & AI_CANONNAME) != 0)
++    {
++      bool do_idn = req->ai_flags & AI_CANONIDN;
++      if (do_idn)
++	{
++	  char *out;
++	  int rc = __idna_from_dns_encoding (canon ?: orig_name, &out);
++	  if (rc == 0)
++	    {
++	      free (canon);
++	      canon = out;
++	    }
++	  else if (rc == EAI_IDN_ENCODE)
++	    /* Use the punycode name as a fallback.  */
++	    do_idn = false;
++	  else
++	    return -rc;
++	}
++      if (!do_idn && canon == NULL && (canon = __strdup (orig_name)) == NULL)
++	return -EAI_MEMORY;
++    }
++
++  *canonp = canon;
++  return 0;
++}
++
+ static int
+ gaih_inet (const char *name, const struct gaih_service *service,
+ 	   const struct addrinfo *req, struct addrinfo **pai,
+@@ -332,7 +367,7 @@ gaih_inet (const char *name, const struct gaih_service *service,
+   struct gaih_servtuple *st = (struct gaih_servtuple *) &nullserv;
+   struct gaih_addrtuple *at = NULL;
+   bool got_ipv6 = false;
+-  const char *canon = NULL;
++  char *canon = NULL;
+   const char *orig_name = name;
+
+   /* Reserve stack memory for the scratch buffer in the getaddrinfo
+@@ -453,7 +488,6 @@ gaih_inet (const char *name, const struct gaih_service *service,
+
+   bool malloc_name = false;
+   struct gaih_addrtuple *addrmem = NULL;
+-  char *canonbuf = NULL;
+   int result = 0;
+
+   if (name != NULL)
+@@ -495,7 +529,15 @@ gaih_inet (const char *name, const struct gaih_service *service,
+ 	    }
+
+ 	  if (req->ai_flags & AI_CANONNAME)
+-	    canon = name;
++	    {
++	      char *canonbuf = __strdup (name);
++	      if (canonbuf == NULL)
++		{
++		  result = -EAI_MEMORY;
++		  goto free_and_return;
++		}
++	      canon = canonbuf;
++	    }
+
+ 	  goto process_list;
+ 	}
+@@ -545,7 +587,15 @@ gaih_inet (const char *name, const struct gaih_service *service,
+ 	    }
+
+ 	  if (req->ai_flags & AI_CANONNAME)
+-	    canon = name;
++	    {
++	      char *canonbuf = __strdup (name);
++	      if (canonbuf == NULL)
++		{
++		  result = -EAI_MEMORY;
++		  goto free_and_return;
++		}
++	      canon = canonbuf;
++	    }
+
+ 	  goto process_list;
+ 	}
+@@ -676,9 +726,9 @@ gaih_inet (const char *name, const struct gaih_service *service,
+ 		      (*pat)->next = NULL;
+ 		      if (added_canon || air->canon == NULL)
+ 			(*pat)->name = NULL;
+-		      else if (canonbuf == NULL)
++		      else if (canon == NULL)
+ 			{
+-			  canonbuf = __strdup (air->canon);
++			  char *canonbuf = __strdup (air->canon);
+ 			  if (canonbuf == NULL)
+ 			    {
+ 			      result = -EAI_MEMORY;
+@@ -748,9 +798,9 @@ gaih_inet (const char *name, const struct gaih_service *service,
+ 	      /* Always start afresh; continue should discard previous results
+ 		 and the hosts database does not support merge.  */
+ 	      at = NULL;
+-	      free (canonbuf);
++	      free (canon);
+ 	      free (addrmem);
+-	      canon = canonbuf = NULL;
++	      canon = NULL;
+ 	      addrmem = NULL;
+ 	      got_ipv6 = false;
+
+@@ -805,7 +855,16 @@ gaih_inet (const char *name, const struct gaih_service *service,
+ 		      no_data = 1;
+
+ 		      if ((req->ai_flags & AI_CANONNAME) != 0 && canon == NULL)
+-			canon = at->name;
++			{
++			  char *canonbuf = __strdup (at->name);
++			  if (canonbuf == NULL)
++			    {
++			      __resolv_context_put (res_ctx);
++			      result = -EAI_MEMORY;
++			      goto free_and_return;
++			    }
++			  canon = canonbuf;
++			}
+
+ 		      struct gaih_addrtuple **pat = &at;
+
+@@ -893,7 +952,7 @@ gaih_inet (const char *name, const struct gaih_service *service,
+ 			  if ((req->ai_flags & AI_CANONNAME) != 0
+ 			      && canon == NULL)
+ 			    {
+-			      canonbuf = getcanonname (nip, at, name);
++			      char *canonbuf = getcanonname (nip, at, name);
+ 			      if (canonbuf == NULL)
+ 				{
+ 				  __resolv_context_put (res_ctx);
+@@ -1004,6 +1063,10 @@ gaih_inet (const char *name, const struct gaih_service *service,
+     }
+
+   {
++    /* Set up the canonical name if we need it.  */
++    if ((result = process_canonname (req, orig_name, &canon)) != 0)
++      goto free_and_return;
++
+     struct gaih_servtuple *st2;
+     struct gaih_addrtuple *at2 = at;
+     size_t socklen;
+@@ -1014,48 +1077,6 @@ gaih_inet (const char *name, const struct gaih_service *service,
+      */
+     while (at2 != NULL)
+       {
+-	/* Only the first entry gets the canonical name.  */
+-	if (at2 == at && (req->ai_flags & AI_CANONNAME) != 0)
+-	  {
+-	    if (canon == NULL)
+-	      /* If the canonical name cannot be determined, use
+-		 the passed in string.  */
+-	      canon = orig_name;
+-
+-	    bool do_idn = req->ai_flags & AI_CANONIDN;
+-	    if (do_idn)
+-	      {
+-		char *out;
+-		int rc = __idna_from_dns_encoding (canon, &out);
+-		if (rc == 0)
+-		  canon = out;
+-		else if (rc == EAI_IDN_ENCODE)
+-		  /* Use the punycode name as a fallback.  */
+-		  do_idn = false;
+-		else
+-		  {
+-		    result = -rc;
+-		    goto free_and_return;
+-		  }
+-	      }
+-	    if (!do_idn)
+-	      {
+-		if (canonbuf != NULL)
+-		  /* We already allocated the string using malloc, but
+-		     the buffer is now owned by canon.  */
+-		  canonbuf = NULL;
+-		else
+-		  {
+-		    canon = __strdup (canon);
+-		    if (canon == NULL)
+-		      {
+-			result = -EAI_MEMORY;
+-			goto free_and_return;
+-		      }
+-		  }
+-	      }
+-	  }
+-
+ 	family = at2->family;
+ 	if (family == AF_INET6)
+ 	  {
+@@ -1078,7 +1099,6 @@ gaih_inet (const char *name, const struct gaih_service *service,
+ 	    ai = *pai = malloc (sizeof (struct addrinfo) + socklen);
+ 	    if (ai == NULL)
+ 	      {
+-		free ((char *) canon);
+ 		result = -EAI_MEMORY;
+ 		goto free_and_return;
+ 	      }
+@@ -1138,7 +1158,7 @@ gaih_inet (const char *name, const struct gaih_service *service,
+   if (malloc_name)
+     free ((char *) name);
+   free (addrmem);
+-  free (canonbuf);
++  free (canon);
+
+   return result;
+ }
+
+From d02808dee9f7e7fa950d83c12ecdbc13053e85e5 Mon Sep 17 00:00:00 2001
+From: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Date: Thu, 3 Mar 2022 23:07:42 +0530
+Subject: [PATCH] getaddrinfo: Fix leak with AI_ALL [BZ #28852]
+
+Use realloc in convert_hostent_to_gaih_addrtuple and fix up pointers in
+the result list so that a single block is maintained for
+hostbyname3_r/hostbyname2_r and freed in gaih_inet.  This result is
+never merged with any other results, since the hosts database does not
+permit merging.
+
+Resolves BZ #28852.
+
+Signed-off-by: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Reviewed-by: DJ Delorie <dj@redhat.com>
+(cherry picked from commit 300460460706ce3ffe29a7df8966e68323ec5bf1)
+---
+ sysdeps/posix/getaddrinfo.c | 34 +++++++++++++++++++++++++---------
+ 1 file changed, 25 insertions(+), 9 deletions(-)
+
+diff --git a/sysdeps/posix/getaddrinfo.c b/sysdeps/posix/getaddrinfo.c
+index 0629fd147b..e9deb2da6a 100644
+--- a/sysdeps/posix/getaddrinfo.c
++++ b/sysdeps/posix/getaddrinfo.c
+@@ -189,19 +189,16 @@ gaih_inet_serv (const char *servicename, const struct gaih_typeproto *tp,
+   return 0;
+ }
+
+-/* Convert struct hostent to a list of struct gaih_addrtuple objects.
+-   h_name is not copied, and the struct hostent object must not be
+-   deallocated prematurely.  *RESULT must be NULL or a pointer to a
+-   linked-list.  The new addresses are appended at the end.  */
++/* Convert struct hostent to a list of struct gaih_addrtuple objects.  h_name
++   is not copied, and the struct hostent object must not be deallocated
++   prematurely.  The new addresses are appended to the tuple array in
++   RESULT.  */
+ static bool
+ convert_hostent_to_gaih_addrtuple (const struct addrinfo *req,
+ 				   int family,
+ 				   struct hostent *h,
+ 				   struct gaih_addrtuple **result)
+ {
+-  while (*result)
+-    result = &(*result)->next;
+-
+   /* Count the number of addresses in h->h_addr_list.  */
+   size_t count = 0;
+   for (char **p = h->h_addr_list; *p != NULL; ++p)
+@@ -212,10 +209,30 @@ convert_hostent_to_gaih_addrtuple (const struct addrinfo *req,
+   if (count == 0 || h->h_length > sizeof (((struct gaih_addrtuple) {}).addr))
+     return true;
+
+-  struct gaih_addrtuple *array = calloc (count, sizeof (*array));
++  struct gaih_addrtuple *array = *result;
++  size_t old = 0;
++
++  while (array != NULL)
++    {
++      old++;
++      array = array->next;
++    }
++
++  array = realloc (*result, (old + count) * sizeof (*array));
++
+   if (array == NULL)
+     return false;
+
++  *result = array;
++
++  /* Update the next pointers on reallocation.  */
++  for (size_t i = 0; i < old; i++)
++    array[i].next = array + i + 1;
++
++  array += old;
++
++  memset (array, 0, count * sizeof (*array));
++
+   for (size_t i = 0; i < count; ++i)
+     {
+       if (family == AF_INET && req->ai_family == AF_INET6)
+@@ -235,7 +252,6 @@ convert_hostent_to_gaih_addrtuple (const struct addrinfo *req,
+   array[0].name = h->h_name;
+   array[count - 1].next = NULL;
+
+-  *result = array;
+   return true;
+ }
+
+
+From 9aad91abe66550541043fe8d4a5171bc53a37418 Mon Sep 17 00:00:00 2001
+From: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Date: Thu, 10 Feb 2022 13:27:11 +0530
+Subject: [PATCH] gaih_inet: Simplify service resolution
+
+Refactor the code to split out the service resolution code into a
+separate function.  Allocate the service tuples array just once to the
+size of the typeproto array, thus avoiding the unnecessary pointer
+chasing and stack allocations.
+
+Signed-off-by: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Reviewed-by: DJ Delorie <dj@redhat.com>
+(cherry picked from commit 8d6cf99f2fb81a097f9334c125e5c23604af1a98)
+---
+ sysdeps/posix/getaddrinfo.c | 178 ++++++++++++++++--------------------
+ 1 file changed, 78 insertions(+), 100 deletions(-)
+
+diff --git a/sysdeps/posix/getaddrinfo.c b/sysdeps/posix/getaddrinfo.c
+index e9deb2da6a..dae5e9f55f 100644
+--- a/sysdeps/posix/getaddrinfo.c
++++ b/sysdeps/posix/getaddrinfo.c
+@@ -100,14 +100,12 @@ struct gaih_service
+
+ struct gaih_servtuple
+   {
+-    struct gaih_servtuple *next;
+     int socktype;
+     int protocol;
+     int port;
++    bool set;
+   };
+
+-static const struct gaih_servtuple nullserv;
+-
+
+ struct gaih_typeproto
+   {
+@@ -180,11 +178,11 @@ gaih_inet_serv (const char *servicename, const struct gaih_typeproto *tp,
+     }
+   while (r);
+
+-  st->next = NULL;
+   st->socktype = tp->socktype;
+   st->protocol = ((tp->protoflag & GAI_PROTO_PROTOANY)
+ 		  ? req->ai_protocol : tp->protocol);
+   st->port = s->s_port;
++  st->set = true;
+
+   return 0;
+ }
+@@ -375,20 +373,11 @@ process_canonname (const struct addrinfo *req, const char *orig_name,
+ }
+
+ static int
+-gaih_inet (const char *name, const struct gaih_service *service,
+-	   const struct addrinfo *req, struct addrinfo **pai,
+-	   unsigned int *naddrs, struct scratch_buffer *tmpbuf)
++get_servtuples (const struct gaih_service *service, const struct addrinfo *req,
++		struct gaih_servtuple *st, struct scratch_buffer *tmpbuf)
+ {
++  int i;
+   const struct gaih_typeproto *tp = gaih_inet_typeproto;
+-  struct gaih_servtuple *st = (struct gaih_servtuple *) &nullserv;
+-  struct gaih_addrtuple *at = NULL;
+-  bool got_ipv6 = false;
+-  char *canon = NULL;
+-  const char *orig_name = name;
+-
+-  /* Reserve stack memory for the scratch buffer in the getaddrinfo
+-     function.  */
+-  size_t alloca_used = sizeof (struct scratch_buffer);
+
+   if (req->ai_protocol || req->ai_socktype)
+     {
+@@ -410,98 +399,88 @@ gaih_inet (const char *name, const struct gaih_service *service,
+ 	}
+     }
+
+-  int port = 0;
+-  if (service != NULL)
++  if (service != NULL && (tp->protoflag & GAI_PROTO_NOSERVICE) != 0)
++    return -EAI_SERVICE;
++
++  if (service == NULL || service->num >= 0)
+     {
+-      if ((tp->protoflag & GAI_PROTO_NOSERVICE) != 0)
+-	return -EAI_SERVICE;
++      int port = service != NULL ? htons (service->num) : 0;
+
+-      if (service->num < 0)
++      if (req->ai_socktype || req->ai_protocol)
+ 	{
+-	  if (tp->name[0])
+-	    {
+-	      st = (struct gaih_servtuple *)
+-		alloca_account (sizeof (struct gaih_servtuple), alloca_used);
+-
+-	      int rc = gaih_inet_serv (service->name, tp, req, st, tmpbuf);
+-	      if (__glibc_unlikely (rc != 0))
+-		return rc;
+-	    }
+-	  else
+-	    {
+-	      struct gaih_servtuple **pst = &st;
+-	      for (tp++; tp->name[0]; tp++)
+-		{
+-		  struct gaih_servtuple *newp;
++	  st[0].socktype = tp->socktype;
++	  st[0].protocol = ((tp->protoflag & GAI_PROTO_PROTOANY)
++			  ? req->ai_protocol : tp->protocol);
++	  st[0].port = port;
++	  st[0].set = true;
+
+-		  if ((tp->protoflag & GAI_PROTO_NOSERVICE) != 0)
+-		    continue;
++	  return 0;
++	}
+
+-		  if (req->ai_socktype != 0
+-		      && req->ai_socktype != tp->socktype)
+-		    continue;
+-		  if (req->ai_protocol != 0
+-		      && !(tp->protoflag & GAI_PROTO_PROTOANY)
+-		      && req->ai_protocol != tp->protocol)
+-		    continue;
++      /* Neither socket type nor protocol is set.  Return all socket types
++	 we know about.  */
++      for (i = 0, ++tp; tp->name[0]; ++tp)
++	if (tp->defaultflag)
++	  {
++	    st[i].socktype = tp->socktype;
++	    st[i].protocol = tp->protocol;
++	    st[i].port = port;
++	    st[i++].set = true;
++	  }
+
+-		  newp = (struct gaih_servtuple *)
+-		    alloca_account (sizeof (struct gaih_servtuple),
+-				    alloca_used);
++      return 0;
++    }
+
+-		  if (gaih_inet_serv (service->name,
+-				      tp, req, newp, tmpbuf) != 0)
+-		    continue;
++  if (tp->name[0])
++    return gaih_inet_serv (service->name, tp, req, st, tmpbuf);
+
+-		  *pst = newp;
+-		  pst = &(newp->next);
+-		}
+-	      if (st == (struct gaih_servtuple *) &nullserv)
+-		return -EAI_SERVICE;
+-	    }
+-	}
+-      else
+-	{
+-	  port = htons (service->num);
+-	  goto got_port;
+-	}
+-    }
+-  else
++  for (i = 0, tp++; tp->name[0]; tp++)
+     {
+-    got_port:
++      if ((tp->protoflag & GAI_PROTO_NOSERVICE) != 0)
++	continue;
+
+-      if (req->ai_socktype || req->ai_protocol)
+-	{
+-	  st = alloca_account (sizeof (struct gaih_servtuple), alloca_used);
+-	  st->next = NULL;
+-	  st->socktype = tp->socktype;
+-	  st->protocol = ((tp->protoflag & GAI_PROTO_PROTOANY)
+-			  ? req->ai_protocol : tp->protocol);
+-	  st->port = port;
+-	}
+-      else
+-	{
+-	  /* Neither socket type nor protocol is set.  Return all socket types
+-	     we know about.  */
+-	  struct gaih_servtuple **lastp = &st;
+-	  for (++tp; tp->name[0]; ++tp)
+-	    if (tp->defaultflag)
+-	      {
+-		struct gaih_servtuple *newp;
++      if (req->ai_socktype != 0
++	  && req->ai_socktype != tp->socktype)
++	continue;
++      if (req->ai_protocol != 0
++	  && !(tp->protoflag & GAI_PROTO_PROTOANY)
++	  && req->ai_protocol != tp->protocol)
++	continue;
+
+-		newp = alloca_account (sizeof (struct gaih_servtuple),
+-				       alloca_used);
+-		newp->next = NULL;
+-		newp->socktype = tp->socktype;
+-		newp->protocol = tp->protocol;
+-		newp->port = port;
++      if (gaih_inet_serv (service->name,
++			  tp, req, &st[i], tmpbuf) != 0)
++	continue;
+
+-		*lastp = newp;
+-		lastp = &newp->next;
+-	      }
+-	}
++      i++;
+     }
+
++  if (!st[0].set)
++    return -EAI_SERVICE;
++
++  return 0;
++}
++
++static int
++gaih_inet (const char *name, const struct gaih_service *service,
++	   const struct addrinfo *req, struct addrinfo **pai,
++	   unsigned int *naddrs, struct scratch_buffer *tmpbuf)
++{
++  struct gaih_servtuple st[sizeof (gaih_inet_typeproto)
++			   / sizeof (struct gaih_typeproto)] = {0};
++
++  struct gaih_addrtuple *at = NULL;
++  bool got_ipv6 = false;
++  char *canon = NULL;
++  const char *orig_name = name;
++
++  /* Reserve stack memory for the scratch buffer in the getaddrinfo
++     function.  */
++  size_t alloca_used = sizeof (struct scratch_buffer);
++
++  int rc;
++  if ((rc = get_servtuples (service, req, st, tmpbuf)) != 0)
++    return rc;
++
+   bool malloc_name = false;
+   struct gaih_addrtuple *addrmem = NULL;
+   int result = 0;
+@@ -1083,7 +1062,6 @@ gaih_inet (const char *name, const struct gaih_service *service,
+     if ((result = process_canonname (req, orig_name, &canon)) != 0)
+       goto free_and_return;
+
+-    struct gaih_servtuple *st2;
+     struct gaih_addrtuple *at2 = at;
+     size_t socklen;
+     sa_family_t family;
+@@ -1109,7 +1087,7 @@ gaih_inet (const char *name, const struct gaih_service *service,
+ 	else
+ 	  socklen = sizeof (struct sockaddr_in);
+
+-	for (st2 = st; st2 != NULL; st2 = st2->next)
++	for (int i = 0; st[i].set; i++)
+ 	  {
+ 	    struct addrinfo *ai;
+ 	    ai = *pai = malloc (sizeof (struct addrinfo) + socklen);
+@@ -1121,8 +1099,8 @@ gaih_inet (const char *name, const struct gaih_service *service,
+
+ 	    ai->ai_flags = req->ai_flags;
+ 	    ai->ai_family = family;
+-	    ai->ai_socktype = st2->socktype;
+-	    ai->ai_protocol = st2->protocol;
++	    ai->ai_socktype = st[i].socktype;
++	    ai->ai_protocol = st[i].protocol;
+ 	    ai->ai_addrlen = socklen;
+ 	    ai->ai_addr = (void *) (ai + 1);
+
+@@ -1144,7 +1122,7 @@ gaih_inet (const char *name, const struct gaih_service *service,
+ 		struct sockaddr_in6 *sin6p =
+ 		  (struct sockaddr_in6 *) ai->ai_addr;
+
+-		sin6p->sin6_port = st2->port;
++		sin6p->sin6_port = st[i].port;
+ 		sin6p->sin6_flowinfo = 0;
+ 		memcpy (&sin6p->sin6_addr,
+ 			at2->addr, sizeof (struct in6_addr));
+@@ -1154,7 +1132,7 @@ gaih_inet (const char *name, const struct gaih_service *service,
+ 	      {
+ 		struct sockaddr_in *sinp =
+ 		  (struct sockaddr_in *) ai->ai_addr;
+-		sinp->sin_port = st2->port;
++		sinp->sin_port = st[i].port;
+ 		memcpy (&sinp->sin_addr,
+ 			at2->addr, sizeof (struct in_addr));
+ 		memset (sinp->sin_zero, '\0', sizeof (sinp->sin_zero));
+
+From 571c531b3ba5e6ae848992cd4f6e19ab63eb564a Mon Sep 17 00:00:00 2001
+From: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Date: Mon, 7 Mar 2022 14:08:51 +0530
+Subject: [PATCH] gaih_inet: make numeric lookup a separate routine
+
+Introduce the gaih_result structure and general paradigm for cleanups
+that follow to process the lookup request and return a result.  A lookup
+function (like text_to_binary_address), should return an integer error
+code and set members of gaih_result based on what it finds.  If the
+function does not have a result and no errors have occurred during the
+lookup, it should return 0 and res.at should be set to NULL, allowing a
+subsequent function to do the lookup until we run out of options.
+
+Signed-off-by: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Reviewed-by: DJ Delorie <dj@redhat.com>
+(cherry picked from commit 26dea461191cca519b498890a9682fe4bc8e4c2f)
+---
+ sysdeps/posix/getaddrinfo.c | 891 ++++++++++++++++++------------------
+ 1 file changed, 452 insertions(+), 439 deletions(-)
+
+diff --git a/sysdeps/posix/getaddrinfo.c b/sysdeps/posix/getaddrinfo.c
+index dae5e9f55f..19bb13db59 100644
+--- a/sysdeps/posix/getaddrinfo.c
++++ b/sysdeps/posix/getaddrinfo.c
+@@ -116,6 +116,12 @@ struct gaih_typeproto
+     char name[8];
+   };
+
++struct gaih_result
++{
++  struct gaih_addrtuple *at;
++  char *canon;
++};
++
+ /* Values for `protoflag'.  */
+ #define GAI_PROTO_NOSERVICE	1
+ #define GAI_PROTO_PROTOANY	2
+@@ -297,7 +303,7 @@ convert_hostent_to_gaih_addrtuple (const struct addrinfo *req,
+ 	}								      \
+       *pat = addrmem;							      \
+ 									      \
+-      if (localcanon != NULL && canon == NULL)				      \
++      if (localcanon != NULL && res.canon == NULL)			      \
+ 	{								      \
+ 	  char *canonbuf = __strdup (localcanon);			      \
+ 	  if (canonbuf == NULL)						      \
+@@ -306,7 +312,7 @@ convert_hostent_to_gaih_addrtuple (const struct addrinfo *req,
+ 	      result = -EAI_SYSTEM;					      \
+ 	      goto free_and_return;					      \
+ 	    }								      \
+-	  canon = canonbuf;						      \
++	  res.canon = canonbuf;						      \
+ 	}								      \
+       if (_family == AF_INET6 && *pat != NULL)				      \
+ 	got_ipv6 = true;						      \
+@@ -342,9 +348,9 @@ getcanonname (nss_action_list nip, struct gaih_addrtuple *at, const char *name)
+
+ static int
+ process_canonname (const struct addrinfo *req, const char *orig_name,
+-		   char **canonp)
++		   struct gaih_result *res)
+ {
+-  char *canon = *canonp;
++  char *canon = res->canon;
+
+   if ((req->ai_flags & AI_CANONNAME) != 0)
+     {
+@@ -368,7 +374,7 @@ process_canonname (const struct addrinfo *req, const char *orig_name,
+ 	return -EAI_MEMORY;
+     }
+
+-  *canonp = canon;
++  res->canon = canon;
+   return 0;
+ }
+
+@@ -460,6 +466,105 @@ get_servtuples (const struct gaih_service *service, const struct addrinfo *req,
+   return 0;
+ }
+
++/* Convert numeric addresses to binary into RES.  On failure, RES->AT is set to
++   NULL and an error code is returned.  If AI_NUMERIC_HOST is not requested and
++   the function cannot determine a result, RES->AT is set to NULL and 0
++   returned.  */
++
++static int
++text_to_binary_address (const char *name, const struct addrinfo *req,
++			struct gaih_result *res)
++{
++  struct gaih_addrtuple *at = res->at;
++  int result = 0;
++
++  assert (at != NULL);
++
++  memset (at->addr, 0, sizeof (at->addr));
++  if (__inet_aton_exact (name, (struct in_addr *) at->addr) != 0)
++    {
++      if (req->ai_family == AF_UNSPEC || req->ai_family == AF_INET)
++	at->family = AF_INET;
++      else if (req->ai_family == AF_INET6 && (req->ai_flags & AI_V4MAPPED))
++	{
++	  at->addr[3] = at->addr[0];
++	  at->addr[2] = htonl (0xffff);
++	  at->addr[1] = 0;
++	  at->addr[0] = 0;
++	  at->family = AF_INET6;
++	}
++      else
++	{
++	  result = -EAI_ADDRFAMILY;
++	  goto out;
++	}
++
++      if (req->ai_flags & AI_CANONNAME)
++	{
++	  char *canonbuf = __strdup (name);
++	  if (canonbuf == NULL)
++	    {
++	      result = -EAI_MEMORY;
++	      goto out;
++	    }
++	  res->canon = canonbuf;
++	}
++      return 0;
++    }
++
++  char *scope_delim = strchr (name, SCOPE_DELIMITER);
++  int e;
++
++  if (scope_delim == NULL)
++    e = inet_pton (AF_INET6, name, at->addr);
++  else
++    e = __inet_pton_length (AF_INET6, name, scope_delim - name, at->addr);
++
++  if (e > 0)
++    {
++      if (req->ai_family == AF_UNSPEC || req->ai_family == AF_INET6)
++	at->family = AF_INET6;
++      else if (req->ai_family == AF_INET
++	       && IN6_IS_ADDR_V4MAPPED (at->addr))
++	{
++	  at->addr[0] = at->addr[3];
++	  at->family = AF_INET;
++	}
++      else
++	{
++	  result = -EAI_ADDRFAMILY;
++	  goto out;
++	}
++
++      if (scope_delim != NULL
++	  && __inet6_scopeid_pton ((struct in6_addr *) at->addr,
++				   scope_delim + 1, &at->scopeid) != 0)
++	{
++	  result = -EAI_NONAME;
++	  goto out;
++	}
++
++      if (req->ai_flags & AI_CANONNAME)
++	{
++	  char *canonbuf = __strdup (name);
++	  if (canonbuf == NULL)
++	    {
++	      result = -EAI_MEMORY;
++	      goto out;
++	    }
++	  res->canon = canonbuf;
++	}
++      return 0;
++    }
++
++  if ((req->ai_flags & AI_NUMERICHOST))
++    result = -EAI_NONAME;
++
++out:
++  res->at = NULL;
++  return result;
++}
++
+ static int
+ gaih_inet (const char *name, const struct gaih_service *service,
+ 	   const struct addrinfo *req, struct addrinfo **pai,
+@@ -468,9 +573,7 @@ gaih_inet (const char *name, const struct gaih_service *service,
+   struct gaih_servtuple st[sizeof (gaih_inet_typeproto)
+ 			   / sizeof (struct gaih_typeproto)] = {0};
+
+-  struct gaih_addrtuple *at = NULL;
+   bool got_ipv6 = false;
+-  char *canon = NULL;
+   const char *orig_name = name;
+
+   /* Reserve stack memory for the scratch buffer in the getaddrinfo
+@@ -485,6 +588,7 @@ gaih_inet (const char *name, const struct gaih_service *service,
+   struct gaih_addrtuple *addrmem = NULL;
+   int result = 0;
+
++  struct gaih_result res = {0};
+   if (name != NULL)
+     {
+       if (req->ai_flags & AI_IDN)
+@@ -497,533 +601,441 @@ gaih_inet (const char *name, const struct gaih_service *service,
+ 	  malloc_name = true;
+ 	}
+
+-      uint32_t addr[4];
+-      if (__inet_aton_exact (name, (struct in_addr *) addr) != 0)
++      res.at = alloca_account (sizeof (struct gaih_addrtuple), alloca_used);
++      res.at->scopeid = 0;
++      res.at->next = NULL;
++
++      if ((result = text_to_binary_address (name, req, &res)) != 0)
++	goto free_and_return;
++      else if (res.at != NULL)
++	goto process_list;
++
++      int no_data = 0;
++      int no_inet6_data = 0;
++      nss_action_list nip;
++      enum nss_status inet6_status = NSS_STATUS_UNAVAIL;
++      enum nss_status status = NSS_STATUS_UNAVAIL;
++      int no_more;
++      struct resolv_context *res_ctx = NULL;
++      bool do_merge = false;
++
++      /* If we do not have to look for IPv6 addresses or the canonical
++	 name, use the simple, old functions, which do not support
++	 IPv6 scope ids, nor retrieving the canonical name.  */
++      if (req->ai_family == AF_INET
++	  && (req->ai_flags & AI_CANONNAME) == 0)
+ 	{
+-	  at = alloca_account (sizeof (struct gaih_addrtuple), alloca_used);
+-	  at->scopeid = 0;
+-	  at->next = NULL;
+-
+-	  if (req->ai_family == AF_UNSPEC || req->ai_family == AF_INET)
+-	    {
+-	      memcpy (at->addr, addr, sizeof (at->addr));
+-	      at->family = AF_INET;
+-	    }
+-	  else if (req->ai_family == AF_INET6 && (req->ai_flags & AI_V4MAPPED))
+-	    {
+-	      at->addr[3] = addr[0];
+-	      at->addr[2] = htonl (0xffff);
+-	      at->addr[1] = 0;
+-	      at->addr[0] = 0;
+-	      at->family = AF_INET6;
+-	    }
+-	  else
+-	    {
+-	      result = -EAI_ADDRFAMILY;
+-	      goto free_and_return;
+-	    }
++	  int rc;
++	  struct hostent th;
++	  struct hostent *h;
+
+-	  if (req->ai_flags & AI_CANONNAME)
++	  while (1)
+ 	    {
+-	      char *canonbuf = __strdup (name);
+-	      if (canonbuf == NULL)
++	      rc = __gethostbyname2_r (name, AF_INET, &th,
++				       tmpbuf->data, tmpbuf->length,
++				       &h, &h_errno);
++	      if (rc != ERANGE || h_errno != NETDB_INTERNAL)
++		break;
++	      if (!scratch_buffer_grow (tmpbuf))
+ 		{
+ 		  result = -EAI_MEMORY;
+ 		  goto free_and_return;
+ 		}
+-	      canon = canonbuf;
+ 	    }
+
+-	  goto process_list;
+-	}
+-
+-      char *scope_delim = strchr (name, SCOPE_DELIMITER);
+-      int e;
+-
+-      if (scope_delim == NULL)
+-	e = inet_pton (AF_INET6, name, addr);
+-      else
+-	e = __inet_pton_length (AF_INET6, name, scope_delim - name, addr);
+-
+-      if (e > 0)
+-	{
+-	  at = alloca_account (sizeof (struct gaih_addrtuple),
+-			       alloca_used);
+-	  at->scopeid = 0;
+-	  at->next = NULL;
+-
+-	  if (req->ai_family == AF_UNSPEC || req->ai_family == AF_INET6)
+-	    {
+-	      memcpy (at->addr, addr, sizeof (at->addr));
+-	      at->family = AF_INET6;
+-	    }
+-	  else if (req->ai_family == AF_INET
+-		   && IN6_IS_ADDR_V4MAPPED (addr))
++	  if (rc == 0)
+ 	    {
+-	      at->addr[0] = addr[3];
+-	      at->addr[1] = addr[1];
+-	      at->addr[2] = addr[2];
+-	      at->addr[3] = addr[3];
+-	      at->family = AF_INET;
++	      if (h != NULL)
++		{
++		  /* We found data, convert it.  */
++		  if (!convert_hostent_to_gaih_addrtuple
++		      (req, AF_INET, h, &addrmem))
++		    {
++		      result = -EAI_MEMORY;
++		      goto free_and_return;
++		    }
++		  res.at = addrmem;
++		}
++	      else
++		{
++		  if (h_errno == NO_DATA)
++		    result = -EAI_NODATA;
++		  else
++		    result = -EAI_NONAME;
++		  goto free_and_return;
++		}
+ 	    }
+ 	  else
+ 	    {
+-	      result = -EAI_ADDRFAMILY;
+-	      goto free_and_return;
+-	    }
++	      if (h_errno == NETDB_INTERNAL)
++		result = -EAI_SYSTEM;
++	      else if (h_errno == TRY_AGAIN)
++		result = -EAI_AGAIN;
++	      else
++		/* We made requests but they turned out no data.
++		   The name is known, though.  */
++		result = -EAI_NODATA;
+
+-	  if (scope_delim != NULL
+-	      && __inet6_scopeid_pton ((struct in6_addr *) at->addr,
+-				       scope_delim + 1,
+-				       &at->scopeid) != 0)
+-	    {
+-	      result = -EAI_NONAME;
+ 	      goto free_and_return;
+ 	    }
+
+-	  if (req->ai_flags & AI_CANONNAME)
++	  goto process_list;
++	}
++
++#ifdef USE_NSCD
++      if (__nss_not_use_nscd_hosts > 0
++	  && ++__nss_not_use_nscd_hosts > NSS_NSCD_RETRY)
++	__nss_not_use_nscd_hosts = 0;
++
++      if (!__nss_not_use_nscd_hosts
++	  && !__nss_database_custom[NSS_DBSIDX_hosts])
++	{
++	  /* Try to use nscd.  */
++	  struct nscd_ai_result *air = NULL;
++	  int err = __nscd_getai (name, &air, &h_errno);
++	  if (air != NULL)
+ 	    {
+-	      char *canonbuf = __strdup (name);
+-	      if (canonbuf == NULL)
++	      /* Transform into gaih_addrtuple list.  */
++	      bool added_canon = (req->ai_flags & AI_CANONNAME) == 0;
++	      char *addrs = air->addrs;
++
++	      addrmem = calloc (air->naddrs, sizeof (*addrmem));
++	      if (addrmem == NULL)
+ 		{
+ 		  result = -EAI_MEMORY;
+ 		  goto free_and_return;
+ 		}
+-	      canon = canonbuf;
+-	    }
+
+-	  goto process_list;
+-	}
+-
+-      if ((req->ai_flags & AI_NUMERICHOST) == 0)
+-	{
+-	  int no_data = 0;
+-	  int no_inet6_data = 0;
+-	  nss_action_list nip;
+-	  enum nss_status inet6_status = NSS_STATUS_UNAVAIL;
+-	  enum nss_status status = NSS_STATUS_UNAVAIL;
+-	  int no_more;
+-	  struct resolv_context *res_ctx = NULL;
+-	  bool do_merge = false;
+-
+-	  /* If we do not have to look for IPv6 addresses or the canonical
+-	     name, use the simple, old functions, which do not support
+-	     IPv6 scope ids, nor retrieving the canonical name.  */
+-	  if (req->ai_family == AF_INET
+-	      && (req->ai_flags & AI_CANONNAME) == 0)
+-	    {
+-	      int rc;
+-	      struct hostent th;
+-	      struct hostent *h;
++	      struct gaih_addrtuple *addrfree = addrmem;
++	      struct gaih_addrtuple **pat = &res.at;
+
+-	      while (1)
++	      for (int i = 0; i < air->naddrs; ++i)
+ 		{
+-		  rc = __gethostbyname2_r (name, AF_INET, &th,
+-					   tmpbuf->data, tmpbuf->length,
+-					   &h, &h_errno);
+-		  if (rc != ERANGE || h_errno != NETDB_INTERNAL)
+-		    break;
+-		  if (!scratch_buffer_grow (tmpbuf))
++		  socklen_t size = (air->family[i] == AF_INET
++				    ? INADDRSZ : IN6ADDRSZ);
++
++		  if (!((air->family[i] == AF_INET
++			 && req->ai_family == AF_INET6
++			 && (req->ai_flags & AI_V4MAPPED) != 0)
++			|| req->ai_family == AF_UNSPEC
++			|| air->family[i] == req->ai_family))
+ 		    {
+-		      result = -EAI_MEMORY;
+-		      goto free_and_return;
++		      /* Skip over non-matching result.  */
++		      addrs += size;
++		      continue;
+ 		    }
+-		}
+
+-	      if (rc == 0)
+-		{
+-		  if (h != NULL)
++		  if (*pat == NULL)
++		    {
++		      *pat = addrfree++;
++		      (*pat)->scopeid = 0;
++		    }
++		  uint32_t *pataddr = (*pat)->addr;
++		  (*pat)->next = NULL;
++		  if (added_canon || air->canon == NULL)
++		    (*pat)->name = NULL;
++		  else if (res.canon == NULL)
+ 		    {
+-		      /* We found data, convert it.  */
+-		      if (!convert_hostent_to_gaih_addrtuple
+-			  (req, AF_INET, h, &addrmem))
++		      char *canonbuf = __strdup (air->canon);
++		      if (canonbuf == NULL)
+ 			{
+ 			  result = -EAI_MEMORY;
+ 			  goto free_and_return;
+ 			}
+-		      at = addrmem;
++		      res.canon = (*pat)->name = canonbuf;
+ 		    }
+-		  else
++
++		  if (air->family[i] == AF_INET
++		      && req->ai_family == AF_INET6
++		      && (req->ai_flags & AI_V4MAPPED))
+ 		    {
+-		      if (h_errno == NO_DATA)
+-			result = -EAI_NODATA;
+-		      else
+-			result = -EAI_NONAME;
+-		      goto free_and_return;
++		      (*pat)->family = AF_INET6;
++		      pataddr[3] = *(uint32_t *) addrs;
++		      pataddr[2] = htonl (0xffff);
++		      pataddr[1] = 0;
++		      pataddr[0] = 0;
++		      pat = &((*pat)->next);
++		      added_canon = true;
++		    }
++		  else if (req->ai_family == AF_UNSPEC
++			   || air->family[i] == req->ai_family)
++		    {
++		      (*pat)->family = air->family[i];
++		      memcpy (pataddr, addrs, size);
++		      pat = &((*pat)->next);
++		      added_canon = true;
++		      if (air->family[i] == AF_INET6)
++			got_ipv6 = true;
+ 		    }
++		  addrs += size;
+ 		}
+-	      else
+-		{
+-		  if (h_errno == NETDB_INTERNAL)
+-		    result = -EAI_SYSTEM;
+-		  else if (h_errno == TRY_AGAIN)
+-		    result = -EAI_AGAIN;
+-		  else
+-		    /* We made requests but they turned out no data.
+-		       The name is known, though.  */
+-		    result = -EAI_NODATA;
+
+-		  goto free_and_return;
+-		}
++	      free (air);
+
+ 	      goto process_list;
+ 	    }
++	  else if (err == 0)
++	    /* The database contains a negative entry.  */
++	    goto free_and_return;
++	  else if (__nss_not_use_nscd_hosts == 0)
++	    {
++	      if (h_errno == NETDB_INTERNAL && errno == ENOMEM)
++		result = -EAI_MEMORY;
++	      else if (h_errno == TRY_AGAIN)
++		result = -EAI_AGAIN;
++	      else
++		result = -EAI_SYSTEM;
+
+-#ifdef USE_NSCD
+-	  if (__nss_not_use_nscd_hosts > 0
+-	      && ++__nss_not_use_nscd_hosts > NSS_NSCD_RETRY)
+-	    __nss_not_use_nscd_hosts = 0;
++	      goto free_and_return;
++	    }
++	}
++#endif
++
++      no_more = !__nss_database_get (nss_database_hosts, &nip);
+
+-	  if (!__nss_not_use_nscd_hosts
+-	      && !__nss_database_custom[NSS_DBSIDX_hosts])
++      /* If we are looking for both IPv4 and IPv6 address we don't
++	 want the lookup functions to automatically promote IPv4
++	 addresses to IPv6 addresses, so we use the no_inet6
++	 function variant.  */
++      res_ctx = __resolv_context_get ();
++      if (res_ctx == NULL)
++	no_more = 1;
++
++      while (!no_more)
++	{
++	  /* Always start afresh; continue should discard previous results
++	     and the hosts database does not support merge.  */
++	  res.at = NULL;
++	  free (res.canon);
++	  free (addrmem);
++	  res.canon = NULL;
++	  addrmem = NULL;
++	  got_ipv6 = false;
++
++	  if (do_merge)
+ 	    {
+-	      /* Try to use nscd.  */
+-	      struct nscd_ai_result *air = NULL;
+-	      int err = __nscd_getai (name, &air, &h_errno);
+-	      if (air != NULL)
++	      __set_h_errno (NETDB_INTERNAL);
++	      __set_errno (EBUSY);
++	      break;
++	    }
++
++	  no_data = 0;
++	  nss_gethostbyname4_r *fct4 = NULL;
++
++	  /* gethostbyname4_r sends out parallel A and AAAA queries and
++	     is thus only suitable for PF_UNSPEC.  */
++	  if (req->ai_family == PF_UNSPEC)
++	    fct4 = __nss_lookup_function (nip, "gethostbyname4_r");
++
++	  if (fct4 != NULL)
++	    {
++	      while (1)
+ 		{
+-		  /* Transform into gaih_addrtuple list.  */
+-		  bool added_canon = (req->ai_flags & AI_CANONNAME) == 0;
+-		  char *addrs = air->addrs;
++		  status = DL_CALL_FCT (fct4, (name, &res.at,
++					       tmpbuf->data, tmpbuf->length,
++					       &errno, &h_errno,
++					       NULL));
++		  if (status == NSS_STATUS_SUCCESS)
++		    break;
++		  /* gethostbyname4_r may write into AT, so reset it.  */
++		  res.at = NULL;
++		  if (status != NSS_STATUS_TRYAGAIN
++		      || errno != ERANGE || h_errno != NETDB_INTERNAL)
++		    {
++		      if (h_errno == TRY_AGAIN)
++			no_data = EAI_AGAIN;
++		      else
++			no_data = h_errno == NO_DATA;
++		      break;
++		    }
+
+-		  addrmem = calloc (air->naddrs, sizeof (*addrmem));
+-		  if (addrmem == NULL)
++		  if (!scratch_buffer_grow (tmpbuf))
+ 		    {
++		      __resolv_context_put (res_ctx);
+ 		      result = -EAI_MEMORY;
+ 		      goto free_and_return;
+ 		    }
++		}
+
+-		  struct gaih_addrtuple *addrfree = addrmem;
+-		  struct gaih_addrtuple **pat = &at;
++	      if (status == NSS_STATUS_SUCCESS)
++		{
++		  assert (!no_data);
++		  no_data = 1;
+
+-		  for (int i = 0; i < air->naddrs; ++i)
++		  if ((req->ai_flags & AI_CANONNAME) != 0 && res.canon == NULL)
+ 		    {
+-		      socklen_t size = (air->family[i] == AF_INET
+-					? INADDRSZ : IN6ADDRSZ);
+-
+-		      if (!((air->family[i] == AF_INET
+-			     && req->ai_family == AF_INET6
+-			     && (req->ai_flags & AI_V4MAPPED) != 0)
+-			    || req->ai_family == AF_UNSPEC
+-			    || air->family[i] == req->ai_family))
++		      char *canonbuf = __strdup (res.at->name);
++		      if (canonbuf == NULL)
+ 			{
+-			  /* Skip over non-matching result.  */
+-			  addrs += size;
+-			  continue;
++			  __resolv_context_put (res_ctx);
++			  result = -EAI_MEMORY;
++			  goto free_and_return;
+ 			}
++		      res.canon = canonbuf;
++		    }
+
+-		      if (*pat == NULL)
+-			{
+-			  *pat = addrfree++;
+-			  (*pat)->scopeid = 0;
+-			}
+-		      uint32_t *pataddr = (*pat)->addr;
+-		      (*pat)->next = NULL;
+-		      if (added_canon || air->canon == NULL)
+-			(*pat)->name = NULL;
+-		      else if (canon == NULL)
+-			{
+-			  char *canonbuf = __strdup (air->canon);
+-			  if (canonbuf == NULL)
+-			    {
+-			      result = -EAI_MEMORY;
+-			      goto free_and_return;
+-			    }
+-			  canon = (*pat)->name = canonbuf;
+-			}
++		  struct gaih_addrtuple **pat = &res.at;
+
+-		      if (air->family[i] == AF_INET
++		  while (*pat != NULL)
++		    {
++		      if ((*pat)->family == AF_INET
+ 			  && req->ai_family == AF_INET6
+-			  && (req->ai_flags & AI_V4MAPPED))
++			  && (req->ai_flags & AI_V4MAPPED) != 0)
+ 			{
++			  uint32_t *pataddr = (*pat)->addr;
+ 			  (*pat)->family = AF_INET6;
+-			  pataddr[3] = *(uint32_t *) addrs;
++			  pataddr[3] = pataddr[0];
+ 			  pataddr[2] = htonl (0xffff);
+ 			  pataddr[1] = 0;
+ 			  pataddr[0] = 0;
+ 			  pat = &((*pat)->next);
+-			  added_canon = true;
++			  no_data = 0;
+ 			}
+ 		      else if (req->ai_family == AF_UNSPEC
+-			       || air->family[i] == req->ai_family)
++			       || (*pat)->family == req->ai_family)
+ 			{
+-			  (*pat)->family = air->family[i];
+-			  memcpy (pataddr, addrs, size);
+ 			  pat = &((*pat)->next);
+-			  added_canon = true;
+-			  if (air->family[i] == AF_INET6)
++
++			  no_data = 0;
++			  if (req->ai_family == AF_INET6)
+ 			    got_ipv6 = true;
+ 			}
+-		      addrs += size;
++		      else
++			*pat = ((*pat)->next);
+ 		    }
+-
+-		  free (air);
+-
+-		  goto process_list;
+ 		}
+-	      else if (err == 0)
+-		/* The database contains a negative entry.  */
+-		goto free_and_return;
+-	      else if (__nss_not_use_nscd_hosts == 0)
+-		{
+-		  if (h_errno == NETDB_INTERNAL && errno == ENOMEM)
+-		    result = -EAI_MEMORY;
+-		  else if (h_errno == TRY_AGAIN)
+-		    result = -EAI_AGAIN;
+-		  else
+-		    result = -EAI_SYSTEM;
+
+-		  goto free_and_return;
+-		}
++	      no_inet6_data = no_data;
+ 	    }
+-#endif
+-
+-	  no_more = !__nss_database_get (nss_database_hosts, &nip);
+-
+-	  /* If we are looking for both IPv4 and IPv6 address we don't
+-	     want the lookup functions to automatically promote IPv4
+-	     addresses to IPv6 addresses, so we use the no_inet6
+-	     function variant.  */
+-	  res_ctx = __resolv_context_get ();
+-	  if (res_ctx == NULL)
+-	    no_more = 1;
+-
+-	  while (!no_more)
++	  else
+ 	    {
+-	      /* Always start afresh; continue should discard previous results
+-		 and the hosts database does not support merge.  */
+-	      at = NULL;
+-	      free (canon);
+-	      free (addrmem);
+-	      canon = NULL;
+-	      addrmem = NULL;
+-	      got_ipv6 = false;
+-
+-	      if (do_merge)
++	      nss_gethostbyname3_r *fct = NULL;
++	      if (req->ai_flags & AI_CANONNAME)
++		/* No need to use this function if we do not look for
++		   the canonical name.  The function does not exist in
++		   all NSS modules and therefore the lookup would
++		   often fail.  */
++		fct = __nss_lookup_function (nip, "gethostbyname3_r");
++	      if (fct == NULL)
++		/* We are cheating here.  The gethostbyname2_r
++		   function does not have the same interface as
++		   gethostbyname3_r but the extra arguments the
++		   latter takes are added at the end.  So the
++		   gethostbyname2_r code will just ignore them.  */
++		fct = __nss_lookup_function (nip, "gethostbyname2_r");
++
++	      if (fct != NULL)
+ 		{
+-		  __set_h_errno (NETDB_INTERNAL);
+-		  __set_errno (EBUSY);
+-		  break;
+-		}
+-
+-	      no_data = 0;
+-	      nss_gethostbyname4_r *fct4 = NULL;
+-
+-	      /* gethostbyname4_r sends out parallel A and AAAA queries and
+-		 is thus only suitable for PF_UNSPEC.  */
+-	      if (req->ai_family == PF_UNSPEC)
+-		fct4 = __nss_lookup_function (nip, "gethostbyname4_r");
++		  struct gaih_addrtuple **pat = &res.at;
+
+-	      if (fct4 != NULL)
+-		{
+-		  while (1)
++		  if (req->ai_family == AF_INET6
++		      || req->ai_family == AF_UNSPEC)
+ 		    {
+-		      status = DL_CALL_FCT (fct4, (name, &at,
+-						   tmpbuf->data, tmpbuf->length,
+-						   &errno, &h_errno,
+-						   NULL));
+-		      if (status == NSS_STATUS_SUCCESS)
+-			break;
+-		      /* gethostbyname4_r may write into AT, so reset it.  */
+-		      at = NULL;
+-		      if (status != NSS_STATUS_TRYAGAIN
+-			  || errno != ERANGE || h_errno != NETDB_INTERNAL)
+-			{
+-			  if (h_errno == TRY_AGAIN)
+-			    no_data = EAI_AGAIN;
+-			  else
+-			    no_data = h_errno == NO_DATA;
+-			  break;
+-			}
++		      gethosts (AF_INET6);
++		      no_inet6_data = no_data;
++		      inet6_status = status;
++		    }
++		  if (req->ai_family == AF_INET
++		      || req->ai_family == AF_UNSPEC
++		      || (req->ai_family == AF_INET6
++			  && (req->ai_flags & AI_V4MAPPED)
++			  /* Avoid generating the mapped addresses if we
++			     know we are not going to need them.  */
++			  && ((req->ai_flags & AI_ALL) || !got_ipv6)))
++		    {
++		      gethosts (AF_INET);
+
+-		      if (!scratch_buffer_grow (tmpbuf))
++		      if (req->ai_family == AF_INET)
+ 			{
+-			  __resolv_context_put (res_ctx);
+-			  result = -EAI_MEMORY;
+-			  goto free_and_return;
++			  no_inet6_data = no_data;
++			  inet6_status = status;
+ 			}
+ 		    }
+
+-		  if (status == NSS_STATUS_SUCCESS)
++		  /* If we found one address for AF_INET or AF_INET6,
++		     don't continue the search.  */
++		  if (inet6_status == NSS_STATUS_SUCCESS
++		      || status == NSS_STATUS_SUCCESS)
+ 		    {
+-		      assert (!no_data);
+-		      no_data = 1;
+-
+-		      if ((req->ai_flags & AI_CANONNAME) != 0 && canon == NULL)
++		      if ((req->ai_flags & AI_CANONNAME) != 0
++			  && res.canon == NULL)
+ 			{
+-			  char *canonbuf = __strdup (at->name);
++			  char *canonbuf = getcanonname (nip, res.at, name);
+ 			  if (canonbuf == NULL)
+ 			    {
+ 			      __resolv_context_put (res_ctx);
+ 			      result = -EAI_MEMORY;
+ 			      goto free_and_return;
+ 			    }
+-			  canon = canonbuf;
+-			}
+-
+-		      struct gaih_addrtuple **pat = &at;
+-
+-		      while (*pat != NULL)
+-			{
+-			  if ((*pat)->family == AF_INET
+-			      && req->ai_family == AF_INET6
+-			      && (req->ai_flags & AI_V4MAPPED) != 0)
+-			    {
+-			      uint32_t *pataddr = (*pat)->addr;
+-			      (*pat)->family = AF_INET6;
+-			      pataddr[3] = pataddr[0];
+-			      pataddr[2] = htonl (0xffff);
+-			      pataddr[1] = 0;
+-			      pataddr[0] = 0;
+-			      pat = &((*pat)->next);
+-			      no_data = 0;
+-			    }
+-			  else if (req->ai_family == AF_UNSPEC
+-				   || (*pat)->family == req->ai_family)
+-			    {
+-			      pat = &((*pat)->next);
+-
+-			      no_data = 0;
+-			      if (req->ai_family == AF_INET6)
+-				got_ipv6 = true;
+-			    }
+-			  else
+-			    *pat = ((*pat)->next);
+-			}
+-		    }
+-
+-		  no_inet6_data = no_data;
+-		}
+-	      else
+-		{
+-		  nss_gethostbyname3_r *fct = NULL;
+-		  if (req->ai_flags & AI_CANONNAME)
+-		    /* No need to use this function if we do not look for
+-		       the canonical name.  The function does not exist in
+-		       all NSS modules and therefore the lookup would
+-		       often fail.  */
+-		    fct = __nss_lookup_function (nip, "gethostbyname3_r");
+-		  if (fct == NULL)
+-		    /* We are cheating here.  The gethostbyname2_r
+-		       function does not have the same interface as
+-		       gethostbyname3_r but the extra arguments the
+-		       latter takes are added at the end.  So the
+-		       gethostbyname2_r code will just ignore them.  */
+-		    fct = __nss_lookup_function (nip, "gethostbyname2_r");
+-
+-		  if (fct != NULL)
+-		    {
+-		      struct gaih_addrtuple **pat = &at;
+-
+-		      if (req->ai_family == AF_INET6
+-			  || req->ai_family == AF_UNSPEC)
+-			{
+-			  gethosts (AF_INET6);
+-			  no_inet6_data = no_data;
+-			  inet6_status = status;
+-			}
+-		      if (req->ai_family == AF_INET
+-			  || req->ai_family == AF_UNSPEC
+-			  || (req->ai_family == AF_INET6
+-			      && (req->ai_flags & AI_V4MAPPED)
+-			      /* Avoid generating the mapped addresses if we
+-				 know we are not going to need them.  */
+-			      && ((req->ai_flags & AI_ALL) || !got_ipv6)))
+-			{
+-			  gethosts (AF_INET);
+-
+-			  if (req->ai_family == AF_INET)
+-			    {
+-			      no_inet6_data = no_data;
+-			      inet6_status = status;
+-			    }
+-			}
+-
+-		      /* If we found one address for AF_INET or AF_INET6,
+-			 don't continue the search.  */
+-		      if (inet6_status == NSS_STATUS_SUCCESS
+-			  || status == NSS_STATUS_SUCCESS)
+-			{
+-			  if ((req->ai_flags & AI_CANONNAME) != 0
+-			      && canon == NULL)
+-			    {
+-			      char *canonbuf = getcanonname (nip, at, name);
+-			      if (canonbuf == NULL)
+-				{
+-				  __resolv_context_put (res_ctx);
+-				  result = -EAI_MEMORY;
+-				  goto free_and_return;
+-				}
+-			      canon = canonbuf;
+-			    }
+-			  status = NSS_STATUS_SUCCESS;
+-			}
+-		      else
+-			{
+-			  /* We can have different states for AF_INET and
+-			     AF_INET6.  Try to find a useful one for both.  */
+-			  if (inet6_status == NSS_STATUS_TRYAGAIN)
+-			    status = NSS_STATUS_TRYAGAIN;
+-			  else if (status == NSS_STATUS_UNAVAIL
+-				   && inet6_status != NSS_STATUS_UNAVAIL)
+-			    status = inet6_status;
++			  res.canon = canonbuf;
+ 			}
++		      status = NSS_STATUS_SUCCESS;
+ 		    }
+ 		  else
+ 		    {
+-		      /* Could not locate any of the lookup functions.
+-			 The NSS lookup code does not consistently set
+-			 errno, so we need to supply our own error
+-			 code here.  The root cause could either be a
+-			 resource allocation failure, or a missing
+-			 service function in the DSO (so it should not
+-			 be listed in /etc/nsswitch.conf).  Assume the
+-			 former, and return EBUSY.  */
+-		      status = NSS_STATUS_UNAVAIL;
+-		     __set_h_errno (NETDB_INTERNAL);
+-		     __set_errno (EBUSY);
++		      /* We can have different states for AF_INET and
++			 AF_INET6.  Try to find a useful one for both.  */
++		      if (inet6_status == NSS_STATUS_TRYAGAIN)
++			status = NSS_STATUS_TRYAGAIN;
++		      else if (status == NSS_STATUS_UNAVAIL
++			       && inet6_status != NSS_STATUS_UNAVAIL)
++			status = inet6_status;
+ 		    }
+ 		}
++	      else
++		{
++		  /* Could not locate any of the lookup functions.
++		     The NSS lookup code does not consistently set
++		     errno, so we need to supply our own error
++		     code here.  The root cause could either be a
++		     resource allocation failure, or a missing
++		     service function in the DSO (so it should not
++		     be listed in /etc/nsswitch.conf).  Assume the
++		     former, and return EBUSY.  */
++		  status = NSS_STATUS_UNAVAIL;
++		  __set_h_errno (NETDB_INTERNAL);
++		  __set_errno (EBUSY);
++		}
++	    }
+
+-	      if (nss_next_action (nip, status) == NSS_ACTION_RETURN)
+-		break;
++	  if (nss_next_action (nip, status) == NSS_ACTION_RETURN)
++	    break;
+
+-	      /* The hosts database does not support MERGE.  */
+-	      if (nss_next_action (nip, status) == NSS_ACTION_MERGE)
+-		do_merge = true;
++	  /* The hosts database does not support MERGE.  */
++	  if (nss_next_action (nip, status) == NSS_ACTION_MERGE)
++	    do_merge = true;
+
+-	      nip++;
+-	      if (nip->module == NULL)
+-		no_more = -1;
+-	    }
++	  nip++;
++	  if (nip->module == NULL)
++	    no_more = -1;
++	}
+
+-	  __resolv_context_put (res_ctx);
++      __resolv_context_put (res_ctx);
+
+-	  /* If we have a failure which sets errno, report it using
+-	     EAI_SYSTEM.  */
+-	  if ((status == NSS_STATUS_TRYAGAIN || status == NSS_STATUS_UNAVAIL)
+-	      && h_errno == NETDB_INTERNAL)
+-	    {
+-	      result = -EAI_SYSTEM;
+-	      goto free_and_return;
+-	    }
++      /* If we have a failure which sets errno, report it using
++	 EAI_SYSTEM.  */
++      if ((status == NSS_STATUS_TRYAGAIN || status == NSS_STATUS_UNAVAIL)
++	  && h_errno == NETDB_INTERNAL)
++	{
++	  result = -EAI_SYSTEM;
++	  goto free_and_return;
++	}
+
+-	  if (no_data != 0 && no_inet6_data != 0)
+-	    {
+-	      /* If both requests timed out report this.  */
+-	      if (no_data == EAI_AGAIN && no_inet6_data == EAI_AGAIN)
+-		result = -EAI_AGAIN;
+-	      else
+-		/* We made requests but they turned out no data.  The name
+-		   is known, though.  */
+-		result = -EAI_NODATA;
++      if (no_data != 0 && no_inet6_data != 0)
++	{
++	  /* If both requests timed out report this.  */
++	  if (no_data == EAI_AGAIN && no_inet6_data == EAI_AGAIN)
++	    result = -EAI_AGAIN;
++	  else
++	    /* We made requests but they turned out no data.  The name
++	       is known, though.  */
++	    result = -EAI_NODATA;
+
+-	      goto free_and_return;
+-	    }
++	  goto free_and_return;
+ 	}
+
+     process_list:
+-      if (at == NULL)
++      if (res.at == NULL)
+ 	{
+ 	  result = -EAI_NONAME;
+ 	  goto free_and_return;
+@@ -1032,21 +1044,22 @@ gaih_inet (const char *name, const struct gaih_service *service,
+   else
+     {
+       struct gaih_addrtuple *atr;
+-      atr = at = alloca_account (sizeof (struct gaih_addrtuple), alloca_used);
+-      memset (at, '\0', sizeof (struct gaih_addrtuple));
++      atr = res.at = alloca_account (sizeof (struct gaih_addrtuple),
++				     alloca_used);
++      memset (res.at, '\0', sizeof (struct gaih_addrtuple));
+
+       if (req->ai_family == AF_UNSPEC)
+ 	{
+-	  at->next = __alloca (sizeof (struct gaih_addrtuple));
+-	  memset (at->next, '\0', sizeof (struct gaih_addrtuple));
++	  res.at->next = __alloca (sizeof (struct gaih_addrtuple));
++	  memset (res.at->next, '\0', sizeof (struct gaih_addrtuple));
+ 	}
+
+       if (req->ai_family == AF_UNSPEC || req->ai_family == AF_INET6)
+ 	{
+-	  at->family = AF_INET6;
++	  res.at->family = AF_INET6;
+ 	  if ((req->ai_flags & AI_PASSIVE) == 0)
+-	    memcpy (at->addr, &in6addr_loopback, sizeof (struct in6_addr));
+-	  atr = at->next;
++	    memcpy (res.at->addr, &in6addr_loopback, sizeof (struct in6_addr));
++	  atr = res.at->next;
+ 	}
+
+       if (req->ai_family == AF_UNSPEC || req->ai_family == AF_INET)
+@@ -1059,10 +1072,10 @@ gaih_inet (const char *name, const struct gaih_service *service,
+
+   {
+     /* Set up the canonical name if we need it.  */
+-    if ((result = process_canonname (req, orig_name, &canon)) != 0)
++    if ((result = process_canonname (req, orig_name, &res)) != 0)
+       goto free_and_return;
+
+-    struct gaih_addrtuple *at2 = at;
++    struct gaih_addrtuple *at2 = res.at;
+     size_t socklen;
+     sa_family_t family;
+
+@@ -1105,8 +1118,8 @@ gaih_inet (const char *name, const struct gaih_service *service,
+ 	    ai->ai_addr = (void *) (ai + 1);
+
+ 	    /* We only add the canonical name once.  */
+-	    ai->ai_canonname = (char *) canon;
+-	    canon = NULL;
++	    ai->ai_canonname = res.canon;
++	    res.canon = NULL;
+
+ #ifdef _HAVE_SA_LEN
+ 	    ai->ai_addr->sa_len = socklen;
+@@ -1152,7 +1165,7 @@ gaih_inet (const char *name, const struct gaih_service *service,
+   if (malloc_name)
+     free ((char *) name);
+   free (addrmem);
+-  free (canon);
++  free (res.canon);
+
+   return result;
+ }
+
+From 4897bf79689d38bb20a7ee5061ccc8221101c360 Mon Sep 17 00:00:00 2001
+From: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Date: Fri, 4 Mar 2022 14:57:12 +0530
+Subject: [PATCH] gaih_inet: Split simple gethostbyname into its own function
+
+Add a free_at flag in gaih_result to indicate if res.at needs to be
+freed by the caller.
+
+Signed-off-by: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Reviewed-by: DJ Delorie <dj@redhat.com>
+(cherry picked from commit b44389cb7fa28a59804571dac09cc32ebfac03d1)
+---
+ sysdeps/posix/getaddrinfo.c | 127 ++++++++++++++++++------------------
+ 1 file changed, 64 insertions(+), 63 deletions(-)
+
+diff --git a/sysdeps/posix/getaddrinfo.c b/sysdeps/posix/getaddrinfo.c
+index 19bb13db59..1137c959ac 100644
+--- a/sysdeps/posix/getaddrinfo.c
++++ b/sysdeps/posix/getaddrinfo.c
+@@ -120,6 +120,7 @@ struct gaih_result
+ {
+   struct gaih_addrtuple *at;
+   char *canon;
++  bool free_at;
+ };
+
+ /* Values for `protoflag'.  */
+@@ -565,6 +566,62 @@ out:
+   return result;
+ }
+
++/* If possible, call the simple, old functions, which do not support IPv6 scope
++   ids, nor retrieving the canonical name.  */
++
++static int
++try_simple_gethostbyname (const char *name, const struct addrinfo *req,
++			  struct scratch_buffer *tmpbuf,
++			  struct gaih_result *res)
++{
++  res->at = NULL;
++
++  if (req->ai_family != AF_INET || (req->ai_flags & AI_CANONNAME) != 0)
++    return 0;
++
++  int rc;
++  struct hostent th;
++  struct hostent *h;
++
++  while (1)
++    {
++      rc = __gethostbyname2_r (name, AF_INET, &th, tmpbuf->data,
++			       tmpbuf->length, &h, &h_errno);
++      if (rc != ERANGE || h_errno != NETDB_INTERNAL)
++	break;
++      if (!scratch_buffer_grow (tmpbuf))
++	return -EAI_MEMORY;
++    }
++
++  if (rc == 0)
++    {
++      if (h != NULL)
++	{
++	  /* We found data, convert it.  RES->AT from the conversion will
++	     either be an allocated block or NULL, both of which are safe to
++	     pass to free ().  */
++	  if (!convert_hostent_to_gaih_addrtuple (req, AF_INET, h, &res->at))
++	    return -EAI_MEMORY;
++
++	  res->free_at = true;
++	  return 0;
++	}
++      if (h_errno == NO_DATA)
++	return -EAI_NODATA;
++
++      return -EAI_NONAME;
++    }
++
++  if (h_errno == NETDB_INTERNAL)
++    return -EAI_SYSTEM;
++  if (h_errno == TRY_AGAIN)
++    return -EAI_AGAIN;
++
++  /* We made requests but they turned out no data.
++     The name is known, though.  */
++  return -EAI_NODATA;
++}
++
+ static int
+ gaih_inet (const char *name, const struct gaih_service *service,
+ 	   const struct addrinfo *req, struct addrinfo **pai,
+@@ -610,6 +667,11 @@ gaih_inet (const char *name, const struct gaih_service *service,
+       else if (res.at != NULL)
+ 	goto process_list;
+
++      if ((result = try_simple_gethostbyname (name, req, tmpbuf, &res)) != 0)
++	goto free_and_return;
++      else if (res.at != NULL)
++	goto process_list;
++
+       int no_data = 0;
+       int no_inet6_data = 0;
+       nss_action_list nip;
+@@ -619,69 +681,6 @@ gaih_inet (const char *name, const struct gaih_service *service,
+       struct resolv_context *res_ctx = NULL;
+       bool do_merge = false;
+
+-      /* If we do not have to look for IPv6 addresses or the canonical
+-	 name, use the simple, old functions, which do not support
+-	 IPv6 scope ids, nor retrieving the canonical name.  */
+-      if (req->ai_family == AF_INET
+-	  && (req->ai_flags & AI_CANONNAME) == 0)
+-	{
+-	  int rc;
+-	  struct hostent th;
+-	  struct hostent *h;
+-
+-	  while (1)
+-	    {
+-	      rc = __gethostbyname2_r (name, AF_INET, &th,
+-				       tmpbuf->data, tmpbuf->length,
+-				       &h, &h_errno);
+-	      if (rc != ERANGE || h_errno != NETDB_INTERNAL)
+-		break;
+-	      if (!scratch_buffer_grow (tmpbuf))
+-		{
+-		  result = -EAI_MEMORY;
+-		  goto free_and_return;
+-		}
+-	    }
+-
+-	  if (rc == 0)
+-	    {
+-	      if (h != NULL)
+-		{
+-		  /* We found data, convert it.  */
+-		  if (!convert_hostent_to_gaih_addrtuple
+-		      (req, AF_INET, h, &addrmem))
+-		    {
+-		      result = -EAI_MEMORY;
+-		      goto free_and_return;
+-		    }
+-		  res.at = addrmem;
+-		}
+-	      else
+-		{
+-		  if (h_errno == NO_DATA)
+-		    result = -EAI_NODATA;
+-		  else
+-		    result = -EAI_NONAME;
+-		  goto free_and_return;
+-		}
+-	    }
+-	  else
+-	    {
+-	      if (h_errno == NETDB_INTERNAL)
+-		result = -EAI_SYSTEM;
+-	      else if (h_errno == TRY_AGAIN)
+-		result = -EAI_AGAIN;
+-	      else
+-		/* We made requests but they turned out no data.
+-		   The name is known, though.  */
+-		result = -EAI_NODATA;
+-
+-	      goto free_and_return;
+-	    }
+-
+-	  goto process_list;
+-	}
+-
+ #ifdef USE_NSCD
+       if (__nss_not_use_nscd_hosts > 0
+ 	  && ++__nss_not_use_nscd_hosts > NSS_NSCD_RETRY)
+@@ -1165,6 +1164,8 @@ gaih_inet (const char *name, const struct gaih_service *service,
+   if (malloc_name)
+     free ((char *) name);
+   free (addrmem);
++  if (res.free_at)
++    free (res.at);
+   free (res.canon);
+
+   return result;
+
+From ce64e72b7da09f97c91a5acf5c36a32778a9fa60 Mon Sep 17 00:00:00 2001
+From: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Date: Mon, 7 Mar 2022 15:53:45 +0530
+Subject: [PATCH] gaih_inet: Split nscd lookup code into its own function.
+
+Add a new member got_ipv6 to indicate if the results have an IPv6
+result and use it instead of the local got_ipv6.
+
+Signed-off-by: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Reviewed-by: DJ Delorie <dj@redhat.com>
+(cherry picked from commit e7e5315b7fa065a9c8bf525ca9a32f46fa4837e5)
+---
+ sysdeps/posix/getaddrinfo.c | 248 +++++++++++++++++++-----------------
+ 1 file changed, 134 insertions(+), 114 deletions(-)
+
+diff --git a/sysdeps/posix/getaddrinfo.c b/sysdeps/posix/getaddrinfo.c
+index 1137c959ac..01be932b3f 100644
+--- a/sysdeps/posix/getaddrinfo.c
++++ b/sysdeps/posix/getaddrinfo.c
+@@ -121,6 +121,7 @@ struct gaih_result
+   struct gaih_addrtuple *at;
+   char *canon;
+   bool free_at;
++  bool got_ipv6;
+ };
+
+ /* Values for `protoflag'.  */
+@@ -316,7 +317,7 @@ convert_hostent_to_gaih_addrtuple (const struct addrinfo *req,
+ 	  res.canon = canonbuf;						      \
+ 	}								      \
+       if (_family == AF_INET6 && *pat != NULL)				      \
+-	got_ipv6 = true;						      \
++	res.got_ipv6 = true;						      \
+     }									      \
+  }
+
+@@ -467,6 +468,128 @@ get_servtuples (const struct gaih_service *service, const struct addrinfo *req,
+   return 0;
+ }
+
++#ifdef USE_NSCD
++/* Query addresses from nscd cache, returning a non-zero value on error.
++   RES members have the lookup result; RES->AT is NULL if there were no errors
++   but also no results.  */
++
++static int
++get_nscd_addresses (const char *name, const struct addrinfo *req,
++		    struct gaih_result *res)
++{
++  if (__nss_not_use_nscd_hosts > 0
++      && ++__nss_not_use_nscd_hosts > NSS_NSCD_RETRY)
++    __nss_not_use_nscd_hosts = 0;
++
++  res->at = NULL;
++
++  if (__nss_not_use_nscd_hosts || __nss_database_custom[NSS_DBSIDX_hosts])
++    return 0;
++
++  /* Try to use nscd.  */
++  struct nscd_ai_result *air = NULL;
++  int err = __nscd_getai (name, &air, &h_errno);
++
++  if (__glibc_unlikely (air == NULL))
++    {
++      /* The database contains a negative entry.  */
++      if (err == 0)
++	return -EAI_NONAME;
++      if (__nss_not_use_nscd_hosts == 0)
++	{
++	  if (h_errno == NETDB_INTERNAL && errno == ENOMEM)
++	    return -EAI_MEMORY;
++	  if (h_errno == TRY_AGAIN)
++	    return -EAI_AGAIN;
++	  return -EAI_SYSTEM;
++	}
++      return 0;
++    }
++
++  /* Transform into gaih_addrtuple list.  */
++  int result = 0;
++  char *addrs = air->addrs;
++
++  struct gaih_addrtuple *addrfree = calloc (air->naddrs, sizeof (*addrfree));
++  struct gaih_addrtuple *at = calloc (air->naddrs, sizeof (*at));
++  if (at == NULL)
++    {
++      result = -EAI_MEMORY;
++      goto out;
++    }
++
++  res->free_at = true;
++
++  int count = 0;
++  for (int i = 0; i < air->naddrs; ++i)
++    {
++      socklen_t size = (air->family[i] == AF_INET
++			? INADDRSZ : IN6ADDRSZ);
++
++      if (!((air->family[i] == AF_INET
++	     && req->ai_family == AF_INET6
++	     && (req->ai_flags & AI_V4MAPPED) != 0)
++	    || req->ai_family == AF_UNSPEC
++	    || air->family[i] == req->ai_family))
++	{
++	  /* Skip over non-matching result.  */
++	  addrs += size;
++	  continue;
++	}
++
++      if (air->family[i] == AF_INET && req->ai_family == AF_INET6
++	  && (req->ai_flags & AI_V4MAPPED))
++	{
++	  at[count].family = AF_INET6;
++	  at[count].addr[3] = *(uint32_t *) addrs;
++	  at[count].addr[2] = htonl (0xffff);
++	}
++      else if (req->ai_family == AF_UNSPEC
++	       || air->family[count] == req->ai_family)
++	{
++	  at[count].family = air->family[count];
++	  memcpy (at[count].addr, addrs, size);
++	  if (air->family[count] == AF_INET6)
++	    res->got_ipv6 = true;
++	}
++      at[count].next = at + count + 1;
++      count++;
++      addrs += size;
++    }
++
++  if ((req->ai_flags & AI_CANONNAME) && air->canon != NULL)
++    {
++      char *canonbuf = __strdup (air->canon);
++      if (canonbuf == NULL)
++	{
++	  result = -EAI_MEMORY;
++	  goto out;
++	}
++      res->canon = canonbuf;
++    }
++
++  if (count == 0)
++    {
++      result = -EAI_NONAME;
++      goto out;
++    }
++
++  at[count - 1].next = NULL;
++
++  res->at = at;
++
++out:
++  free (air);
++  if (result != 0)
++    {
++      free (at);
++      res->free_at = false;
++    }
++
++  return result;
++}
++#endif
++
+ /* Convert numeric addresses to binary into RES.  On failure, RES->AT is set to
+    NULL and an error code is returned.  If AI_NUMERIC_HOST is not requested and
+    the function cannot determine a result, RES->AT is set to NULL and 0
+@@ -630,7 +753,6 @@ gaih_inet (const char *name, const struct gaih_service *service,
+   struct gaih_servtuple st[sizeof (gaih_inet_typeproto)
+ 			   / sizeof (struct gaih_typeproto)] = {0};
+
+-  bool got_ipv6 = false;
+   const char *orig_name = name;
+
+   /* Reserve stack memory for the scratch buffer in the getaddrinfo
+@@ -672,6 +794,13 @@ gaih_inet (const char *name, const struct gaih_service *service,
+       else if (res.at != NULL)
+ 	goto process_list;
+
++#ifdef USE_NSCD
++      if ((result = get_nscd_addresses (name, req, &res)) != 0)
++	goto free_and_return;
++      else if (res.at != NULL)
++	goto process_list;
++#endif
++
+       int no_data = 0;
+       int no_inet6_data = 0;
+       nss_action_list nip;
+@@ -681,115 +810,6 @@ gaih_inet (const char *name, const struct gaih_service *service,
+       struct resolv_context *res_ctx = NULL;
+       bool do_merge = false;
+
+-#ifdef USE_NSCD
+-      if (__nss_not_use_nscd_hosts > 0
+-	  && ++__nss_not_use_nscd_hosts > NSS_NSCD_RETRY)
+-	__nss_not_use_nscd_hosts = 0;
+-
+-      if (!__nss_not_use_nscd_hosts
+-	  && !__nss_database_custom[NSS_DBSIDX_hosts])
+-	{
+-	  /* Try to use nscd.  */
+-	  struct nscd_ai_result *air = NULL;
+-	  int err = __nscd_getai (name, &air, &h_errno);
+-	  if (air != NULL)
+-	    {
+-	      /* Transform into gaih_addrtuple list.  */
+-	      bool added_canon = (req->ai_flags & AI_CANONNAME) == 0;
+-	      char *addrs = air->addrs;
+-
+-	      addrmem = calloc (air->naddrs, sizeof (*addrmem));
+-	      if (addrmem == NULL)
+-		{
+-		  result = -EAI_MEMORY;
+-		  goto free_and_return;
+-		}
+-
+-	      struct gaih_addrtuple *addrfree = addrmem;
+-	      struct gaih_addrtuple **pat = &res.at;
+-
+-	      for (int i = 0; i < air->naddrs; ++i)
+-		{
+-		  socklen_t size = (air->family[i] == AF_INET
+-				    ? INADDRSZ : IN6ADDRSZ);
+-
+-		  if (!((air->family[i] == AF_INET
+-			 && req->ai_family == AF_INET6
+-			 && (req->ai_flags & AI_V4MAPPED) != 0)
+-			|| req->ai_family == AF_UNSPEC
+-			|| air->family[i] == req->ai_family))
+-		    {
+-		      /* Skip over non-matching result.  */
+-		      addrs += size;
+-		      continue;
+-		    }
+-
+-		  if (*pat == NULL)
+-		    {
+-		      *pat = addrfree++;
+-		      (*pat)->scopeid = 0;
+-		    }
+-		  uint32_t *pataddr = (*pat)->addr;
+-		  (*pat)->next = NULL;
+-		  if (added_canon || air->canon == NULL)
+-		    (*pat)->name = NULL;
+-		  else if (res.canon == NULL)
+-		    {
+-		      char *canonbuf = __strdup (air->canon);
+-		      if (canonbuf == NULL)
+-			{
+-			  result = -EAI_MEMORY;
+-			  goto free_and_return;
+-			}
+-		      res.canon = (*pat)->name = canonbuf;
+-		    }
+-
+-		  if (air->family[i] == AF_INET
+-		      && req->ai_family == AF_INET6
+-		      && (req->ai_flags & AI_V4MAPPED))
+-		    {
+-		      (*pat)->family = AF_INET6;
+-		      pataddr[3] = *(uint32_t *) addrs;
+-		      pataddr[2] = htonl (0xffff);
+-		      pataddr[1] = 0;
+-		      pataddr[0] = 0;
+-		      pat = &((*pat)->next);
+-		      added_canon = true;
+-		    }
+-		  else if (req->ai_family == AF_UNSPEC
+-			   || air->family[i] == req->ai_family)
+-		    {
+-		      (*pat)->family = air->family[i];
+-		      memcpy (pataddr, addrs, size);
+-		      pat = &((*pat)->next);
+-		      added_canon = true;
+-		      if (air->family[i] == AF_INET6)
+-			got_ipv6 = true;
+-		    }
+-		  addrs += size;
+-		}
+-
+-	      free (air);
+-
+-	      goto process_list;
+-	    }
+-	  else if (err == 0)
+-	    /* The database contains a negative entry.  */
+-	    goto free_and_return;
+-	  else if (__nss_not_use_nscd_hosts == 0)
+-	    {
+-	      if (h_errno == NETDB_INTERNAL && errno == ENOMEM)
+-		result = -EAI_MEMORY;
+-	      else if (h_errno == TRY_AGAIN)
+-		result = -EAI_AGAIN;
+-	      else
+-		result = -EAI_SYSTEM;
+-
+-	      goto free_and_return;
+-	    }
+-	}
+-#endif
+-
+       no_more = !__nss_database_get (nss_database_hosts, &nip);
+
+       /* If we are looking for both IPv4 and IPv6 address we don't
+@@ -897,7 +917,7 @@ gaih_inet (const char *name, const struct gaih_service *service,
+
+ 			  no_data = 0;
+ 			  if (req->ai_family == AF_INET6)
+-			    got_ipv6 = true;
++			    res.got_ipv6 = true;
+ 			}
+ 		      else
+ 			*pat = ((*pat)->next);
+@@ -940,7 +960,7 @@ gaih_inet (const char *name, const struct gaih_service *service,
+ 			  && (req->ai_flags & AI_V4MAPPED)
+ 			  /* Avoid generating the mapped addresses if we
+ 			     know we are not going to need them.  */
+-			  && ((req->ai_flags & AI_ALL) || !got_ipv6)))
++			  && ((req->ai_flags & AI_ALL) || !res.got_ipv6)))
+ 		    {
+ 		      gethosts (AF_INET);
+
+@@ -1091,7 +1111,7 @@ gaih_inet (const char *name, const struct gaih_service *service,
+ 	    /* If we looked up IPv4 mapped address discard them here if
+ 	       the caller isn't interested in all address and we have
+ 	       found at least one IPv6 address.  */
+-	    if (got_ipv6
++	    if (res.got_ipv6
+ 		&& (req->ai_flags & (AI_V4MAPPED|AI_ALL)) == AI_V4MAPPED
+ 		&& IN6_IS_ADDR_V4MAPPED (at2->addr))
+ 	      goto ignore;
+
+From 9098deb96a49fdb88ec833b7fa2087f6bd4c6aca Mon Sep 17 00:00:00 2001
+From: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Date: Mon, 7 Mar 2022 15:56:22 +0530
+Subject: [PATCH] gaih_inet: separate nss lookup loop into its own function
+
+Signed-off-by: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Reviewed-by: DJ Delorie <dj@redhat.com>
+(cherry picked from commit 906cecbe0889e601c91d9aba738049c73ebe4dd2)
+---
+ sysdeps/posix/getaddrinfo.c | 563 ++++++++++++++++++------------------
+ 1 file changed, 286 insertions(+), 277 deletions(-)
+
+diff --git a/sysdeps/posix/getaddrinfo.c b/sysdeps/posix/getaddrinfo.c
+index 01be932b3f..f70ce2c76b 100644
+--- a/sysdeps/posix/getaddrinfo.c
++++ b/sysdeps/posix/getaddrinfo.c
+@@ -159,6 +159,14 @@ static const struct addrinfo default_hints =
+     .ai_next = NULL
+   };
+
++static void
++gaih_result_reset (struct gaih_result *res)
++{
++  if (res->free_at)
++    free (res->at);
++  free (res->canon);
++  memset (res, 0, sizeof (*res));
++}
+
+ static int
+ gaih_inet_serv (const char *servicename, const struct gaih_typeproto *tp,
+@@ -197,13 +205,10 @@ gaih_inet_serv (const char *servicename, const struct gaih_typeproto *tp,
+
+ /* Convert struct hostent to a list of struct gaih_addrtuple objects.  h_name
+    is not copied, and the struct hostent object must not be deallocated
+-   prematurely.  The new addresses are appended to the tuple array in
+-   RESULT.  */
++   prematurely.  The new addresses are appended to the tuple array in RES.  */
+ static bool
+-convert_hostent_to_gaih_addrtuple (const struct addrinfo *req,
+-				   int family,
+-				   struct hostent *h,
+-				   struct gaih_addrtuple **result)
++convert_hostent_to_gaih_addrtuple (const struct addrinfo *req, int family,
++				   struct hostent *h, struct gaih_result *res)
+ {
+   /* Count the number of addresses in h->h_addr_list.  */
+   size_t count = 0;
+@@ -215,7 +220,7 @@ convert_hostent_to_gaih_addrtuple (const struct addrinfo *req,
+   if (count == 0 || h->h_length > sizeof (((struct gaih_addrtuple) {}).addr))
+     return true;
+
+-  struct gaih_addrtuple *array = *result;
++  struct gaih_addrtuple *array = res->at;
+   size_t old = 0;
+
+   while (array != NULL)
+@@ -224,12 +229,14 @@ convert_hostent_to_gaih_addrtuple (const struct addrinfo *req,
+       array = array->next;
+     }
+
+-  array = realloc (*result, (old + count) * sizeof (*array));
++  array = realloc (res->at, (old + count) * sizeof (*array));
+
+   if (array == NULL)
+     return false;
+
+-  *result = array;
++  res->got_ipv6 = family == AF_INET6;
++  res->at = array;
++  res->free_at = true;
+
+   /* Update the next pointers on reallocation.  */
+   for (size_t i = 0; i < old; i++)
+@@ -278,7 +285,7 @@ convert_hostent_to_gaih_addrtuple (const struct addrinfo *req,
+ 	{								      \
+ 	  __resolv_context_put (res_ctx);				      \
+ 	  result = -EAI_MEMORY;						      \
+-	  goto free_and_return;						      \
++	  goto out;							      \
+ 	}								      \
+     }									      \
+   if (status == NSS_STATUS_NOTFOUND					      \
+@@ -288,7 +295,7 @@ convert_hostent_to_gaih_addrtuple (const struct addrinfo *req,
+ 	{								      \
+ 	  __resolv_context_put (res_ctx);				      \
+ 	  result = -EAI_SYSTEM;						      \
+-	  goto free_and_return;						      \
++	  goto out;							      \
+ 	}								      \
+       if (h_errno == TRY_AGAIN)						      \
+ 	no_data = EAI_AGAIN;						      \
+@@ -297,27 +304,24 @@ convert_hostent_to_gaih_addrtuple (const struct addrinfo *req,
+     }									      \
+   else if (status == NSS_STATUS_SUCCESS)				      \
+     {									      \
+-      if (!convert_hostent_to_gaih_addrtuple (req, _family, &th, &addrmem))   \
++      if (!convert_hostent_to_gaih_addrtuple (req, _family, &th, res))	      \
+ 	{								      \
+ 	  __resolv_context_put (res_ctx);				      \
+ 	  result = -EAI_SYSTEM;						      \
+-	  goto free_and_return;						      \
++	  goto out;							      \
+ 	}								      \
+-      *pat = addrmem;							      \
+ 									      \
+-      if (localcanon != NULL && res.canon == NULL)			      \
++      if (localcanon != NULL && res->canon == NULL)			      \
+ 	{								      \
+ 	  char *canonbuf = __strdup (localcanon);			      \
+ 	  if (canonbuf == NULL)						      \
+ 	    {								      \
+ 	      __resolv_context_put (res_ctx);				      \
+ 	      result = -EAI_SYSTEM;					      \
+-	      goto free_and_return;					      \
++	      goto out;							      \
+ 	    }								      \
+-	  res.canon = canonbuf;						      \
++	  res->canon = canonbuf;					      \
+ 	}								      \
+-      if (_family == AF_INET6 && *pat != NULL)				      \
+-	res.got_ipv6 = true;						      \
+     }									      \
+  }
+
+@@ -590,6 +594,260 @@ out:
+ }
+ #endif
+
++static int
++get_nss_addresses (const char *name, const struct addrinfo *req,
++		   struct scratch_buffer *tmpbuf, struct gaih_result *res)
++{
++  int no_data = 0;
++  int no_inet6_data = 0;
++  nss_action_list nip;
++  enum nss_status inet6_status = NSS_STATUS_UNAVAIL;
++  enum nss_status status = NSS_STATUS_UNAVAIL;
++  int no_more;
++  struct resolv_context *res_ctx = NULL;
++  bool do_merge = false;
++  int result = 0;
++
++  no_more = !__nss_database_get (nss_database_hosts, &nip);
++
++  /* If we are looking for both IPv4 and IPv6 address we don't
++     want the lookup functions to automatically promote IPv4
++     addresses to IPv6 addresses, so we use the no_inet6
++     function variant.  */
++  res_ctx = __resolv_context_get ();
++  if (res_ctx == NULL)
++    no_more = 1;
++
++  while (!no_more)
++    {
++      /* Always start afresh; continue should discard previous results
++	 and the hosts database does not support merge.  */
++      gaih_result_reset (res);
++
++      if (do_merge)
++	{
++	  __set_h_errno (NETDB_INTERNAL);
++	  __set_errno (EBUSY);
++	  break;
++	}
++
++      no_data = 0;
++      nss_gethostbyname4_r *fct4 = NULL;
++
++      /* gethostbyname4_r sends out parallel A and AAAA queries and
++	 is thus only suitable for PF_UNSPEC.  */
++      if (req->ai_family == PF_UNSPEC)
++	fct4 = __nss_lookup_function (nip, "gethostbyname4_r");
++
++      if (fct4 != NULL)
++	{
++	  while (1)
++	    {
++	      status = DL_CALL_FCT (fct4, (name, &res->at,
++					   tmpbuf->data, tmpbuf->length,
++					   &errno, &h_errno,
++					   NULL));
++	      if (status == NSS_STATUS_SUCCESS)
++		break;
++	      /* gethostbyname4_r may write into AT, so reset it.  */
++	      res->at = NULL;
++	      if (status != NSS_STATUS_TRYAGAIN
++		  || errno != ERANGE || h_errno != NETDB_INTERNAL)
++		{
++		  if (h_errno == TRY_AGAIN)
++		    no_data = EAI_AGAIN;
++		  else
++		    no_data = h_errno == NO_DATA;
++		  break;
++		}
++
++	      if (!scratch_buffer_grow (tmpbuf))
++		{
++		  __resolv_context_put (res_ctx);
++		  result = -EAI_MEMORY;
++		  goto out;
++		}
++	    }
++
++	  if (status == NSS_STATUS_SUCCESS)
++	    {
++	      assert (!no_data);
++	      no_data = 1;
++
++	      if ((req->ai_flags & AI_CANONNAME) != 0 && res->canon == NULL)
++		{
++		  char *canonbuf = __strdup (res->at->name);
++		  if (canonbuf == NULL)
++		    {
++		      __resolv_context_put (res_ctx);
++		      result = -EAI_MEMORY;
++		      goto out;
++		    }
++		  res->canon = canonbuf;
++		}
++
++	      struct gaih_addrtuple **pat = &res->at;
++
++	      while (*pat != NULL)
++		{
++		  if ((*pat)->family == AF_INET
++		      && req->ai_family == AF_INET6
++		      && (req->ai_flags & AI_V4MAPPED) != 0)
++		    {
++		      uint32_t *pataddr = (*pat)->addr;
++		      (*pat)->family = AF_INET6;
++		      pataddr[3] = pataddr[0];
++		      pataddr[2] = htonl (0xffff);
++		      pataddr[1] = 0;
++		      pataddr[0] = 0;
++		      pat = &((*pat)->next);
++		      no_data = 0;
++		    }
++		  else if (req->ai_family == AF_UNSPEC
++			   || (*pat)->family == req->ai_family)
++		    {
++		      pat = &((*pat)->next);
++
++		      no_data = 0;
++		      if (req->ai_family == AF_INET6)
++			res->got_ipv6 = true;
++		    }
++		  else
++		    *pat = ((*pat)->next);
++		}
++	    }
++
++	  no_inet6_data = no_data;
++	}
++      else
++	{
++	  nss_gethostbyname3_r *fct = NULL;
++	  if (req->ai_flags & AI_CANONNAME)
++	    /* No need to use this function if we do not look for
++	       the canonical name.  The function does not exist in
++	       all NSS modules and therefore the lookup would
++	       often fail.  */
++	    fct = __nss_lookup_function (nip, "gethostbyname3_r");
++	  if (fct == NULL)
++	    /* We are cheating here.  The gethostbyname2_r
++	       function does not have the same interface as
++	       gethostbyname3_r but the extra arguments the
++	       latter takes are added at the end.  So the
++	       gethostbyname2_r code will just ignore them.  */
++	    fct = __nss_lookup_function (nip, "gethostbyname2_r");
++
++	  if (fct != NULL)
++	    {
++	      if (req->ai_family == AF_INET6
++		  || req->ai_family == AF_UNSPEC)
++		{
++		  gethosts (AF_INET6);
++		  no_inet6_data = no_data;
++		  inet6_status = status;
++		}
++	      if (req->ai_family == AF_INET
++		  || req->ai_family == AF_UNSPEC
++		  || (req->ai_family == AF_INET6
++		      && (req->ai_flags & AI_V4MAPPED)
++		      /* Avoid generating the mapped addresses if we
++			 know we are not going to need them.  */
++		      && ((req->ai_flags & AI_ALL) || !res->got_ipv6)))
++		{
++		  gethosts (AF_INET);
++
++		  if (req->ai_family == AF_INET)
++		    {
++		      no_inet6_data = no_data;
++		      inet6_status = status;
++		    }
++		}
++
++	      /* If we found one address for AF_INET or AF_INET6,
++		 don't continue the search.  */
++	      if (inet6_status == NSS_STATUS_SUCCESS
++		  || status == NSS_STATUS_SUCCESS)
++		{
++		  if ((req->ai_flags & AI_CANONNAME) != 0
++		      && res->canon == NULL)
++		    {
++		      char *canonbuf = getcanonname (nip, res->at, name);
++		      if (canonbuf == NULL)
++			{
++			  __resolv_context_put (res_ctx);
++			  result = -EAI_MEMORY;
++			  goto out;
++			}
++		      res->canon = canonbuf;
++		    }
++		  status = NSS_STATUS_SUCCESS;
++		}
++	      else
++		{
++		  /* We can have different states for AF_INET and
++		     AF_INET6.  Try to find a useful one for both.  */
++		  if (inet6_status == NSS_STATUS_TRYAGAIN)
++		    status = NSS_STATUS_TRYAGAIN;
++		  else if (status == NSS_STATUS_UNAVAIL
++			   && inet6_status != NSS_STATUS_UNAVAIL)
++		    status = inet6_status;
++		}
++	    }
++	  else
++	    {
++	      /* Could not locate any of the lookup functions.
++		 The NSS lookup code does not consistently set
++		 errno, so we need to supply our own error
++		 code here.  The root cause could either be a
++		 resource allocation failure, or a missing
++		 service function in the DSO (so it should not
++		 be listed in /etc/nsswitch.conf).  Assume the
++		 former, and return EBUSY.  */
++	      status = NSS_STATUS_UNAVAIL;
++	      __set_h_errno (NETDB_INTERNAL);
++	      __set_errno (EBUSY);
++	    }
++	}
++
++      if (nss_next_action (nip, status) == NSS_ACTION_RETURN)
++	break;
++
++      /* The hosts database does not support MERGE.  */
++      if (nss_next_action (nip, status) == NSS_ACTION_MERGE)
++	do_merge = true;
++
++      nip++;
++      if (nip->module == NULL)
++	no_more = -1;
++    }
++
++  __resolv_context_put (res_ctx);
++
++  /* If we have a failure which sets errno, report it using
++     EAI_SYSTEM.  */
++  if ((status == NSS_STATUS_TRYAGAIN || status == NSS_STATUS_UNAVAIL)
++      && h_errno == NETDB_INTERNAL)
++    {
++      result = -EAI_SYSTEM;
++      goto out;
++    }
++
++  if (no_data != 0 && no_inet6_data != 0)
++    {
++      /* If both requests timed out report this.  */
++      if (no_data == EAI_AGAIN && no_inet6_data == EAI_AGAIN)
++	result = -EAI_AGAIN;
++      else
++	/* We made requests but they turned out no data.  The name
++	   is known, though.  */
++	result = -EAI_NODATA;
++    }
++
++out:
++  if (result != 0)
++    gaih_result_reset (res);
++  return result;
++}
++
+ /* Convert numeric addresses to binary into RES.  On failure, RES->AT is set to
+    NULL and an error code is returned.  If AI_NUMERIC_HOST is not requested and
+    the function cannot determine a result, RES->AT is set to NULL and 0
+@@ -723,7 +981,7 @@ try_simple_gethostbyname (const char *name, const struct addrinfo *req,
+ 	  /* We found data, convert it.  RES->AT from the conversion will
+ 	     either be an allocated block or NULL, both of which are safe to
+ 	     pass to free ().  */
+-	  if (!convert_hostent_to_gaih_addrtuple (req, AF_INET, h, &res->at))
++	  if (!convert_hostent_to_gaih_addrtuple (req, AF_INET, h, res))
+ 	    return -EAI_MEMORY;
+
+ 	  res->free_at = true;
+@@ -801,264 +1059,14 @@ gaih_inet (const char *name, const struct gaih_service *service,
+ 	goto process_list;
+ #endif
+
+-      int no_data = 0;
+-      int no_inet6_data = 0;
+-      nss_action_list nip;
+-      enum nss_status inet6_status = NSS_STATUS_UNAVAIL;
+-      enum nss_status status = NSS_STATUS_UNAVAIL;
+-      int no_more;
+-      struct resolv_context *res_ctx = NULL;
+-      bool do_merge = false;
+-
+-      no_more = !__nss_database_get (nss_database_hosts, &nip);
+-
+-      /* If we are looking for both IPv4 and IPv6 address we don't
+-	 want the lookup functions to automatically promote IPv4
+-	 addresses to IPv6 addresses, so we use the no_inet6
+-	 function variant.  */
+-      res_ctx = __resolv_context_get ();
+-      if (res_ctx == NULL)
+-	no_more = 1;
+-
+-      while (!no_more)
+-	{
+-	  /* Always start afresh; continue should discard previous results
+-	     and the hosts database does not support merge.  */
+-	  res.at = NULL;
+-	  free (res.canon);
+-	  free (addrmem);
+-	  res.canon = NULL;
+-	  addrmem = NULL;
+-	  got_ipv6 = false;
+-
+-	  if (do_merge)
+-	    {
+-	      __set_h_errno (NETDB_INTERNAL);
+-	      __set_errno (EBUSY);
+-	      break;
+-	    }
+-
+-	  no_data = 0;
+-	  nss_gethostbyname4_r *fct4 = NULL;
+-
+-	  /* gethostbyname4_r sends out parallel A and AAAA queries and
+-	     is thus only suitable for PF_UNSPEC.  */
+-	  if (req->ai_family == PF_UNSPEC)
+-	    fct4 = __nss_lookup_function (nip, "gethostbyname4_r");
+-
+-	  if (fct4 != NULL)
+-	    {
+-	      while (1)
+-		{
+-		  status = DL_CALL_FCT (fct4, (name, &res.at,
+-					       tmpbuf->data, tmpbuf->length,
+-					       &errno, &h_errno,
+-					       NULL));
+-		  if (status == NSS_STATUS_SUCCESS)
+-		    break;
+-		  /* gethostbyname4_r may write into AT, so reset it.  */
+-		  res.at = NULL;
+-		  if (status != NSS_STATUS_TRYAGAIN
+-		      || errno != ERANGE || h_errno != NETDB_INTERNAL)
+-		    {
+-		      if (h_errno == TRY_AGAIN)
+-			no_data = EAI_AGAIN;
+-		      else
+-			no_data = h_errno == NO_DATA;
+-		      break;
+-		    }
+-
+-		  if (!scratch_buffer_grow (tmpbuf))
+-		    {
+-		      __resolv_context_put (res_ctx);
+-		      result = -EAI_MEMORY;
+-		      goto free_and_return;
+-		    }
+-		}
+-
+-	      if (status == NSS_STATUS_SUCCESS)
+-		{
+-		  assert (!no_data);
+-		  no_data = 1;
+-
+-		  if ((req->ai_flags & AI_CANONNAME) != 0 && res.canon == NULL)
+-		    {
+-		      char *canonbuf = __strdup (res.at->name);
+-		      if (canonbuf == NULL)
+-			{
+-			  __resolv_context_put (res_ctx);
+-			  result = -EAI_MEMORY;
+-			  goto free_and_return;
+-			}
+-		      res.canon = canonbuf;
+-		    }
+-
+-		  struct gaih_addrtuple **pat = &res.at;
+-
+-		  while (*pat != NULL)
+-		    {
+-		      if ((*pat)->family == AF_INET
+-			  && req->ai_family == AF_INET6
+-			  && (req->ai_flags & AI_V4MAPPED) != 0)
+-			{
+-			  uint32_t *pataddr = (*pat)->addr;
+-			  (*pat)->family = AF_INET6;
+-			  pataddr[3] = pataddr[0];
+-			  pataddr[2] = htonl (0xffff);
+-			  pataddr[1] = 0;
+-			  pataddr[0] = 0;
+-			  pat = &((*pat)->next);
+-			  no_data = 0;
+-			}
+-		      else if (req->ai_family == AF_UNSPEC
+-			       || (*pat)->family == req->ai_family)
+-			{
+-			  pat = &((*pat)->next);
+-
+-			  no_data = 0;
+-			  if (req->ai_family == AF_INET6)
+-			    res.got_ipv6 = true;
+-			}
+-		      else
+-			*pat = ((*pat)->next);
+-		    }
+-		}
+-
+-	      no_inet6_data = no_data;
+-	    }
+-	  else
+-	    {
+-	      nss_gethostbyname3_r *fct = NULL;
+-	      if (req->ai_flags & AI_CANONNAME)
+-		/* No need to use this function if we do not look for
+-		   the canonical name.  The function does not exist in
+-		   all NSS modules and therefore the lookup would
+-		   often fail.  */
+-		fct = __nss_lookup_function (nip, "gethostbyname3_r");
+-	      if (fct == NULL)
+-		/* We are cheating here.  The gethostbyname2_r
+-		   function does not have the same interface as
+-		   gethostbyname3_r but the extra arguments the
+-		   latter takes are added at the end.  So the
+-		   gethostbyname2_r code will just ignore them.  */
+-		fct = __nss_lookup_function (nip, "gethostbyname2_r");
+-
+-	      if (fct != NULL)
+-		{
+-		  struct gaih_addrtuple **pat = &res.at;
+-
+-		  if (req->ai_family == AF_INET6
+-		      || req->ai_family == AF_UNSPEC)
+-		    {
+-		      gethosts (AF_INET6);
+-		      no_inet6_data = no_data;
+-		      inet6_status = status;
+-		    }
+-		  if (req->ai_family == AF_INET
+-		      || req->ai_family == AF_UNSPEC
+-		      || (req->ai_family == AF_INET6
+-			  && (req->ai_flags & AI_V4MAPPED)
+-			  /* Avoid generating the mapped addresses if we
+-			     know we are not going to need them.  */
+-			  && ((req->ai_flags & AI_ALL) || !res.got_ipv6)))
+-		    {
+-		      gethosts (AF_INET);
+-
+-		      if (req->ai_family == AF_INET)
+-			{
+-			  no_inet6_data = no_data;
+-			  inet6_status = status;
+-			}
+-		    }
+-
+-		  /* If we found one address for AF_INET or AF_INET6,
+-		     don't continue the search.  */
+-		  if (inet6_status == NSS_STATUS_SUCCESS
+-		      || status == NSS_STATUS_SUCCESS)
+-		    {
+-		      if ((req->ai_flags & AI_CANONNAME) != 0
+-			  && res.canon == NULL)
+-			{
+-			  char *canonbuf = getcanonname (nip, res.at, name);
+-			  if (canonbuf == NULL)
+-			    {
+-			      __resolv_context_put (res_ctx);
+-			      result = -EAI_MEMORY;
+-			      goto free_and_return;
+-			    }
+-			  res.canon = canonbuf;
+-			}
+-		      status = NSS_STATUS_SUCCESS;
+-		    }
+-		  else
+-		    {
+-		      /* We can have different states for AF_INET and
+-			 AF_INET6.  Try to find a useful one for both.  */
+-		      if (inet6_status == NSS_STATUS_TRYAGAIN)
+-			status = NSS_STATUS_TRYAGAIN;
+-		      else if (status == NSS_STATUS_UNAVAIL
+-			       && inet6_status != NSS_STATUS_UNAVAIL)
+-			status = inet6_status;
+-		    }
+-		}
+-	      else
+-		{
+-		  /* Could not locate any of the lookup functions.
+-		     The NSS lookup code does not consistently set
+-		     errno, so we need to supply our own error
+-		     code here.  The root cause could either be a
+-		     resource allocation failure, or a missing
+-		     service function in the DSO (so it should not
+-		     be listed in /etc/nsswitch.conf).  Assume the
+-		     former, and return EBUSY.  */
+-		  status = NSS_STATUS_UNAVAIL;
+-		  __set_h_errno (NETDB_INTERNAL);
+-		  __set_errno (EBUSY);
+-		}
+-	    }
+-
+-	  if (nss_next_action (nip, status) == NSS_ACTION_RETURN)
+-	    break;
+-
+-	  /* The hosts database does not support MERGE.  */
+-	  if (nss_next_action (nip, status) == NSS_ACTION_MERGE)
+-	    do_merge = true;
+-
+-	  nip++;
+-	  if (nip->module == NULL)
+-	    no_more = -1;
+-	}
+-
+-      __resolv_context_put (res_ctx);
+-
+-      /* If we have a failure which sets errno, report it using
+-	 EAI_SYSTEM.  */
+-      if ((status == NSS_STATUS_TRYAGAIN || status == NSS_STATUS_UNAVAIL)
+-	  && h_errno == NETDB_INTERNAL)
+-	{
+-	  result = -EAI_SYSTEM;
+-	  goto free_and_return;
+-	}
+-
+-      if (no_data != 0 && no_inet6_data != 0)
+-	{
+-	  /* If both requests timed out report this.  */
+-	  if (no_data == EAI_AGAIN && no_inet6_data == EAI_AGAIN)
+-	    result = -EAI_AGAIN;
+-	  else
+-	    /* We made requests but they turned out no data.  The name
+-	       is known, though.  */
+-	    result = -EAI_NODATA;
+-
+-	  goto free_and_return;
+-	}
++      if ((result = get_nss_addresses (name, req, tmpbuf, &res)) != 0)
++	goto free_and_return;
++      else if (res.at != NULL)
++	goto process_list;
+
+-    process_list:
+-      if (res.at == NULL)
+-	{
+-	  result = -EAI_NONAME;
+-	  goto free_and_return;
+-	}
++      /* None of the lookups worked, so name not found.  */
++      result = -EAI_NONAME;
++      goto free_and_return;
+     }
+   else
+     {
+@@ -1089,6 +1097,7 @@ gaih_inet (const char *name, const struct gaih_service *service,
+ 	}
+     }
+
++process_list:
+   {
+     /* Set up the canonical name if we need it.  */
+     if ((result = process_canonname (req, orig_name, &res)) != 0)
+
+From 8b70d97b0899f457d1ebfe5d17f11cf002fd5a06 Mon Sep 17 00:00:00 2001
+From: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Date: Mon, 7 Mar 2022 19:48:48 +0530
+Subject: [PATCH] gaih_inet: make gethosts into a function
+
+The macro is quite a pain to debug, so make gethosts into a function to
+make it easier to maintain.
+
+Signed-off-by: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Reviewed-by: DJ Delorie <dj@redhat.com>
+(cherry picked from commit cfa3bd48cb19a70e4367a9978dbba09d9df27a72)
+---
+ sysdeps/posix/getaddrinfo.c | 117 ++++++++++++++++++------------------
+ 1 file changed, 59 insertions(+), 58 deletions(-)
+
+diff --git a/sysdeps/posix/getaddrinfo.c b/sysdeps/posix/getaddrinfo.c
+index f70ce2c76b..bc385dd322 100644
+--- a/sysdeps/posix/getaddrinfo.c
++++ b/sysdeps/posix/getaddrinfo.c
+@@ -268,63 +268,54 @@ convert_hostent_to_gaih_addrtuple (const struct addrinfo *req, int family,
+   return true;
+ }
+
+-#define gethosts(_family) \
+- {									      \
+-  struct hostent th;							      \
+-  char *localcanon = NULL;						      \
+-  no_data = 0;								      \
+-  while (1)								      \
+-    {									      \
+-      status = DL_CALL_FCT (fct, (name, _family, &th,			      \
+-				  tmpbuf->data, tmpbuf->length,		      \
+-				  &errno, &h_errno, NULL, &localcanon));      \
+-      if (status != NSS_STATUS_TRYAGAIN || h_errno != NETDB_INTERNAL	      \
+-	  || errno != ERANGE)						      \
+-	break;								      \
+-      if (!scratch_buffer_grow (tmpbuf))				      \
+-	{								      \
+-	  __resolv_context_put (res_ctx);				      \
+-	  result = -EAI_MEMORY;						      \
+-	  goto out;							      \
+-	}								      \
+-    }									      \
+-  if (status == NSS_STATUS_NOTFOUND					      \
+-      || status == NSS_STATUS_TRYAGAIN || status == NSS_STATUS_UNAVAIL)	      \
+-    {									      \
+-      if (h_errno == NETDB_INTERNAL)					      \
+-	{								      \
+-	  __resolv_context_put (res_ctx);				      \
+-	  result = -EAI_SYSTEM;						      \
+-	  goto out;							      \
+-	}								      \
+-      if (h_errno == TRY_AGAIN)						      \
+-	no_data = EAI_AGAIN;						      \
+-      else								      \
+-	no_data = h_errno == NO_DATA;					      \
+-    }									      \
+-  else if (status == NSS_STATUS_SUCCESS)				      \
+-    {									      \
+-      if (!convert_hostent_to_gaih_addrtuple (req, _family, &th, res))	      \
+-	{								      \
+-	  __resolv_context_put (res_ctx);				      \
+-	  result = -EAI_SYSTEM;						      \
+-	  goto out;							      \
+-	}								      \
+-									      \
+-      if (localcanon != NULL && res->canon == NULL)			      \
+-	{								      \
+-	  char *canonbuf = __strdup (localcanon);			      \
+-	  if (canonbuf == NULL)						      \
+-	    {								      \
+-	      __resolv_context_put (res_ctx);				      \
+-	      result = -EAI_SYSTEM;					      \
+-	      goto out;							      \
+-	    }								      \
+-	  res->canon = canonbuf;					      \
+-	}								      \
+-    }									      \
+- }
++static int
++gethosts (nss_gethostbyname3_r fct, int family, const char *name,
++	  const struct addrinfo *req, struct scratch_buffer *tmpbuf,
++	  struct gaih_result *res, enum nss_status *statusp, int *no_datap)
++{
++  struct hostent th;
++  char *localcanon = NULL;
++  enum nss_status status;
++
++  *no_datap = 0;
++  while (1)
++    {
++      *statusp = status = DL_CALL_FCT (fct, (name, family, &th,
++					     tmpbuf->data, tmpbuf->length,
++					     &errno, &h_errno, NULL,
++					     &localcanon));
++      if (status != NSS_STATUS_TRYAGAIN || h_errno != NETDB_INTERNAL
++	  || errno != ERANGE)
++	break;
++      if (!scratch_buffer_grow (tmpbuf))
++	return -EAI_MEMORY;
++    }
++  if (status == NSS_STATUS_NOTFOUND
++      || status == NSS_STATUS_TRYAGAIN || status == NSS_STATUS_UNAVAIL)
++    {
++      if (h_errno == NETDB_INTERNAL)
++	return -EAI_SYSTEM;
++      if (h_errno == TRY_AGAIN)
++	*no_datap = EAI_AGAIN;
++      else
++	*no_datap = h_errno == NO_DATA;
++    }
++  else if (status == NSS_STATUS_SUCCESS)
++    {
++      if (!convert_hostent_to_gaih_addrtuple (req, family, &th, res))
++	return -EAI_SYSTEM;
++
++      if (localcanon != NULL && res->canon == NULL)
++	{
++	  char *canonbuf = __strdup (localcanon);
++	  if (canonbuf == NULL)
++	    return  -EAI_SYSTEM;
++	  res->canon = canonbuf;
++	}
++    }
+
++  return 0;
++}
+
+ /* This function is called if a canonical name is requested, but if
+    the service function did not provide it.  It tries to obtain the
+@@ -741,7 +732,12 @@ get_nss_addresses (const char *name, const struct addrinfo *req,
+ 	      if (req->ai_family == AF_INET6
+ 		  || req->ai_family == AF_UNSPEC)
+ 		{
+-		  gethosts (AF_INET6);
++		  if ((result = gethosts (fct, AF_INET6, name, req, tmpbuf,
++					  res, &status, &no_data)) != 0)
++		    {
++		      __resolv_context_put (res_ctx);
++		      goto out;
++		    }
+ 		  no_inet6_data = no_data;
+ 		  inet6_status = status;
+ 		}
+@@ -753,7 +749,12 @@ get_nss_addresses (const char *name, const struct addrinfo *req,
+ 			 know we are not going to need them.  */
+ 		      && ((req->ai_flags & AI_ALL) || !res->got_ipv6)))
+ 		{
+-		  gethosts (AF_INET);
++		  if ((result = gethosts (fct, AF_INET, name, req, tmpbuf,
++					  res, &status, &no_data)) != 0)
++		    {
++		      __resolv_context_put (res_ctx);
++		      goto out;
++		    }
+
+ 		  if (req->ai_family == AF_INET)
+ 		    {
+
+From a6da10689237c39dfaa1e50de211e6954f95977f Mon Sep 17 00:00:00 2001
+From: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Date: Mon, 7 Mar 2022 20:24:37 +0530
+Subject: [PATCH] gaih_inet: split loopback lookup into its own function
+
+Flatten the condition nesting and replace the alloca for RET.AT/ATR with
+a single array LOCAL_AT[2].  This gets rid of alloca and alloca
+accounting.
+
+`git diff -b` is probably the best way to view this change since much of
+the diff is whitespace changes.
+
+Signed-off-by: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Reviewed-by: DJ Delorie <dj@redhat.com>
+(cherry picked from commit 657472b2a50f67b12e5bbe5827582c9c2bb82dc3)
+---
+ sysdeps/posix/getaddrinfo.c | 127 ++++++++++++++++++------------------
+ 1 file changed, 62 insertions(+), 65 deletions(-)
+
+diff --git a/sysdeps/posix/getaddrinfo.c b/sysdeps/posix/getaddrinfo.c
+index bc385dd322..47c41d332d 100644
+--- a/sysdeps/posix/getaddrinfo.c
++++ b/sysdeps/posix/getaddrinfo.c
+@@ -1004,6 +1004,32 @@ try_simple_gethostbyname (const char *name, const struct addrinfo *req,
+   return -EAI_NODATA;
+ }
+
++/* Add local address information into RES.  RES->AT is assumed to have enough
++   space for two tuples and is zeroed out.  */
++
++static void
++get_local_addresses (const struct addrinfo *req, struct gaih_result *res)
++{
++  struct gaih_addrtuple *atr = res->at;
++  if (req->ai_family == AF_UNSPEC)
++    res->at->next = res->at + 1;
++
++  if (req->ai_family == AF_UNSPEC || req->ai_family == AF_INET6)
++    {
++      res->at->family = AF_INET6;
++      if ((req->ai_flags & AI_PASSIVE) == 0)
++	memcpy (res->at->addr, &in6addr_loopback, sizeof (struct in6_addr));
++      atr = res->at->next;
++    }
++
++  if (req->ai_family == AF_UNSPEC || req->ai_family == AF_INET)
++    {
++      atr->family = AF_INET;
++      if ((req->ai_flags & AI_PASSIVE) == 0)
++	atr->addr[0] = htonl (INADDR_LOOPBACK);
++    }
++}
++
+ static int
+ gaih_inet (const char *name, const struct gaih_service *service,
+ 	   const struct addrinfo *req, struct addrinfo **pai,
+@@ -1014,10 +1040,6 @@ gaih_inet (const char *name, const struct gaih_service *service,
+
+   const char *orig_name = name;
+
+-  /* Reserve stack memory for the scratch buffer in the getaddrinfo
+-     function.  */
+-  size_t alloca_used = sizeof (struct scratch_buffer);
+-
+   int rc;
+   if ((rc = get_servtuples (service, req, st, tmpbuf)) != 0)
+     return rc;
+@@ -1027,76 +1049,51 @@ gaih_inet (const char *name, const struct gaih_service *service,
+   int result = 0;
+
+   struct gaih_result res = {0};
+-  if (name != NULL)
++  struct gaih_addrtuple local_at[2] = {0};
++
++  res.at = local_at;
++
++  if (__glibc_unlikely (name == NULL))
+     {
+-      if (req->ai_flags & AI_IDN)
+-	{
+-	  char *out;
+-	  result = __idna_to_dns_encoding (name, &out);
+-	  if (result != 0)
+-	    return -result;
+-	  name = out;
+-	  malloc_name = true;
+-	}
++      get_local_addresses (req, &res);
++      goto process_list;
++    }
+
+-      res.at = alloca_account (sizeof (struct gaih_addrtuple), alloca_used);
+-      res.at->scopeid = 0;
+-      res.at->next = NULL;
++  if (req->ai_flags & AI_IDN)
++    {
++      char *out;
++      result = __idna_to_dns_encoding (name, &out);
++      if (result != 0)
++	return -result;
++      name = out;
++      malloc_name = true;
++    }
+
+-      if ((result = text_to_binary_address (name, req, &res)) != 0)
+-	goto free_and_return;
+-      else if (res.at != NULL)
+-	goto process_list;
++  if ((result = text_to_binary_address (name, req, &res)) != 0)
++    goto free_and_return;
++  else if (res.at != NULL)
++    goto process_list;
+
+-      if ((result = try_simple_gethostbyname (name, req, tmpbuf, &res)) != 0)
+-	goto free_and_return;
+-      else if (res.at != NULL)
+-	goto process_list;
++  if ((result = try_simple_gethostbyname (name, req, tmpbuf, &res)) != 0)
++    goto free_and_return;
++  else if (res.at != NULL)
++    goto process_list;
+
+ #ifdef USE_NSCD
+-      if ((result = get_nscd_addresses (name, req, &res)) != 0)
+-	goto free_and_return;
+-      else if (res.at != NULL)
+-	goto process_list;
++  if ((result = get_nscd_addresses (name, req, &res)) != 0)
++    goto free_and_return;
++  else if (res.at != NULL)
++    goto process_list;
+ #endif
+
+-      if ((result = get_nss_addresses (name, req, tmpbuf, &res)) != 0)
+-	goto free_and_return;
+-      else if (res.at != NULL)
+-	goto process_list;
+-
+-      /* None of the lookups worked, so name not found.  */
+-      result = -EAI_NONAME;
+-      goto free_and_return;
+-    }
+-  else
+-    {
+-      struct gaih_addrtuple *atr;
+-      atr = res.at = alloca_account (sizeof (struct gaih_addrtuple),
+-				     alloca_used);
+-      memset (res.at, '\0', sizeof (struct gaih_addrtuple));
+-
+-      if (req->ai_family == AF_UNSPEC)
+-	{
+-	  res.at->next = __alloca (sizeof (struct gaih_addrtuple));
+-	  memset (res.at->next, '\0', sizeof (struct gaih_addrtuple));
+-	}
+-
+-      if (req->ai_family == AF_UNSPEC || req->ai_family == AF_INET6)
+-	{
+-	  res.at->family = AF_INET6;
+-	  if ((req->ai_flags & AI_PASSIVE) == 0)
+-	    memcpy (res.at->addr, &in6addr_loopback, sizeof (struct in6_addr));
+-	  atr = res.at->next;
+-	}
++  if ((result = get_nss_addresses (name, req, tmpbuf, &res)) != 0)
++    goto free_and_return;
++  else if (res.at != NULL)
++    goto process_list;
+
+-      if (req->ai_family == AF_UNSPEC || req->ai_family == AF_INET)
+-	{
+-	  atr->family = AF_INET;
+-	  if ((req->ai_flags & AI_PASSIVE) == 0)
+-	    atr->addr[0] = htonl (INADDR_LOOPBACK);
+-	}
+-    }
++  /* None of the lookups worked, so name not found.  */
++  result = -EAI_NONAME;
++  goto free_and_return;
+
+ process_list:
+   {
+
+From f5f88f142ae67d45388fd669947ec23e0af8ea37 Mon Sep 17 00:00:00 2001
+From: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Date: Mon, 7 Mar 2022 20:38:31 +0530
+Subject: [PATCH] gaih_inet: Split result generation into its own function
+
+Simplify the loop a wee bit and clean up variable names too.
+
+Signed-off-by: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Reviewed-by: DJ Delorie <dj@redhat.com>
+(cherry picked from commit ac4653ef503d1e87893d1a6714748a1cdf4bf7ad)
+---
+ sysdeps/posix/getaddrinfo.c | 176 ++++++++++++++++++------------------
+ 1 file changed, 86 insertions(+), 90 deletions(-)
+
+diff --git a/sysdeps/posix/getaddrinfo.c b/sysdeps/posix/getaddrinfo.c
+index 47c41d332d..f5d4a5cfd9 100644
+--- a/sysdeps/posix/getaddrinfo.c
++++ b/sysdeps/posix/getaddrinfo.c
+@@ -1030,6 +1030,87 @@ get_local_addresses (const struct addrinfo *req, struct gaih_result *res)
+     }
+ }
+
++/* Generate results in PAI and its count in NADDRS.  Return 0 on success or an
++   error code on failure.  */
++
++static int
++generate_addrinfo (const struct addrinfo *req, struct gaih_result *res,
++		   const struct gaih_servtuple *st, struct addrinfo **pai,
++		   unsigned int *naddrs)
++{
++  size_t socklen;
++  sa_family_t family;
++
++  /* Buffer is the size of an unformatted IPv6 address in printable format.  */
++  for (struct gaih_addrtuple *at = res->at; at != NULL; at = at->next)
++    {
++      family = at->family;
++      if (family == AF_INET6)
++	{
++	  socklen = sizeof (struct sockaddr_in6);
++
++	  /* If we looked up IPv4 mapped address discard them here if
++	     the caller isn't interested in all address and we have
++	     found at least one IPv6 address.  */
++	  if (res->got_ipv6
++	      && (req->ai_flags & (AI_V4MAPPED|AI_ALL)) == AI_V4MAPPED
++	      && IN6_IS_ADDR_V4MAPPED (at->addr))
++	    continue;
++	}
++      else
++	socklen = sizeof (struct sockaddr_in);
++
++      for (int i = 0; st[i].set; i++)
++	{
++	  struct addrinfo *ai;
++	  ai = *pai = malloc (sizeof (struct addrinfo) + socklen);
++	  if (ai == NULL)
++	    return -EAI_MEMORY;
++
++	  ai->ai_flags = req->ai_flags;
++	  ai->ai_family = family;
++	  ai->ai_socktype = st[i].socktype;
++	  ai->ai_protocol = st[i].protocol;
++	  ai->ai_addrlen = socklen;
++	  ai->ai_addr = (void *) (ai + 1);
++
++	  /* We only add the canonical name once.  */
++	  ai->ai_canonname = res->canon;
++	  res->canon = NULL;
++
++#ifdef _HAVE_SA_LEN
++	  ai->ai_addr->sa_len = socklen;
++#endif /* _HAVE_SA_LEN */
++	  ai->ai_addr->sa_family = family;
++
++	  /* In case of an allocation error the list must be NULL
++	     terminated.  */
++	  ai->ai_next = NULL;
++
++	  if (family == AF_INET6)
++	    {
++	      struct sockaddr_in6 *sin6p = (struct sockaddr_in6 *) ai->ai_addr;
++	      sin6p->sin6_port = st[i].port;
++	      sin6p->sin6_flowinfo = 0;
++	      memcpy (&sin6p->sin6_addr, at->addr, sizeof (struct in6_addr));
++	      sin6p->sin6_scope_id = at->scopeid;
++	    }
++	  else
++	    {
++	      struct sockaddr_in *sinp = (struct sockaddr_in *) ai->ai_addr;
++	      sinp->sin_port = st[i].port;
++	      memcpy (&sinp->sin_addr, at->addr, sizeof (struct in_addr));
++	      memset (sinp->sin_zero, '\0', sizeof (sinp->sin_zero));
++	    }
++
++	  pai = &(ai->ai_next);
++	}
++
++      ++*naddrs;
++    }
++  return 0;
++}
++
+ static int
+ gaih_inet (const char *name, const struct gaih_service *service,
+ 	   const struct addrinfo *req, struct addrinfo **pai,
+@@ -1096,98 +1177,13 @@ gaih_inet (const char *name, const struct gaih_service *service,
+   goto free_and_return;
+
+ process_list:
+-  {
+-    /* Set up the canonical name if we need it.  */
+-    if ((result = process_canonname (req, orig_name, &res)) != 0)
+-      goto free_and_return;
+-
+-    struct gaih_addrtuple *at2 = res.at;
+-    size_t socklen;
+-    sa_family_t family;
+-
+-    /*
+-      buffer is the size of an unformatted IPv6 address in printable format.
+-     */
+-    while (at2 != NULL)
+-      {
+-	family = at2->family;
+-	if (family == AF_INET6)
+-	  {
+-	    socklen = sizeof (struct sockaddr_in6);
+-
+-	    /* If we looked up IPv4 mapped address discard them here if
+-	       the caller isn't interested in all address and we have
+-	       found at least one IPv6 address.  */
+-	    if (res.got_ipv6
+-		&& (req->ai_flags & (AI_V4MAPPED|AI_ALL)) == AI_V4MAPPED
+-		&& IN6_IS_ADDR_V4MAPPED (at2->addr))
+-	      goto ignore;
+-	  }
+-	else
+-	  socklen = sizeof (struct sockaddr_in);
+-
+-	for (int i = 0; st[i].set; i++)
+-	  {
+-	    struct addrinfo *ai;
+-	    ai = *pai = malloc (sizeof (struct addrinfo) + socklen);
+-	    if (ai == NULL)
+-	      {
+-		result = -EAI_MEMORY;
+-		goto free_and_return;
+-	      }
+-
+-	    ai->ai_flags = req->ai_flags;
+-	    ai->ai_family = family;
+-	    ai->ai_socktype = st[i].socktype;
+-	    ai->ai_protocol = st[i].protocol;
+-	    ai->ai_addrlen = socklen;
+-	    ai->ai_addr = (void *) (ai + 1);
+-
+-	    /* We only add the canonical name once.  */
+-	    ai->ai_canonname = res.canon;
+-	    res.canon = NULL;
+-
+-#ifdef _HAVE_SA_LEN
+-	    ai->ai_addr->sa_len = socklen;
+-#endif /* _HAVE_SA_LEN */
+-	    ai->ai_addr->sa_family = family;
+-
+-	    /* In case of an allocation error the list must be NULL
+-	       terminated.  */
+-	    ai->ai_next = NULL;
+-
+-	    if (family == AF_INET6)
+-	      {
+-		struct sockaddr_in6 *sin6p =
+-		  (struct sockaddr_in6 *) ai->ai_addr;
+-
+-		sin6p->sin6_port = st[i].port;
+-		sin6p->sin6_flowinfo = 0;
+-		memcpy (&sin6p->sin6_addr,
+-			at2->addr, sizeof (struct in6_addr));
+-		sin6p->sin6_scope_id = at2->scopeid;
+-	      }
+-	    else
+-	      {
+-		struct sockaddr_in *sinp =
+-		  (struct sockaddr_in *) ai->ai_addr;
+-		sinp->sin_port = st[i].port;
+-		memcpy (&sinp->sin_addr,
+-			at2->addr, sizeof (struct in_addr));
+-		memset (sinp->sin_zero, '\0', sizeof (sinp->sin_zero));
+-	      }
+-
+-	    pai = &(ai->ai_next);
+-	  }
+-
+-	++*naddrs;
++  /* Set up the canonical name if we need it.  */
++  if ((result = process_canonname (req, orig_name, &res)) != 0)
++    goto free_and_return;
+
+-      ignore:
+-	at2 = at2->next;
+-      }
+-  }
++  result = generate_addrinfo (req, &res, st, pai, naddrs);
+
+- free_and_return:
++free_and_return:
+   if (malloc_name)
+     free ((char *) name);
+   free (addrmem);
+
+From 1b9087dcec81e2fd5d7c59ae66d04bd2f0bb64ad Mon Sep 17 00:00:00 2001
+From: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Date: Wed, 2 Mar 2022 11:45:29 +0530
+Subject: [PATCH] gethosts: Return EAI_MEMORY on allocation failure
+
+All other cases of failures due to lack of memory return EAI_MEMORY, so
+it seems wrong to return EAI_SYSTEM here.  The only reason
+convert_hostent_to_gaih_addrtuple could fail is on calloc failure.
+
+Signed-off-by: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Reviewed-by: DJ Delorie <dj@redhat.com>
+(cherry picked from commit b587456c0e7b59dcfdbd2d44db000a3bc8244e57)
+---
+ sysdeps/posix/getaddrinfo.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/sysdeps/posix/getaddrinfo.c b/sysdeps/posix/getaddrinfo.c
+index f5d4a5cfd9..0ece3b46b7 100644
+--- a/sysdeps/posix/getaddrinfo.c
++++ b/sysdeps/posix/getaddrinfo.c
+@@ -303,13 +303,13 @@ gethosts (nss_gethostbyname3_r fct, int family, const char *name,
+   else if (status == NSS_STATUS_SUCCESS)
+     {
+       if (!convert_hostent_to_gaih_addrtuple (req, family, &th, res))
+-	return -EAI_SYSTEM;
++	return -EAI_MEMORY;
+
+       if (localcanon != NULL && res->canon == NULL)
+ 	{
+ 	  char *canonbuf = __strdup (localcanon);
+ 	  if (canonbuf == NULL)
+-	    return  -EAI_SYSTEM;
++	    return  -EAI_MEMORY;
+ 	  res->canon = canonbuf;
+ 	}
+     }
+
+From e3ccb230a961b4797510e6a1f5f21fd9021853e7 Mon Sep 17 00:00:00 2001
+From: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Date: Fri, 15 Sep 2023 13:51:12 -0400
+Subject: [PATCH] getaddrinfo: Fix use after free in getcanonname
+ (CVE-2023-4806)
+
+When an NSS plugin only implements the _gethostbyname2_r and
+_getcanonname_r callbacks, getaddrinfo could use memory that was freed
+during tmpbuf resizing, through h_name in a previous query response.
+
+The backing store for res->at->name when doing a query with
+gethostbyname3_r or gethostbyname2_r is tmpbuf, which is reallocated in
+gethosts during the query.  For AF_INET6 lookup with AI_ALL |
+AI_V4MAPPED, gethosts gets called twice, once for a v6 lookup and second
+for a v4 lookup.  In this case, if the first call reallocates tmpbuf
+enough number of times, resulting in a malloc, th->h_name (that
+res->at->name refers to) ends up on a heap allocated storage in tmpbuf.
+Now if the second call to gethosts also causes the plugin callback to
+return NSS_STATUS_TRYAGAIN, tmpbuf will get freed, resulting in a UAF
+reference in res->at->name.  This then gets dereferenced in the
+getcanonname_r plugin call, resulting in the use after free.
+
+Fix this by copying h_name over and freeing it at the end.  This
+resolves BZ #30843, which is assigned CVE-2023-4806.
+
+Signed-off-by: Siddhesh Poyarekar <siddhesh@sourceware.org>
+(cherry picked from commit 973fe93a5675c42798b2161c6f29c01b0e243994)
+---
+ nss/Makefile                                  | 15 ++++-
+ nss/nss_test_gai_hv2_canonname.c              | 56 +++++++++++++++++
+ nss/tst-nss-gai-hv2-canonname.c               | 63 +++++++++++++++++++
+ nss/tst-nss-gai-hv2-canonname.h               |  1 +
+ .../postclean.req                             |  0
+ .../tst-nss-gai-hv2-canonname.script          |  2 +
+ sysdeps/posix/getaddrinfo.c                   | 25 +++++---
+ 7 files changed, 152 insertions(+), 10 deletions(-)
+ create mode 100644 nss/nss_test_gai_hv2_canonname.c
+ create mode 100644 nss/tst-nss-gai-hv2-canonname.c
+ create mode 100644 nss/tst-nss-gai-hv2-canonname.h
+ create mode 100644 nss/tst-nss-gai-hv2-canonname.root/postclean.req
+ create mode 100644 nss/tst-nss-gai-hv2-canonname.root/tst-nss-gai-hv2-canonname.script
+
+diff --git a/nss/Makefile b/nss/Makefile
+index d8b06b44fb..ed1c05158e 100644
+--- a/nss/Makefile
++++ b/nss/Makefile
+@@ -80,6 +80,7 @@ tests-container := \
+   tst-nss-test3 \
+   tst-reload1 \
+   tst-reload2 \
++  tst-nss-gai-hv2-canonname \
+ # tests-container
+
+ # Tests which need libdl
+@@ -143,7 +144,8 @@ libnss_compat-inhibit-o	= $(filter-out .os,$(object-suffixes))
+ ifeq ($(build-static-nss),yes)
+ tests-static		+= tst-nss-static
+ endif
+-extra-test-objs		+= nss_test1.os nss_test2.os nss_test_errno.os
++extra-test-objs		+= nss_test1.os nss_test2.os nss_test_errno.os \
++			   nss_test_gai_hv2_canonname.os
+
+ include ../Rules
+
+@@ -178,12 +180,16 @@ rtld-tests-LDFLAGS += -Wl,--dynamic-list=nss_test.ver
+ libof-nss_test1 = extramodules
+ libof-nss_test2 = extramodules
+ libof-nss_test_errno = extramodules
++libof-nss_test_gai_hv2_canonname = extramodules
+ $(objpfx)/libnss_test1.so: $(objpfx)nss_test1.os $(link-libc-deps)
+ 	$(build-module)
+ $(objpfx)/libnss_test2.so: $(objpfx)nss_test2.os $(link-libc-deps)
+ 	$(build-module)
+ $(objpfx)/libnss_test_errno.so: $(objpfx)nss_test_errno.os $(link-libc-deps)
+ 	$(build-module)
++$(objpfx)/libnss_test_gai_hv2_canonname.so: \
++  $(objpfx)nss_test_gai_hv2_canonname.os $(link-libc-deps)
++	$(build-module)
+ $(objpfx)nss_test2.os : nss_test1.c
+ # Use the nss_files suffix for these objects as well.
+ $(objpfx)/libnss_test1.so$(libnss_files.so-version): $(objpfx)/libnss_test1.so
+@@ -193,10 +199,14 @@ $(objpfx)/libnss_test2.so$(libnss_files.so-version): $(objpfx)/libnss_test2.so
+ $(objpfx)/libnss_test_errno.so$(libnss_files.so-version): \
+   $(objpfx)/libnss_test_errno.so
+ 	$(make-link)
++$(objpfx)/libnss_test_gai_hv2_canonname.so$(libnss_files.so-version): \
++  $(objpfx)/libnss_test_gai_hv2_canonname.so
++	$(make-link)
+ $(patsubst %,$(objpfx)%.out,$(tests) $(tests-container)) : \
+ 	$(objpfx)/libnss_test1.so$(libnss_files.so-version) \
+ 	$(objpfx)/libnss_test2.so$(libnss_files.so-version) \
+-	$(objpfx)/libnss_test_errno.so$(libnss_files.so-version)
++	$(objpfx)/libnss_test_errno.so$(libnss_files.so-version) \
++	$(objpfx)/libnss_test_gai_hv2_canonname.so$(libnss_files.so-version)
+
+ ifeq (yes,$(have-thread-library))
+ $(objpfx)tst-cancel-getpwuid_r: $(shared-thread-library)
+@@ -213,3 +223,4 @@ LDFLAGS-tst-nss-test3 = -Wl,--disable-new-dtags
+ LDFLAGS-tst-nss-test4 = -Wl,--disable-new-dtags
+ LDFLAGS-tst-nss-test5 = -Wl,--disable-new-dtags
+ LDFLAGS-tst-nss-test_errno = -Wl,--disable-new-dtags
++LDFLAGS-tst-nss-test_gai_hv2_canonname = -Wl,--disable-new-dtags
+diff --git a/nss/nss_test_gai_hv2_canonname.c b/nss/nss_test_gai_hv2_canonname.c
+new file mode 100644
+index 0000000000..4439c83c9f
+--- /dev/null
++++ b/nss/nss_test_gai_hv2_canonname.c
+@@ -0,0 +1,56 @@
++/* NSS service provider that only provides gethostbyname2_r.
++   Copyright The GNU Toolchain Authors.
++   This file is part of the GNU C Library.
++
++   The GNU C Library is free software; you can redistribute it and/or
++   modify it under the terms of the GNU Lesser General Public
++   License as published by the Free Software Foundation; either
++   version 2.1 of the License, or (at your option) any later version.
++
++   The GNU C Library is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   Lesser General Public License for more details.
++
++   You should have received a copy of the GNU Lesser General Public
++   License along with the GNU C Library; if not, see
++   <https://www.gnu.org/licenses/>.  */
++
++#include <nss.h>
++#include <stdlib.h>
++#include <string.h>
++#include "nss/tst-nss-gai-hv2-canonname.h"
++
++/* Catch misnamed and functions.  */
++#pragma GCC diagnostic error "-Wmissing-prototypes"
++NSS_DECLARE_MODULE_FUNCTIONS (test_gai_hv2_canonname)
++
++extern enum nss_status _nss_files_gethostbyname2_r (const char *, int,
++						    struct hostent *, char *,
++						    size_t, int *, int *);
++
++enum nss_status
++_nss_test_gai_hv2_canonname_gethostbyname2_r (const char *name, int af,
++					      struct hostent *result,
++					      char *buffer, size_t buflen,
++					      int *errnop, int *herrnop)
++{
++  return _nss_files_gethostbyname2_r (name, af, result, buffer, buflen, errnop,
++				      herrnop);
++}
++
++enum nss_status
++_nss_test_gai_hv2_canonname_getcanonname_r (const char *name, char *buffer,
++					    size_t buflen, char **result,
++					    int *errnop, int *h_errnop)
++{
++  /* We expect QUERYNAME, which is a small enough string that it shouldn't fail
++     the test.  */
++  if (memcmp (QUERYNAME, name, sizeof (QUERYNAME))
++      || buflen < sizeof (QUERYNAME))
++    abort ();
++
++  strncpy (buffer, name, buflen);
++  *result = buffer;
++  return NSS_STATUS_SUCCESS;
++}
+diff --git a/nss/tst-nss-gai-hv2-canonname.c b/nss/tst-nss-gai-hv2-canonname.c
+new file mode 100644
+index 0000000000..d5f10c07d6
+--- /dev/null
++++ b/nss/tst-nss-gai-hv2-canonname.c
+@@ -0,0 +1,63 @@
++/* Test NSS query path for plugins that only implement gethostbyname2
++   (#30843).
++   Copyright The GNU Toolchain Authors.
++   This file is part of the GNU C Library.
++
++   The GNU C Library is free software; you can redistribute it and/or
++   modify it under the terms of the GNU Lesser General Public
++   License as published by the Free Software Foundation; either
++   version 2.1 of the License, or (at your option) any later version.
++
++   The GNU C Library is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   Lesser General Public License for more details.
++
++   You should have received a copy of the GNU Lesser General Public
++   License along with the GNU C Library; if not, see
++   <https://www.gnu.org/licenses/>.  */
++
++#include <nss.h>
++#include <netdb.h>
++#include <stdlib.h>
++#include <string.h>
++#include <support/check.h>
++#include <support/xstdio.h>
++#include "nss/tst-nss-gai-hv2-canonname.h"
++
++#define PREPARE do_prepare
++
++static void do_prepare (int a, char **av)
++{
++  FILE *hosts = xfopen ("/etc/hosts", "w");
++  for (unsigned i = 2; i < 255; i++)
++    {
++      fprintf (hosts, "ff01::ff02:ff03:%u:2\ttest.example.com\n", i);
++      fprintf (hosts, "192.168.0.%u\ttest.example.com\n", i);
++    }
++  xfclose (hosts);
++}
++
++static int
++do_test (void)
++{
++  __nss_configure_lookup ("hosts", "test_gai_hv2_canonname");
++
++  struct addrinfo hints = {};
++  struct addrinfo *result = NULL;
++
++  hints.ai_family = AF_INET6;
++  hints.ai_flags = AI_ALL | AI_V4MAPPED | AI_CANONNAME;
++
++  int ret = getaddrinfo (QUERYNAME, NULL, &hints, &result);
++
++  if (ret != 0)
++    FAIL_EXIT1 ("getaddrinfo failed: %s\n", gai_strerror (ret));
++
++  TEST_COMPARE_STRING (result->ai_canonname, QUERYNAME);
++
++  freeaddrinfo(result);
++  return 0;
++}
++
++#include <support/test-driver.c>
+diff --git a/nss/tst-nss-gai-hv2-canonname.h b/nss/tst-nss-gai-hv2-canonname.h
+new file mode 100644
+index 0000000000..14f2a9cb08
+--- /dev/null
++++ b/nss/tst-nss-gai-hv2-canonname.h
+@@ -0,0 +1 @@
++#define QUERYNAME "test.example.com"
+diff --git a/nss/tst-nss-gai-hv2-canonname.root/postclean.req b/nss/tst-nss-gai-hv2-canonname.root/postclean.req
+new file mode 100644
+index 0000000000..e69de29bb2
+diff --git a/nss/tst-nss-gai-hv2-canonname.root/tst-nss-gai-hv2-canonname.script b/nss/tst-nss-gai-hv2-canonname.root/tst-nss-gai-hv2-canonname.script
+new file mode 100644
+index 0000000000..31848b4a28
+--- /dev/null
++++ b/nss/tst-nss-gai-hv2-canonname.root/tst-nss-gai-hv2-canonname.script
+@@ -0,0 +1,2 @@
++cp $B/nss/libnss_test_gai_hv2_canonname.so $L/libnss_test_gai_hv2_canonname.so.2
++su
+diff --git a/sysdeps/posix/getaddrinfo.c b/sysdeps/posix/getaddrinfo.c
+index 0ece3b46b7..ad7891a953 100644
+--- a/sysdeps/posix/getaddrinfo.c
++++ b/sysdeps/posix/getaddrinfo.c
+@@ -120,6 +120,7 @@ struct gaih_result
+ {
+   struct gaih_addrtuple *at;
+   char *canon;
++  char *h_name;
+   bool free_at;
+   bool got_ipv6;
+ };
+@@ -165,6 +166,7 @@ gaih_result_reset (struct gaih_result *res)
+   if (res->free_at)
+     free (res->at);
+   free (res->canon);
++  free (res->h_name);
+   memset (res, 0, sizeof (*res));
+ }
+
+@@ -203,9 +205,8 @@ gaih_inet_serv (const char *servicename, const struct gaih_typeproto *tp,
+   return 0;
+ }
+
+-/* Convert struct hostent to a list of struct gaih_addrtuple objects.  h_name
+-   is not copied, and the struct hostent object must not be deallocated
+-   prematurely.  The new addresses are appended to the tuple array in RES.  */
++/* Convert struct hostent to a list of struct gaih_addrtuple objects.  The new
++   addresses are appended to the tuple array in RES.  */
+ static bool
+ convert_hostent_to_gaih_addrtuple (const struct addrinfo *req, int family,
+ 				   struct hostent *h, struct gaih_result *res)
+@@ -238,6 +239,15 @@ convert_hostent_to_gaih_addrtuple (const struct addrinfo *req, int family,
+   res->at = array;
+   res->free_at = true;
+
++  /* Duplicate h_name because it may get reclaimed when the underlying storage
++     is freed.  */
++  if (res->h_name == NULL)
++    {
++      res->h_name = __strdup (h->h_name);
++      if (res->h_name == NULL)
++	return false;
++    }
++
+   /* Update the next pointers on reallocation.  */
+   for (size_t i = 0; i < old; i++)
+     array[i].next = array + i + 1;
+@@ -262,7 +272,6 @@ convert_hostent_to_gaih_addrtuple (const struct addrinfo *req, int family,
+ 	}
+       array[i].next = array + i + 1;
+     }
+-  array[0].name = h->h_name;
+   array[count - 1].next = NULL;
+
+   return true;
+@@ -324,15 +333,15 @@ gethosts (nss_gethostbyname3_r fct, int family, const char *name,
+    memory allocation failure.  The returned string is allocated on the
+    heap; the caller has to free it.  */
+ static char *
+-getcanonname (nss_action_list nip, struct gaih_addrtuple *at, const char *name)
++getcanonname (nss_action_list nip, const char *hname, const char *name)
+ {
+   nss_getcanonname_r *cfct = __nss_lookup_function (nip, "getcanonname_r");
+   char *s = (char *) name;
+   if (cfct != NULL)
+     {
+       char buf[256];
+-      if (DL_CALL_FCT (cfct, (at->name ?: name, buf, sizeof (buf),
+-			      &s, &errno, &h_errno)) != NSS_STATUS_SUCCESS)
++      if (DL_CALL_FCT (cfct, (hname ?: name, buf, sizeof (buf), &s, &errno,
++			      &h_errno)) != NSS_STATUS_SUCCESS)
+ 	/* If the canonical name cannot be determined, use the passed
+ 	   string.  */
+ 	s = (char *) name;
+@@ -771,7 +780,7 @@ get_nss_addresses (const char *name, const struct addrinfo *req,
+ 		  if ((req->ai_flags & AI_CANONNAME) != 0
+ 		      && res->canon == NULL)
+ 		    {
+-		      char *canonbuf = getcanonname (nip, res->at, name);
++		      char *canonbuf = getcanonname (nip, res->h_name, name);
+ 		      if (canonbuf == NULL)
+ 			{
+ 			  __resolv_context_put (res_ctx);
+
+From c84018a05aec80f5ee6f682db0da1130b0196aef Mon Sep 17 00:00:00 2001
+From: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Date: Tue, 19 Sep 2023 18:39:32 -0400
+Subject: [PATCH] tunables: Terminate if end of input is reached
+ (CVE-2023-4911)
+
+The string parsing routine may end up writing beyond bounds of tunestr
+if the input tunable string is malformed, of the form name=name=val.
+This gets processed twice, first as name=name=val and next as name=val,
+resulting in tunestr being name=name=val:name=val, thus overflowing
+tunestr.
+
+Terminate the parsing loop at the first instance itself so that tunestr
+does not overflow.
+
+This also fixes up tst-env-setuid-tunables to actually handle failures
+correct and add new tests to validate the fix for this CVE.
+
+Signed-off-by: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Reviewed-by: Carlos O'Donell <carlos@redhat.com>
+(cherry picked from commit 1056e5b4c3f2d90ed2b4a55f96add28da2f4c8fa)
+---
+ elf/dl-tunables.c             | 17 +++++++++-------
+ elf/tst-env-setuid-tunables.c | 37 +++++++++++++++++++++++++++--------
+ 2 files changed, 39 insertions(+), 15 deletions(-)
+
+diff --git a/elf/dl-tunables.c b/elf/dl-tunables.c
+index 8e7ee9df10..76cf8b9da3 100644
+--- a/elf/dl-tunables.c
++++ b/elf/dl-tunables.c
+@@ -187,11 +187,7 @@ parse_tunables (char *tunestr, char *valstring)
+       /* If we reach the end of the string before getting a valid name-value
+ 	 pair, bail out.  */
+       if (p[len] == '\0')
+-	{
+-	  if (__libc_enable_secure)
+-	    tunestr[off] = '\0';
+-	  return;
+-	}
++	break;
+
+       /* We did not find a valid name-value pair before encountering the
+ 	 colon.  */
+@@ -251,9 +247,16 @@ parse_tunables (char *tunestr, char *valstring)
+ 	    }
+ 	}
+
+-      if (p[len] != '\0')
+-	p += len + 1;
++      /* We reached the end while processing the tunable string.  */
++      if (p[len] == '\0')
++	break;
++
++      p += len + 1;
+     }
++
++  /* Terminate tunestr before we leave.  */
++  if (__libc_enable_secure)
++    tunestr[off] = '\0';
+ }
+ #endif
+
+diff --git a/elf/tst-env-setuid-tunables.c b/elf/tst-env-setuid-tunables.c
+index 88182b7b25..5e9e4c5756 100644
+--- a/elf/tst-env-setuid-tunables.c
++++ b/elf/tst-env-setuid-tunables.c
+@@ -52,6 +52,8 @@ const char *teststrings[] =
+   "glibc.malloc.perturb=0x800:not_valid.malloc.check=2:glibc.malloc.mmap_threshold=4096",
+   "glibc.not_valid.check=2:glibc.malloc.mmap_threshold=4096",
+   "not_valid.malloc.check=2:glibc.malloc.mmap_threshold=4096",
++  "glibc.malloc.mmap_threshold=glibc.malloc.mmap_threshold=4096",
++  "glibc.malloc.check=2",
+   "glibc.malloc.garbage=2:glibc.maoc.mmap_threshold=4096:glibc.malloc.check=2",
+   "glibc.malloc.check=4:glibc.malloc.garbage=2:glibc.maoc.mmap_threshold=4096",
+   ":glibc.malloc.garbage=2:glibc.malloc.check=1",
+@@ -70,6 +72,8 @@ const char *resultstrings[] =
+   "glibc.malloc.perturb=0x800:glibc.malloc.mmap_threshold=4096",
+   "glibc.malloc.mmap_threshold=4096",
+   "glibc.malloc.mmap_threshold=4096",
++  "glibc.malloc.mmap_threshold=glibc.malloc.mmap_threshold=4096",
++  "",
+   "",
+   "",
+   "",
+@@ -84,11 +88,18 @@ test_child (int off)
+   const char *val = getenv ("GLIBC_TUNABLES");
+
+ #if HAVE_TUNABLES
++  printf ("    [%d] GLIBC_TUNABLES is %s\n", off, val);
++  fflush (stdout);
+   if (val != NULL && strcmp (val, resultstrings[off]) == 0)
+     return 0;
+
+   if (val != NULL)
+-    printf ("[%d] Unexpected GLIBC_TUNABLES VALUE %s\n", off, val);
++    printf ("    [%d] Unexpected GLIBC_TUNABLES VALUE %s, expected %s\n",
++	    off, val, resultstrings[off]);
++  else
++    printf ("    [%d] GLIBC_TUNABLES environment variable absent\n", off);
++
++  fflush (stdout);
+
+   return 1;
+ #else
+@@ -117,21 +128,26 @@ do_test (int argc, char **argv)
+       if (ret != 0)
+ 	exit (1);
+
+-      exit (EXIT_SUCCESS);
++      /* Special return code to make sure that the child executed all the way
++	 through.  */
++      exit (42);
+     }
+   else
+     {
+-      int ret = 0;
+-
+       /* Spawn tests.  */
+       for (int i = 0; i < array_length (teststrings); i++)
+ 	{
+ 	  char buf[INT_BUFSIZE_BOUND (int)];
+
+-	  printf ("Spawned test for %s (%d)\n", teststrings[i], i);
++	  printf ("[%d] Spawned test for %s\n", i, teststrings[i]);
+ 	  snprintf (buf, sizeof (buf), "%d\n", i);
++	  fflush (stdout);
+ 	  if (setenv ("GLIBC_TUNABLES", teststrings[i], 1) != 0)
+-	    exit (1);
++	    {
++	      printf ("    [%d] Failed to set GLIBC_TUNABLES: %m", i);
++	      support_record_failure ();
++	      continue;
++	    }
+
+ 	  int status = support_capture_subprogram_self_sgid (buf);
+
+@@ -139,9 +155,14 @@ do_test (int argc, char **argv)
+ 	  if (WEXITSTATUS (status) == EXIT_UNSUPPORTED)
+ 	    return EXIT_UNSUPPORTED;
+
+-	  ret |= status;
++	  if (WEXITSTATUS (status) != 42)
++	    {
++	      printf ("    [%d] child failed with status %d\n", i,
++		      WEXITSTATUS (status));
++	      support_record_failure ();
++	    }
+ 	}
+-      return ret;
++      return 0;
+     }
+ }
+
+
+From 17092c0311f954e6f3c010f73ce3a78c24ac279a Mon Sep 17 00:00:00 2001
+From: Romain Geissler <romain.geissler@amadeus.com>
+Date: Mon, 25 Sep 2023 01:21:51 +0100
+Subject: [PATCH] Fix leak in getaddrinfo introduced by the fix for
+ CVE-2023-4806 [BZ #30843]
+
+This patch fixes a very recently added leak in getaddrinfo.
+
+This was assigned CVE-2023-5156.
+
+Resolves: BZ #30884
+Related: BZ #30842
+
+Reviewed-by: Siddhesh Poyarekar <siddhesh@sourceware.org>
+(cherry picked from commit ec6b95c3303c700eb89eebeda2d7264cc184a796)
+---
+ nss/Makefile                    | 20 ++++++++++++++++++++
+ nss/tst-nss-gai-hv2-canonname.c |  3 +++
+ sysdeps/posix/getaddrinfo.c     |  4 +---
+ 3 files changed, 24 insertions(+), 3 deletions(-)
+
+diff --git a/nss/Makefile b/nss/Makefile
+index ed1c05158e..6cac7dd83b 100644
+--- a/nss/Makefile
++++ b/nss/Makefile
+@@ -147,6 +147,15 @@ endif
+ extra-test-objs		+= nss_test1.os nss_test2.os nss_test_errno.os \
+ 			   nss_test_gai_hv2_canonname.os
+
++ifeq ($(run-built-tests),yes)
++ifneq (no,$(PERL))
++tests-special += $(objpfx)mtrace-tst-nss-gai-hv2-canonname.out
++endif
++endif
++
++generated += mtrace-tst-nss-gai-hv2-canonname.out \
++		tst-nss-gai-hv2-canonname.mtrace
++
+ include ../Rules
+
+ ifeq (yes,$(have-selinux))
+@@ -215,6 +224,17 @@ endif
+ $(objpfx)tst-nss-files-alias-leak.out: $(objpfx)/libnss_files.so
+ $(objpfx)tst-nss-files-alias-truncated.out: $(objpfx)/libnss_files.so
+
++tst-nss-gai-hv2-canonname-ENV = \
++		MALLOC_TRACE=$(objpfx)tst-nss-gai-hv2-canonname.mtrace \
++		LD_PRELOAD=$(common-objpfx)/malloc/libc_malloc_debug.so
++$(objpfx)mtrace-tst-nss-gai-hv2-canonname.out: \
++  $(objpfx)tst-nss-gai-hv2-canonname.out
++	{ test -r $(objpfx)tst-nss-gai-hv2-canonname.mtrace \
++	|| ( echo "tst-nss-gai-hv2-canonname.mtrace does not exist"; exit 77; ) \
++	&& $(common-objpfx)malloc/mtrace \
++	$(objpfx)tst-nss-gai-hv2-canonname.mtrace; } > $@; \
++	$(evaluate-test)
++
+ # Disable DT_RUNPATH on NSS tests so that the glibc internal NSS
+ # functions can load testing NSS modules via DT_RPATH.
+ LDFLAGS-tst-nss-test1 = -Wl,--disable-new-dtags
+diff --git a/nss/tst-nss-gai-hv2-canonname.c b/nss/tst-nss-gai-hv2-canonname.c
+index d5f10c07d6..7db53cf09d 100644
+--- a/nss/tst-nss-gai-hv2-canonname.c
++++ b/nss/tst-nss-gai-hv2-canonname.c
+@@ -21,6 +21,7 @@
+ #include <netdb.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <mcheck.h>
+ #include <support/check.h>
+ #include <support/xstdio.h>
+ #include "nss/tst-nss-gai-hv2-canonname.h"
+@@ -41,6 +42,8 @@ static void do_prepare (int a, char **av)
+ static int
+ do_test (void)
+ {
++  mtrace ();
++
+   __nss_configure_lookup ("hosts", "test_gai_hv2_canonname");
+
+   struct addrinfo hints = {};
+diff --git a/sysdeps/posix/getaddrinfo.c b/sysdeps/posix/getaddrinfo.c
+index ad7891a953..f4c08d6e3b 100644
+--- a/sysdeps/posix/getaddrinfo.c
++++ b/sysdeps/posix/getaddrinfo.c
+@@ -1196,9 +1196,7 @@ free_and_return:
+   if (malloc_name)
+     free ((char *) name);
+   free (addrmem);
+-  if (res.free_at)
+-    free (res.at);
+-  free (res.canon);
++  gaih_result_reset (&res);
+
+   return result;
+ }
+
+From e9eb987894007cf928a0a31df25a5d0435fb7911 Mon Sep 17 00:00:00 2001
+From: DJ Delorie <dj@redhat.com>
+Date: Mon, 28 Mar 2022 23:53:33 -0400
+Subject: [PATCH] Allow for unpriviledged nested containers
+
+If the build itself is run in a container, we may not be able to
+fully set up a nested container for test-container testing.
+Notably is the mounting of /proc, since it's critical that it
+be mounted from within the same PID namespace as its users, and
+thus cannot be bind mounted from outside the container like other
+mounts.
+
+This patch defaults to using the parent's PID namespace instead of
+creating a new one, as this is more likely to be allowed.
+
+If the test needs an isolated PID namespace, it should add the "pidns"
+command to its init script.
+
+Reviewed-by: Carlos O'Donell <carlos@redhat.com>
+(cherry picked from commit 2fe64148a81f0d78050c302f34a6853d21f7cae4)
+---
+ elf/tst-pldd.c              |   2 +
+ nptl/tst-pthread-getattr.c  |   4 +
+ nss/tst-reload2.c           |   2 +
+ support/Makefile            |   1 +
+ support/support.h           |   5 ++
+ support/support_need_proc.c |  35 +++++++++
+ support/test-container.c    | 141 +++++++++++++++++++++++++++---------
+ 7 files changed, 155 insertions(+), 35 deletions(-)
+ create mode 100644 support/support_need_proc.c
+
+diff --git a/elf/tst-pldd.c b/elf/tst-pldd.c
+index 8916ce5a2e..0616545b1d 100644
+--- a/elf/tst-pldd.c
++++ b/elf/tst-pldd.c
+@@ -85,6 +85,8 @@ in_str_list (const char *libname, const char *const strlist[])
+ static int
+ do_test (void)
+ {
++  support_need_proc ("needs /proc/sys/kernel/yama/ptrace_scope and /proc/$child");
++
+   /* Check if our subprocess can be debugged with ptrace.  */
+   {
+     int ptrace_scope = support_ptrace_scope ();
+diff --git a/nptl/tst-pthread-getattr.c b/nptl/tst-pthread-getattr.c
+index d2ebf308ae..3f6f76ea83 100644
+--- a/nptl/tst-pthread-getattr.c
++++ b/nptl/tst-pthread-getattr.c
+@@ -28,6 +28,8 @@
+ #include <unistd.h>
+ #include <inttypes.h>
+
++#include <support/support.h>
++
+ /* There is an obscure bug in the kernel due to which RLIMIT_STACK is sometimes
+    returned as unlimited when it is not, which may cause this test to fail.
+    There is also the other case where RLIMIT_STACK is intentionally set as
+@@ -153,6 +155,8 @@ check_stack_top (void)
+ static int
+ do_test (void)
+ {
++  support_need_proc ("Reads /proc/self/maps to get stack size.");
++
+   pagesize = sysconf (_SC_PAGESIZE);
+   return check_stack_top ();
+ }
+diff --git a/nss/tst-reload2.c b/nss/tst-reload2.c
+index fb3b94a1fa..7df0ca740b 100644
+--- a/nss/tst-reload2.c
++++ b/nss/tst-reload2.c
+@@ -95,6 +95,8 @@ do_test (void)
+   char buf1[PATH_MAX];
+   char buf2[PATH_MAX];
+
++  support_need_proc ("Our xmkdirp fails if we can't map our uid, which requires /proc.");
++
+   sprintf (buf1, "/subdir%s", support_slibdir_prefix);
+   xmkdirp (buf1, 0777);
+
+diff --git a/support/Makefile b/support/Makefile
+index 5ddcb8d158..f036a81304 100644
+--- a/support/Makefile
++++ b/support/Makefile
+@@ -64,6 +64,7 @@ libsupport-routines = \
+   support_format_netent \
+   support_isolate_in_subprocess \
+   support_mutex_pi_monotonic \
++  support_need_proc \
+   support_path_support_time64 \
+   support_process_state \
+   support_ptrace \
+diff --git a/support/support.h b/support/support.h
+index 73b9fc48f0..d20051da4d 100644
+--- a/support/support.h
++++ b/support/support.h
+@@ -91,6 +91,11 @@ char *support_quote_string (const char *);
+    regular file open for writing, and initially empty.  */
+ int support_descriptor_supports_holes (int fd);
+
++/* Predicates that a test requires a working /proc filesystem.  This
++   call will exit with UNSUPPORTED if /proc is not available, printing
++   WHY_MSG as part of the diagnostic.  */
++void support_need_proc (const char *why_msg);
++
+ /* Error-checking wrapper functions which terminate the process on
+    error.  */
+
+diff --git a/support/support_need_proc.c b/support/support_need_proc.c
+new file mode 100644
+index 0000000000..9b4eab7539
+--- /dev/null
++++ b/support/support_need_proc.c
+@@ -0,0 +1,35 @@
++/* Indicate that a test requires a working /proc.
++   Copyright (C) 2022 Free Software Foundation, Inc.
++   This file is part of the GNU C Library.
++
++   The GNU C Library is free software; you can redistribute it and/or
++   modify it under the terms of the GNU Lesser General Public
++   License as published by the Free Software Foundation; either
++   version 2.1 of the License, or (at your option) any later version.
++
++   The GNU C Library is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   Lesser General Public License for more details.
++
++   You should have received a copy of the GNU Lesser General Public
++   License along with the GNU C Library; if not, see
++   <https://www.gnu.org/licenses/>.  */
++
++#include <unistd.h>
++#include <support/check.h>
++#include <support/support.h>
++
++/* We test for /proc/self/maps since that's one of the files that one
++   of our tests actually uses, but the general idea is if Linux's
++   /proc/ (procfs) filesystem is mounted.  If not, the process exits
++   with an UNSUPPORTED result code.  */
++
++void
++support_need_proc (const char *why_msg)
++{
++#ifdef __linux__
++  if (access ("/proc/self/maps", R_OK))
++    FAIL_UNSUPPORTED ("/proc is not available, %s", why_msg);
++#endif
++}
+diff --git a/support/test-container.c b/support/test-container.c
+index 25e7f14219..c837c4d758 100644
+--- a/support/test-container.c
++++ b/support/test-container.c
+@@ -97,6 +97,7 @@ int verbose = 0;
+    * mytest.root/mytest.script has a list of "commands" to run:
+        syntax:
+          # comment
++	 pidns <comment>
+          su
+          mv FILE FILE
+ 	 cp FILE FILE
+@@ -122,6 +123,8 @@ int verbose = 0;
+
+        details:
+          - '#': A comment.
++	 - 'pidns': Require a separate PID namespace, prints comment if it can't
++	    (default is a shared pid namespace)
+          - 'su': Enables running test as root in the container.
+          - 'mv': A minimal move files command.
+          - 'cp': A minimal copy files command.
+@@ -148,7 +151,7 @@ int verbose = 0;
+    * Simple, easy to review code (i.e. prefer simple naive code over
+      complex efficient code)
+
+-   * The current implementation ist parallel-make-safe, but only in
++   * The current implementation is parallel-make-safe, but only in
+      that it uses a lock to prevent parallel access to the testroot.  */
+
+ 
+@@ -227,11 +230,37 @@ concat (const char *str, ...)
+   return bufs[n];
+ }
+
++/* Like the above, but put spaces between words.  Caller frees.  */
++static char *
++concat_words (char **words, int num_words)
++{
++  int len = 0;
++  int i;
++  char *rv, *p;
++
++  for (i = 0; i < num_words; i ++)
++    {
++      len += strlen (words[i]);
++      len ++;
++    }
++
++  p = rv = (char *) xmalloc (len);
++
++  for (i = 0; i < num_words; i ++)
++    {
++      if (i > 0)
++	p = stpcpy (p, " ");
++      p = stpcpy (p, words[i]);
++    }
++
++  return rv;
++}
++
+ /* Try to mount SRC onto DEST.  */
+ static void
+ trymount (const char *src, const char *dest)
+ {
+-  if (mount (src, dest, "", MS_BIND, NULL) < 0)
++  if (mount (src, dest, "", MS_BIND | MS_REC, NULL) < 0)
+     FAIL_EXIT1 ("can't mount %s onto %s\n", src, dest);
+ }
+
+@@ -726,6 +755,9 @@ main (int argc, char **argv)
+   gid_t original_gid;
+   /* If set, the test runs as root instead of the user running the testsuite.  */
+   int be_su = 0;
++  int require_pidns = 0;
++  const char *pidns_comment = NULL;
++  int do_proc_mounts = 0;
+   int UMAP;
+   int GMAP;
+   /* Used for "%lld %lld 1" so need not be large.  */
+@@ -1011,6 +1043,12 @@ main (int argc, char **argv)
+ 	      {
+ 		be_su = 1;
+ 	      }
++	    else if (nt >= 1 && strcmp (the_words[0], "pidns") == 0)
++	      {
++		require_pidns = 1;
++		if (nt > 1)
++		  pidns_comment = concat_words (the_words + 1, nt - 1);
++	      }
+ 	    else if (nt == 3 && strcmp (the_words[0], "mkdirp") == 0)
+ 	      {
+ 		long int m;
+@@ -1068,7 +1106,8 @@ main (int argc, char **argv)
+
+ #ifdef CLONE_NEWNS
+   /* The unshare here gives us our own spaces and capabilities.  */
+-  if (unshare (CLONE_NEWUSER | CLONE_NEWPID | CLONE_NEWNS) < 0)
++  if (unshare (CLONE_NEWUSER | CLONE_NEWNS
++	       | (require_pidns ? CLONE_NEWPID : 0)) < 0)
+     {
+       /* Older kernels may not support all the options, or security
+ 	 policy may block this call.  */
+@@ -1079,6 +1118,11 @@ main (int argc, char **argv)
+ 	    check_for_unshare_hints ();
+ 	  FAIL_UNSUPPORTED ("unable to unshare user/fs: %s", strerror (saved_errno));
+ 	}
++      /* We're about to exit anyway, it's "safe" to call unshare again
++	 just to see if the CLONE_NEWPID caused the error.  */
++      else if (require_pidns && unshare (CLONE_NEWUSER | CLONE_NEWNS) >= 0)
++	FAIL_EXIT1 ("unable to unshare pid ns: %s : %s", strerror (errno),
++		    pidns_comment ? pidns_comment : "required by test");
+       else
+ 	FAIL_EXIT1 ("unable to unshare user/fs: %s", strerror (errno));
+     }
+@@ -1094,6 +1138,15 @@ main (int argc, char **argv)
+   trymount (support_srcdir_root, new_srcdir_path);
+   trymount (support_objdir_root, new_objdir_path);
+
++  /* It may not be possible to mount /proc directly.  */
++  if (! require_pidns)
++  {
++    char *new_proc = concat (new_root_path, "/proc", NULL);
++    xmkdirp (new_proc, 0755);
++    trymount ("/proc", new_proc);
++    do_proc_mounts = 1;
++  }
++
+   xmkdirp (concat (new_root_path, "/dev", NULL), 0755);
+   devmount (new_root_path, "null");
+   devmount (new_root_path, "zero");
+@@ -1163,42 +1216,60 @@ main (int argc, char **argv)
+
+   maybe_xmkdir ("/tmp", 0755);
+
+-  /* Now that we're pid 1 (effectively "root") we can mount /proc  */
+-  maybe_xmkdir ("/proc", 0777);
+-  if (mount ("proc", "/proc", "proc", 0, NULL) < 0)
+-    FAIL_EXIT1 ("Unable to mount /proc: ");
+-
+-  /* We map our original UID to the same UID in the container so we
+-     can own our own files normally.  */
+-  UMAP = open ("/proc/self/uid_map", O_WRONLY);
+-  if (UMAP < 0)
+-    FAIL_EXIT1 ("can't write to /proc/self/uid_map\n");
+-
+-  sprintf (tmp, "%lld %lld 1\n",
+-	   (long long) (be_su ? 0 : original_uid), (long long) original_uid);
+-  write (UMAP, tmp, strlen (tmp));
+-  xclose (UMAP);
+-
+-  /* We must disable setgroups () before we can map our groups, else we
+-     get EPERM.  */
+-  GMAP = open ("/proc/self/setgroups", O_WRONLY);
+-  if (GMAP >= 0)
++  if (require_pidns)
+     {
+-      /* We support kernels old enough to not have this.  */
+-      write (GMAP, "deny\n", 5);
+-      xclose (GMAP);
++      /* Now that we're pid 1 (effectively "root") we can mount /proc  */
++      maybe_xmkdir ("/proc", 0777);
++      if (mount ("proc", "/proc", "proc", 0, NULL) != 0)
++	{
++	  /* This happens if we're trying to create a nested container,
++	     like if the build is running under podman, and we lack
++	     priviledges.
++
++	     Ideally we would WARN here, but that would just add noise to
++	     *every* test-container test, and the ones that care should
++	     have their own relevent diagnostics.
++
++	     FAIL_EXIT1 ("Unable to mount /proc: ");  */
++	}
++      else
++	do_proc_mounts = 1;
+     }
+
+-  /* We map our original GID to the same GID in the container so we
+-     can own our own files normally.  */
+-  GMAP = open ("/proc/self/gid_map", O_WRONLY);
+-  if (GMAP < 0)
+-    FAIL_EXIT1 ("can't write to /proc/self/gid_map\n");
++  if (do_proc_mounts)
++    {
++      /* We map our original UID to the same UID in the container so we
++	 can own our own files normally.  */
++      UMAP = open ("/proc/self/uid_map", O_WRONLY);
++      if (UMAP < 0)
++	FAIL_EXIT1 ("can't write to /proc/self/uid_map\n");
++
++      sprintf (tmp, "%lld %lld 1\n",
++	       (long long) (be_su ? 0 : original_uid), (long long) original_uid);
++      write (UMAP, tmp, strlen (tmp));
++      xclose (UMAP);
++
++      /* We must disable setgroups () before we can map our groups, else we
++	 get EPERM.  */
++      GMAP = open ("/proc/self/setgroups", O_WRONLY);
++      if (GMAP >= 0)
++	{
++	  /* We support kernels old enough to not have this.  */
++	  write (GMAP, "deny\n", 5);
++	  xclose (GMAP);
++	}
+
+-  sprintf (tmp, "%lld %lld 1\n",
+-	   (long long) (be_su ? 0 : original_gid), (long long) original_gid);
+-  write (GMAP, tmp, strlen (tmp));
+-  xclose (GMAP);
++      /* We map our original GID to the same GID in the container so we
++	 can own our own files normally.  */
++      GMAP = open ("/proc/self/gid_map", O_WRONLY);
++      if (GMAP < 0)
++	FAIL_EXIT1 ("can't write to /proc/self/gid_map\n");
++
++      sprintf (tmp, "%lld %lld 1\n",
++	       (long long) (be_su ? 0 : original_gid), (long long) original_gid);
++      write (GMAP, tmp, strlen (tmp));
++      xclose (GMAP);
++    }
+
+   if (change_cwd)
+     {
+
+From 36280d1ce5e245aabefb877fe4d3c6cff95dabfa Mon Sep 17 00:00:00 2001
+From: Charles Fol <folcharles@gmail.com>
+Date: Thu, 28 Mar 2024 12:25:38 -0300
+Subject: [PATCH] iconv: ISO-2022-CN-EXT: fix out-of-bound writes when writing
+ escape sequence (CVE-2024-2961)
+
+ISO-2022-CN-EXT uses escape sequences to indicate character set changes
+(as specified by RFC 1922).  While the SOdesignation has the expected
+bounds checks, neither SS2designation nor SS3designation have its;
+allowing a write overflow of 1, 2, or 3 bytes with fixed values:
+'$+I', '$+J', '$+K', '$+L', '$+M', or '$*H'.
+
+Checked on aarch64-linux-gnu.
+
+Co-authored-by: Adhemerval Zanella  <adhemerval.zanella@linaro.org>
+Reviewed-by: Carlos O'Donell <carlos@redhat.com>
+Tested-by: Carlos O'Donell <carlos@redhat.com>
+
+(cherry picked from commit f9dc609e06b1136bb0408be9605ce7973a767ada)
+---
+ iconvdata/Makefile                    |   5 +-
+ iconvdata/iso-2022-cn-ext.c           |  12 +++
+ iconvdata/tst-iconv-iso-2022-cn-ext.c | 128 ++++++++++++++++++++++++++
+ 3 files changed, 144 insertions(+), 1 deletion(-)
+ create mode 100644 iconvdata/tst-iconv-iso-2022-cn-ext.c
+
+diff --git a/iconvdata/Makefile b/iconvdata/Makefile
+index f4c089ed5d..d01b3fcab6 100644
+--- a/iconvdata/Makefile
++++ b/iconvdata/Makefile
+@@ -75,7 +75,8 @@ ifeq (yes,$(build-shared))
+ tests = bug-iconv1 bug-iconv2 tst-loading tst-e2big tst-iconv4 bug-iconv4 \
+ 	tst-iconv6 bug-iconv5 bug-iconv6 tst-iconv7 bug-iconv8 bug-iconv9 \
+ 	bug-iconv10 bug-iconv11 bug-iconv12 tst-iconv-big5-hkscs-to-2ucs4 \
+-	bug-iconv13 bug-iconv14 bug-iconv15
++	bug-iconv13 bug-iconv14 bug-iconv15 \
++	tst-iconv-iso-2022-cn-ext
+ ifeq ($(have-thread-library),yes)
+ tests += bug-iconv3
+ endif
+@@ -330,6 +331,8 @@ $(objpfx)bug-iconv14.out: $(addprefix $(objpfx), $(gconv-modules)) \
+ 			  $(addprefix $(objpfx),$(modules.so))
+ $(objpfx)bug-iconv15.out: $(addprefix $(objpfx), $(gconv-modules)) \
+ 			  $(addprefix $(objpfx),$(modules.so))
++$(objpfx)tst-iconv-iso-2022-cn-ext.out: $(addprefix $(objpfx), $(gconv-modules)) \
++					$(addprefix $(objpfx),$(modules.so))
+
+ $(objpfx)iconv-test.out: run-iconv-test.sh \
+ 			 $(addprefix $(objpfx), $(gconv-modules)) \
+diff --git a/iconvdata/iso-2022-cn-ext.c b/iconvdata/iso-2022-cn-ext.c
+index e09f358cad..2cc478a8c6 100644
+--- a/iconvdata/iso-2022-cn-ext.c
++++ b/iconvdata/iso-2022-cn-ext.c
+@@ -574,6 +574,12 @@ DIAG_IGNORE_Os_NEEDS_COMMENT (5, "-Wmaybe-uninitialized");
+ 	      {								      \
+ 		const char *escseq;					      \
+ 									      \
++		if (outptr + 4 > outend)				      \
++		  {							      \
++		    result = __GCONV_FULL_OUTPUT;			      \
++		    break;						      \
++		  }							      \
++									      \
+ 		assert (used == CNS11643_2_set); /* XXX */		      \
+ 		escseq = "*H";						      \
+ 		*outptr++ = ESC;					      \
+@@ -587,6 +593,12 @@ DIAG_IGNORE_Os_NEEDS_COMMENT (5, "-Wmaybe-uninitialized");
+ 	      {								      \
+ 		const char *escseq;					      \
+ 									      \
++		if (outptr + 4 > outend)				      \
++		  {							      \
++		    result = __GCONV_FULL_OUTPUT;			      \
++		    break;						      \
++		  }							      \
++									      \
+ 		assert ((used >> 5) >= 3 && (used >> 5) <= 7);		      \
+ 		escseq = "+I+J+K+L+M" + ((used >> 5) - 3) * 2;		      \
+ 		*outptr++ = ESC;					      \
+diff --git a/iconvdata/tst-iconv-iso-2022-cn-ext.c b/iconvdata/tst-iconv-iso-2022-cn-ext.c
+new file mode 100644
+index 0000000000..96a8765fd5
+--- /dev/null
++++ b/iconvdata/tst-iconv-iso-2022-cn-ext.c
+@@ -0,0 +1,128 @@
++/* Verify ISO-2022-CN-EXT does not write out of the bounds.
++   Copyright (C) 2024 Free Software Foundation, Inc.
++   This file is part of the GNU C Library.
++
++   The GNU C Library is free software; you can redistribute it and/or
++   modify it under the terms of the GNU Lesser General Public
++   License as published by the Free Software Foundation; either
++   version 2.1 of the License, or (at your option) any later version.
++
++   The GNU C Library is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   Lesser General Public License for more details.
++
++   You should have received a copy of the GNU Lesser General Public
++   License along with the GNU C Library; if not, see
++   <https://www.gnu.org/licenses/>.  */
++
++#include <stdio.h>
++#include <string.h>
++
++#include <errno.h>
++#include <iconv.h>
++#include <sys/mman.h>
++
++#include <support/xunistd.h>
++#include <support/check.h>
++#include <support/support.h>
++
++/* The test sets up a two memory page buffer with the second page marked
++   PROT_NONE to trigger a fault if the conversion writes beyond the exact
++   expected amount.  Then we carry out various conversions and precisely
++   place the start of the output buffer in order to trigger a SIGSEGV if the
++   process writes anywhere between 1 and page sized bytes more (only one
++   PROT_NONE page is setup as a canary) than expected.  These tests exercise
++   all three of the cases in ISO-2022-CN-EXT where the converter must switch
++   character sets and may run out of buffer space while doing the
++   operation.  */
++
++static int
++do_test (void)
++{
++  iconv_t cd = iconv_open ("ISO-2022-CN-EXT", "UTF-8");
++  TEST_VERIFY_EXIT (cd != (iconv_t) -1);
++
++  char *ntf;
++  size_t ntfsize;
++  char *outbufbase;
++  {
++    int pgz = getpagesize ();
++    TEST_VERIFY_EXIT (pgz > 0);
++    ntfsize = 2 * pgz;
++
++    ntf = xmmap (NULL, ntfsize, PROT_READ | PROT_WRITE, MAP_PRIVATE
++		 | MAP_ANONYMOUS, -1);
++    xmprotect (ntf + pgz, pgz, PROT_NONE);
++
++    outbufbase = ntf + pgz;
++  }
++
++  /* Check if SOdesignation escape sequence does not trigger an OOB write.  */
++  {
++    char inbuf[] = "\xe4\xba\xa4\xe6\x8d\xa2";
++
++    for (int i = 0; i < 9; i++)
++      {
++	char *inp = inbuf;
++	size_t inleft = sizeof (inbuf) - 1;
++
++	char *outp = outbufbase - i;
++	size_t outleft = i;
++
++	TEST_VERIFY_EXIT (iconv (cd, &inp, &inleft, &outp, &outleft)
++			  == (size_t) -1);
++	TEST_COMPARE (errno, E2BIG);
++
++	TEST_VERIFY_EXIT (iconv (cd, NULL, NULL, NULL, NULL) == 0);
++      }
++  }
++
++  /* Same as before for SS2designation.  */
++  {
++    char inbuf[] = "㴽 \xe3\xb4\xbd";
++
++    for (int i = 0; i < 14; i++)
++      {
++	char *inp = inbuf;
++	size_t inleft = sizeof (inbuf) - 1;
++
++	char *outp = outbufbase - i;
++	size_t outleft = i;
++
++	TEST_VERIFY_EXIT (iconv (cd, &inp, &inleft, &outp, &outleft)
++			  == (size_t) -1);
++	TEST_COMPARE (errno, E2BIG);
++
++	TEST_VERIFY_EXIT (iconv (cd, NULL, NULL, NULL, NULL) == 0);
++      }
++  }
++
++  /* Same as before for SS3designation.  */
++  {
++    char inbuf[] = "劄 \xe5\x8a\x84";
++
++    for (int i = 0; i < 14; i++)
++      {
++	char *inp = inbuf;
++	size_t inleft = sizeof (inbuf) - 1;
++
++	char *outp = outbufbase - i;
++	size_t outleft = i;
++
++	TEST_VERIFY_EXIT (iconv (cd, &inp, &inleft, &outp, &outleft)
++			  == (size_t) -1);
++	TEST_COMPARE (errno, E2BIG);
++
++	TEST_VERIFY_EXIT (iconv (cd, NULL, NULL, NULL, NULL) == 0);
++      }
++  }
++
++  TEST_VERIFY_EXIT (iconv_close (cd) != -1);
++
++  xmunmap (ntf, ntfsize);
++
++  return 0;
++}
++
++#include <support/test-driver.c>
+
+From 7a95873543ce225376faf13bb71c43dea6d24f86 Mon Sep 17 00:00:00 2001
+From: Florian Weimer <fweimer@redhat.com>
+Date: Thu, 25 Apr 2024 15:00:45 +0200
+Subject: [PATCH] CVE-2024-33599: nscd: Stack-based buffer overflow in netgroup
+ cache (bug 31677)
+
+Using alloca matches what other caches do.  The request length is
+bounded by MAXKEYLEN.
+
+Reviewed-by: Carlos O'Donell <carlos@redhat.com>
+(cherry picked from commit 87801a8fd06db1d654eea3e4f7626ff476a9bdaa)
+---
+ nscd/netgroupcache.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/nscd/netgroupcache.c b/nscd/netgroupcache.c
+index 85977521a6..f0de064368 100644
+--- a/nscd/netgroupcache.c
++++ b/nscd/netgroupcache.c
+@@ -502,12 +502,13 @@ addinnetgrX (struct database_dyn *db, int fd, request_header *req,
+       = (struct indataset *) mempool_alloc (db,
+ 					    sizeof (*dataset) + req->key_len,
+ 					    1);
+-  struct indataset dataset_mem;
+   bool cacheable = true;
+   if (__glibc_unlikely (dataset == NULL))
+     {
+       cacheable = false;
+-      dataset = &dataset_mem;
++      /* The alloca is safe because nscd_run_worker verfies that
++	 key_len is not larger than MAXKEYLEN.  */
++      dataset = alloca (sizeof (*dataset) + req->key_len);
+     }
+
+   datahead_init_pos (&dataset->head, sizeof (*dataset) + req->key_len,
+
+From 4370bef52b0f3f3652c6aa13d7a9bb3ac079746d Mon Sep 17 00:00:00 2001
+From: Florian Weimer <fweimer@redhat.com>
+Date: Thu, 25 Apr 2024 15:01:07 +0200
+Subject: [PATCH] CVE-2024-33600: nscd: Do not send missing not-found response
+ in addgetnetgrentX (bug 31678)
+
+If we failed to add a not-found response to the cache, the dataset
+point can be null, resulting in a null pointer dereference.
+
+Reviewed-by: Siddhesh Poyarekar <siddhesh@sourceware.org>
+(cherry picked from commit 7835b00dbce53c3c87bbbb1754a95fb5e58187aa)
+---
+ nscd/netgroupcache.c | 14 ++++++--------
+ 1 file changed, 6 insertions(+), 8 deletions(-)
+
+diff --git a/nscd/netgroupcache.c b/nscd/netgroupcache.c
+index f0de064368..a64b5930d5 100644
+--- a/nscd/netgroupcache.c
++++ b/nscd/netgroupcache.c
+@@ -147,7 +147,7 @@ addgetnetgrentX (struct database_dyn *db, int fd, request_header *req,
+       /* No such service.  */
+       cacheable = do_notfound (db, fd, req, key, &dataset, &total, &timeout,
+ 			       &key_copy);
+-      goto writeout;
++      goto maybe_cache_add;
+     }
+
+   memset (&data, '\0', sizeof (data));
+@@ -348,7 +348,7 @@ addgetnetgrentX (struct database_dyn *db, int fd, request_header *req,
+     {
+       cacheable = do_notfound (db, fd, req, key, &dataset, &total, &timeout,
+ 			       &key_copy);
+-      goto writeout;
++      goto maybe_cache_add;
+     }
+
+   total = buffilled;
+@@ -410,14 +410,12 @@ addgetnetgrentX (struct database_dyn *db, int fd, request_header *req,
+   }
+
+   if (he == NULL && fd != -1)
+-    {
+-      /* We write the dataset before inserting it to the database
+-	 since while inserting this thread might block and so would
+-	 unnecessarily let the receiver wait.  */
+-    writeout:
++    /* We write the dataset before inserting it to the database since
++       while inserting this thread might block and so would
++       unnecessarily let the receiver wait.  */
+       writeall (fd, &dataset->resp, dataset->head.recsize);
+-    }
+
++ maybe_cache_add:
+   if (cacheable)
+     {
+       /* If necessary, we also propagate the data to disk.  */
+
+From bafadc589fbe21ae330e8c2af74db9da44a17660 Mon Sep 17 00:00:00 2001
+From: Florian Weimer <fweimer@redhat.com>
+Date: Thu, 25 Apr 2024 15:01:07 +0200
+Subject: [PATCH] CVE-2024-33600: nscd: Avoid null pointer crashes after
+ notfound response (bug 31678)
+
+The addgetnetgrentX call in addinnetgrX may have failed to produce
+a result, so the result variable in addinnetgrX can be NULL.
+Use db->negtimeout as the fallback value if there is no result data;
+the timeout is also overwritten below.
+
+Also avoid sending a second not-found response.  (The client
+disconnects after receiving the first response, so the data stream did
+not go out of sync even without this fix.)  It is still beneficial to
+add the negative response to the mapping, so that the client can get
+it from there in the future, instead of going through the socket.
+
+Reviewed-by: Siddhesh Poyarekar <siddhesh@sourceware.org>
+(cherry picked from commit b048a482f088e53144d26a61c390bed0210f49f2)
+---
+ nscd/netgroupcache.c | 11 +++++++----
+ 1 file changed, 7 insertions(+), 4 deletions(-)
+
+diff --git a/nscd/netgroupcache.c b/nscd/netgroupcache.c
+index a64b5930d5..787e44d851 100644
+--- a/nscd/netgroupcache.c
++++ b/nscd/netgroupcache.c
+@@ -511,14 +511,15 @@ addinnetgrX (struct database_dyn *db, int fd, request_header *req,
+
+   datahead_init_pos (&dataset->head, sizeof (*dataset) + req->key_len,
+ 		     sizeof (innetgroup_response_header),
+-		     he == NULL ? 0 : dh->nreloads + 1, result->head.ttl);
++		     he == NULL ? 0 : dh->nreloads + 1,
++		     result == NULL ? db->negtimeout : result->head.ttl);
+   /* Set the notfound status and timeout based on the result from
+      getnetgrent.  */
+-  dataset->head.notfound = result->head.notfound;
++  dataset->head.notfound = result == NULL || result->head.notfound;
+   dataset->head.timeout = timeout;
+
+   dataset->resp.version = NSCD_VERSION;
+-  dataset->resp.found = result->resp.found;
++  dataset->resp.found = result != NULL && result->resp.found;
+   /* Until we find a matching entry the result is 0.  */
+   dataset->resp.result = 0;
+
+@@ -566,7 +567,9 @@ addinnetgrX (struct database_dyn *db, int fd, request_header *req,
+       goto out;
+     }
+
+-  if (he == NULL)
++  /* addgetnetgrentX may have already sent a notfound response.  Do
++     not send another one.  */
++  if (he == NULL && dataset->resp.found)
+     {
+       /* We write the dataset before inserting it to the database
+ 	 since while inserting this thread might block and so would
+
+From 7a5864cac60e06000394128a5a2817b03542f5a3 Mon Sep 17 00:00:00 2001
+From: Florian Weimer <fweimer@redhat.com>
+Date: Thu, 25 Apr 2024 15:01:07 +0200
+Subject: [PATCH] CVE-2024-33601, CVE-2024-33602: nscd: netgroup: Use two
+ buffers in addgetnetgrentX (bug 31680)
+
+This avoids potential memory corruption when the underlying NSS
+callback function does not use the buffer space to store all strings
+(e.g., for constant strings).
+
+Instead of custom buffer management, two scratch buffers are used.
+This increases stack usage somewhat.
+
+Scratch buffer allocation failure is handled by return -1
+(an invalid timeout value) instead of terminating the process.
+This fixes bug 31679.
+
+Reviewed-by: Siddhesh Poyarekar <siddhesh@sourceware.org>
+(cherry picked from commit c04a21e050d64a1193a6daab872bca2528bda44b)
+---
+ nscd/netgroupcache.c | 219 ++++++++++++++++++++++++-------------------
+ 1 file changed, 121 insertions(+), 98 deletions(-)
+
+diff --git a/nscd/netgroupcache.c b/nscd/netgroupcache.c
+index 787e44d851..aaabbbb003 100644
+--- a/nscd/netgroupcache.c
++++ b/nscd/netgroupcache.c
+@@ -23,6 +23,7 @@
+ #include <stdlib.h>
+ #include <unistd.h>
+ #include <sys/mman.h>
++#include <scratch_buffer.h>
+
+ #include "../inet/netgroup.h"
+ #include "nscd.h"
+@@ -65,6 +66,16 @@ struct dataset
+   char strdata[0];
+ };
+
++/* Send a notfound response to FD.  Always returns -1 to indicate an
++   ephemeral error.  */
++static time_t
++send_notfound (int fd)
++{
++  if (fd != -1)
++    TEMP_FAILURE_RETRY (send (fd, &notfound, sizeof (notfound), MSG_NOSIGNAL));
++  return -1;
++}
++
+ /* Sends a notfound message and prepares a notfound dataset to write to the
+    cache.  Returns true if there was enough memory to allocate the dataset and
+    returns the dataset in DATASETP, total bytes to write in TOTALP and the
+@@ -83,8 +94,7 @@ do_notfound (struct database_dyn *db, int fd, request_header *req,
+   total = sizeof (notfound);
+   timeout = time (NULL) + db->negtimeout;
+
+-  if (fd != -1)
+-    TEMP_FAILURE_RETRY (send (fd, &notfound, total, MSG_NOSIGNAL));
++  send_notfound (fd);
+
+   dataset = mempool_alloc (db, sizeof (struct dataset) + req->key_len, 1);
+   /* If we cannot permanently store the result, so be it.  */
+@@ -109,11 +119,78 @@ do_notfound (struct database_dyn *db, int fd, request_header *req,
+   return cacheable;
+ }
+
++struct addgetnetgrentX_scratch
++{
++  /* This is the result that the caller should use.  It can be NULL,
++     point into buffer, or it can be in the cache.  */
++  struct dataset *dataset;
++
++  struct scratch_buffer buffer;
++
++  /* Used internally in addgetnetgrentX as a staging area.  */
++  struct scratch_buffer tmp;
++
++  /* Number of bytes in buffer that are actually used.  */
++  size_t buffer_used;
++};
++
++static void
++addgetnetgrentX_scratch_init (struct addgetnetgrentX_scratch *scratch)
++{
++  scratch->dataset = NULL;
++  scratch_buffer_init (&scratch->buffer);
++  scratch_buffer_init (&scratch->tmp);
++
++  /* Reserve space for the header.  */
++  scratch->buffer_used = sizeof (struct dataset);
++  static_assert (sizeof (struct dataset) < sizeof (scratch->tmp.__space),
++		 "initial buffer space");
++  memset (scratch->tmp.data, 0, sizeof (struct dataset));
++}
++
++static void
++addgetnetgrentX_scratch_free (struct addgetnetgrentX_scratch *scratch)
++{
++  scratch_buffer_free (&scratch->buffer);
++  scratch_buffer_free (&scratch->tmp);
++}
++
++/* Copy LENGTH bytes from S into SCRATCH.  Returns NULL if SCRATCH
++   could not be resized, otherwise a pointer to the copy.  */
++static char *
++addgetnetgrentX_append_n (struct addgetnetgrentX_scratch *scratch,
++			  const char *s, size_t length)
++{
++  while (true)
++    {
++      size_t remaining = scratch->buffer.length - scratch->buffer_used;
++      if (remaining >= length)
++	break;
++      if (!scratch_buffer_grow_preserve (&scratch->buffer))
++	return NULL;
++    }
++  char *copy = scratch->buffer.data + scratch->buffer_used;
++  memcpy (copy, s, length);
++  scratch->buffer_used += length;
++  return copy;
++}
++
++/* Copy S into SCRATCH, including its null terminator.  Returns false
++   if SCRATCH could not be resized.  */
++static bool
++addgetnetgrentX_append (struct addgetnetgrentX_scratch *scratch, const char *s)
++{
++  if (s == NULL)
++    s = "";
++  return addgetnetgrentX_append_n (scratch, s, strlen (s) + 1) != NULL;
++}
++
++/* Caller must initialize and free *SCRATCH.  If the return value is
++   negative, this function has sent a notfound response.  */
+ static time_t
+ addgetnetgrentX (struct database_dyn *db, int fd, request_header *req,
+ 		 const char *key, uid_t uid, struct hashentry *he,
+-		 struct datahead *dh, struct dataset **resultp,
+-		 void **tofreep)
++		 struct datahead *dh, struct addgetnetgrentX_scratch *scratch)
+ {
+   if (__glibc_unlikely (debug_level > 0))
+     {
+@@ -132,14 +209,10 @@ addgetnetgrentX (struct database_dyn *db, int fd, request_header *req,
+
+   char *key_copy = NULL;
+   struct __netgrent data;
+-  size_t buflen = MAX (1024, sizeof (*dataset) + req->key_len);
+-  size_t buffilled = sizeof (*dataset);
+-  char *buffer = NULL;
+   size_t nentries = 0;
+   size_t group_len = strlen (key) + 1;
+   struct name_list *first_needed
+     = alloca (sizeof (struct name_list) + group_len);
+-  *tofreep = NULL;
+
+   if (netgroup_database == NULL
+       && !__nss_database_get (nss_database_netgroup, &netgroup_database))
+@@ -151,8 +224,6 @@ addgetnetgrentX (struct database_dyn *db, int fd, request_header *req,
+     }
+
+   memset (&data, '\0', sizeof (data));
+-  buffer = xmalloc (buflen);
+-  *tofreep = buffer;
+   first_needed->next = first_needed;
+   memcpy (first_needed->name, key, group_len);
+   data.needed_groups = first_needed;
+@@ -195,8 +266,8 @@ addgetnetgrentX (struct database_dyn *db, int fd, request_header *req,
+ 		while (1)
+ 		  {
+ 		    int e;
+-		    status = getfct.f (&data, buffer + buffilled,
+-				       buflen - buffilled - req->key_len, &e);
++		    status = getfct.f (&data, scratch->tmp.data,
++				       scratch->tmp.length, &e);
+ 		    if (status == NSS_STATUS_SUCCESS)
+ 		      {
+ 			if (data.type == triple_val)
+@@ -204,68 +275,10 @@ addgetnetgrentX (struct database_dyn *db, int fd, request_header *req,
+ 			    const char *nhost = data.val.triple.host;
+ 			    const char *nuser = data.val.triple.user;
+ 			    const char *ndomain = data.val.triple.domain;
+-
+-			    size_t hostlen = strlen (nhost ?: "") + 1;
+-			    size_t userlen = strlen (nuser ?: "") + 1;
+-			    size_t domainlen = strlen (ndomain ?: "") + 1;
+-
+-			    if (nhost == NULL || nuser == NULL || ndomain == NULL
+-				|| nhost > nuser || nuser > ndomain)
+-			      {
+-				const char *last = nhost;
+-				if (last == NULL
+-				    || (nuser != NULL && nuser > last))
+-				  last = nuser;
+-				if (last == NULL
+-				    || (ndomain != NULL && ndomain > last))
+-				  last = ndomain;
+-
+-				size_t bufused
+-				  = (last == NULL
+-				     ? buffilled
+-				     : last + strlen (last) + 1 - buffer);
+-
+-				/* We have to make temporary copies.  */
+-				size_t needed = hostlen + userlen + domainlen;
+-
+-				if (buflen - req->key_len - bufused < needed)
+-				  {
+-				    buflen += MAX (buflen, 2 * needed);
+-				    /* Save offset in the old buffer.  We don't
+-				       bother with the NULL check here since
+-				       we'll do that later anyway.  */
+-				    size_t nhostdiff = nhost - buffer;
+-				    size_t nuserdiff = nuser - buffer;
+-				    size_t ndomaindiff = ndomain - buffer;
+-
+-				    char *newbuf = xrealloc (buffer, buflen);
+-				    /* Fix up the triplet pointers into the new
+-				       buffer.  */
+-				    nhost = (nhost ? newbuf + nhostdiff
+-					     : NULL);
+-				    nuser = (nuser ? newbuf + nuserdiff
+-					     : NULL);
+-				    ndomain = (ndomain ? newbuf + ndomaindiff
+-					       : NULL);
+-				    *tofreep = buffer = newbuf;
+-				  }
+-
+-				nhost = memcpy (buffer + bufused,
+-						nhost ?: "", hostlen);
+-				nuser = memcpy ((char *) nhost + hostlen,
+-						nuser ?: "", userlen);
+-				ndomain = memcpy ((char *) nuser + userlen,
+-						  ndomain ?: "", domainlen);
+-			      }
+-
+-			    char *wp = buffer + buffilled;
+-			    wp = memmove (wp, nhost ?: "", hostlen);
+-			    wp += hostlen;
+-			    wp = memmove (wp, nuser ?: "", userlen);
+-			    wp += userlen;
+-			    wp = memmove (wp, ndomain ?: "", domainlen);
+-			    wp += domainlen;
+-			    buffilled = wp - buffer;
++			    if (!(addgetnetgrentX_append (scratch, nhost)
++				  && addgetnetgrentX_append (scratch, nuser)
++				  && addgetnetgrentX_append (scratch, ndomain)))
++			      return send_notfound (fd);
+ 			    ++nentries;
+ 			  }
+ 			else
+@@ -317,8 +330,8 @@ addgetnetgrentX (struct database_dyn *db, int fd, request_header *req,
+ 		      }
+ 		    else if (status == NSS_STATUS_TRYAGAIN && e == ERANGE)
+ 		      {
+-			buflen *= 2;
+-			*tofreep = buffer = xrealloc (buffer, buflen);
++			if (!scratch_buffer_grow (&scratch->tmp))
++			  return send_notfound (fd);
+ 		      }
+ 		    else if (status == NSS_STATUS_RETURN
+ 			     || status == NSS_STATUS_NOTFOUND
+@@ -351,10 +364,17 @@ addgetnetgrentX (struct database_dyn *db, int fd, request_header *req,
+       goto maybe_cache_add;
+     }
+
+-  total = buffilled;
++  /* Capture the result size without the key appended.   */
++  total = scratch->buffer_used;
++
++  /* Make a copy of the key.  The scratch buffer must not move after
++     this point.  */
++  key_copy = addgetnetgrentX_append_n (scratch, key, req->key_len);
++  if (key_copy == NULL)
++    return send_notfound (fd);
+
+   /* Fill in the dataset.  */
+-  dataset = (struct dataset *) buffer;
++  dataset = scratch->buffer.data;
+   timeout = datahead_init_pos (&dataset->head, total + req->key_len,
+ 			       total - offsetof (struct dataset, resp),
+ 			       he == NULL ? 0 : dh->nreloads + 1,
+@@ -363,11 +383,7 @@ addgetnetgrentX (struct database_dyn *db, int fd, request_header *req,
+   dataset->resp.version = NSCD_VERSION;
+   dataset->resp.found = 1;
+   dataset->resp.nresults = nentries;
+-  dataset->resp.result_len = buffilled - sizeof (*dataset);
+-
+-  assert (buflen - buffilled >= req->key_len);
+-  key_copy = memcpy (buffer + buffilled, key, req->key_len);
+-  buffilled += req->key_len;
++  dataset->resp.result_len = total - sizeof (*dataset);
+
+   /* Now we can determine whether on refill we have to create a new
+      record or not.  */
+@@ -398,7 +414,7 @@ addgetnetgrentX (struct database_dyn *db, int fd, request_header *req,
+     if (__glibc_likely (newp != NULL))
+       {
+ 	/* Adjust pointer into the memory block.  */
+-	key_copy = (char *) newp + (key_copy - buffer);
++	key_copy = (char *) newp + (key_copy - (char *) dataset);
+
+ 	dataset = memcpy (newp, dataset, total + req->key_len);
+ 	cacheable = true;
+@@ -439,7 +455,7 @@ addgetnetgrentX (struct database_dyn *db, int fd, request_header *req,
+     }
+
+  out:
+-  *resultp = dataset;
++  scratch->dataset = dataset;
+
+   return timeout;
+ }
+@@ -460,6 +476,9 @@ addinnetgrX (struct database_dyn *db, int fd, request_header *req,
+   if (user != NULL)
+     key = (char *) rawmemchr (key, '\0') + 1;
+   const char *domain = *key++ ? key : NULL;
++  struct addgetnetgrentX_scratch scratch;
++
++  addgetnetgrentX_scratch_init (&scratch);
+
+   if (__glibc_unlikely (debug_level > 0))
+     {
+@@ -475,12 +494,8 @@ addinnetgrX (struct database_dyn *db, int fd, request_header *req,
+ 							    group, group_len,
+ 							    db, uid);
+   time_t timeout;
+-  void *tofree;
+   if (result != NULL)
+-    {
+-      timeout = result->head.timeout;
+-      tofree = NULL;
+-    }
++    timeout = result->head.timeout;
+   else
+     {
+       request_header req_get =
+@@ -489,7 +504,10 @@ addinnetgrX (struct database_dyn *db, int fd, request_header *req,
+ 	  .key_len = group_len
+ 	};
+       timeout = addgetnetgrentX (db, -1, &req_get, group, uid, NULL, NULL,
+-				 &result, &tofree);
++				 &scratch);
++      result = scratch.dataset;
++      if (timeout < 0)
++	goto out;
+     }
+
+   struct indataset
+@@ -603,7 +621,7 @@ addinnetgrX (struct database_dyn *db, int fd, request_header *req,
+     }
+
+  out:
+-  free (tofree);
++  addgetnetgrentX_scratch_free (&scratch);
+   return timeout;
+ }
+
+@@ -613,11 +631,12 @@ addgetnetgrentX_ignore (struct database_dyn *db, int fd, request_header *req,
+ 			const char *key, uid_t uid, struct hashentry *he,
+ 			struct datahead *dh)
+ {
+-  struct dataset *ignore;
+-  void *tofree;
+-  time_t timeout = addgetnetgrentX (db, fd, req, key, uid, he, dh,
+-				    &ignore, &tofree);
+-  free (tofree);
++  struct addgetnetgrentX_scratch scratch;
++  addgetnetgrentX_scratch_init (&scratch);
++  time_t timeout = addgetnetgrentX (db, fd, req, key, uid, he, dh, &scratch);
++  addgetnetgrentX_scratch_free (&scratch);
++  if (timeout < 0)
++    timeout = 0;
+   return timeout;
+ }
+
+@@ -661,5 +680,9 @@ readdinnetgr (struct database_dyn *db, struct hashentry *he,
+       .key_len = he->len
+     };
+
+-  return addinnetgrX (db, -1, &req, db->data + he->key, he->owner, he, dh);
++  int timeout = addinnetgrX (db, -1, &req, db->data + he->key, he->owner,
++			     he, dh);
++  if (timeout < 0)
++    timeout = 0;
++  return timeout;
+ }
+
+From 934ba77add195dde2c922b4ae809968cde62a1ff Mon Sep 17 00:00:00 2001
+From: "Maciej W. Rozycki" <macro@redhat.com>
+Date: Wed, 7 Aug 2024 19:46:21 +0100
+Subject: [PATCH] nptl: Reorder semaphore release in tst-cancel7
+
+Move the release of the semaphore used to synchronize between an extra
+copy of the test run as a separate process and the main test process
+until after the PID file has been locked.  It is so that if the cleanup
+function gets called by the test driver due to premature termination of
+the main test process, then the function does not get at the PID file
+before it has been locked and conclude that the extra copy of the test
+has already terminated.  This won't usually happen due to a relatively
+high amount of time required to elapse before timeout triggers in the
+test driver, but it will change with the next change.
+
+There is still a small time window remaining with this change in place
+where the main test process gets killed for some reason between the
+extra copy of the test has been already started by pthread_create(3) and
+a successful return from the call to sem_wait(3), in which case the
+cleanup function can be reached before PID has been written to the PID
+file and the file locked.  It seems that with the test case structured
+as it is now and PID-based process management we have no means to avoid
+it.
+
+Reviewed-by: Adhemerval Zanella <adhemerval.zanella@linaro.org>
+---
+ nptl/tst-cancel7.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/nptl/tst-cancel7.c b/nptl/tst-cancel7.c
+index d2350bde20..574429098c 100644
+--- a/nptl/tst-cancel7.c
++++ b/nptl/tst-cancel7.c
+@@ -57,9 +57,6 @@ sl (void)
+   fprintf (f, "%lld\n", (long long) getpid ());
+   fflush (f);
+
+-  if (sem_post (sem) != 0)
+-    FAIL_EXIT1 ("sem_post: %m");
+-
+   struct flock fl =
+     {
+       .l_type = F_WRLCK,
+@@ -70,6 +67,9 @@ sl (void)
+   if (fcntl (fileno (f), F_SETLK, &fl) != 0)
+     FAIL_EXIT1 ("fcntl (F_SETFL): %m");
+
++  if (sem_post (sem) != 0)
++    FAIL_EXIT1 ("sem_post: %m");
++
+   sigset_t ss;
+   sigfillset (&ss);
+   sigsuspend (&ss);
+@@ -116,7 +116,7 @@ do_test (void)
+ {
+   pthread_t th = xpthread_create (NULL, tf, NULL);
+
+-  /* Wait to cancel until after the pid is written.  */
++  /* Wait to cancel until after the pid is written and file locked.  */
+   if (sem_wait (sem) != 0)
+     FAIL_EXIT1 ("sem_wait: %m");
+
+
+From bea2ad022dadae46059de681d902129e56653c85 Mon Sep 17 00:00:00 2001
+From: "Maciej W. Rozycki" <macro@redhat.com>
+Date: Wed, 7 Aug 2024 19:46:21 +0100
+Subject: [PATCH] nptl: Fix stray process left by tst-cancel7 blocking testing
+
+Fix an issue with commit b74121ae4bc5 ("Update.") and prevent a stray
+process from being left behind by tst-cancel7 (and also tst-cancelx7,
+which is the same test built with '-fexceptions' additionally supplied
+to the compiler), which then blocks remote testing until the process has
+been killed by hand.
+
+This test case creates a thread that runs an extra copy of the test via
+system(3) and using the '--direct' option so that the test wrapper does
+not interfere with this instance.  This extra copy executes its business
+and calls sigsuspend(2) and then never terminates by itself.  Instead it
+relies on being killed by the main test process directly via a thread
+cancellation request or, should that fail, by issuing SIGKILL either at
+the conclusion of 'do_test' or by the test driver via 'do_cleanup' where
+the test timeout has been hit or the test driver interrupted.
+
+However if the main test process has been instead killed by a signal,
+such as due to incorrect execution, before it had a chance to kill the
+extra copy of the test case, then the test wrapper will terminate
+without running 'do_cleanup' and consequently the extra copy of the test
+case will remain forever in its suspended state, and in the remote case
+in particular it means that the remote test wrapper will wait forever
+for the SSH command to complete.
+
+This has been observed with the 'alpha-linux-gnu' target, where the main
+test process triggers SIGSEGV and the test wrapper correctly records:
+
+Didn't expect signal from child: got `Segmentation fault'
+
+in nptl/tst-cancel7.out and terminates, but then the calling SSH command
+continues waiting for the remaining process started in the same session
+on the remote target to complete.
+
+Address this problem by also registering 'do_cleanup' via atexit(3),
+observing that 'support_delete_temp_files' is registered by the test
+wrapper before the test initializing function 'do_prepare' is called and
+that we call all the functions registered in the reverse of the order in
+which they were registered, so it is safe to refer to 'pidfilename' in
+'do_cleanup' invoked by exit(3) because by that time temporary files
+have not yet been deleted.
+
+A minor inconvenience is that if 'signal_handler' is invoked in the test
+wrapper as a result of SIGALRM rather than SIGINT, then 'do_cleanup'
+will be called twice, once as a cleanup handler and again by exit(3).
+In reality it is harmless though, because issuing SIGKILL is guarded by
+a record lock, so if the first call has succeeded in killing the extra
+copy of the test case, then the subsequent call will do nothing.
+
+Reviewed-by: Adhemerval Zanella <adhemerval.zanella@linaro.org>
+---
+ nptl/tst-cancel7.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/nptl/tst-cancel7.c b/nptl/tst-cancel7.c
+index 574429098c..3f874c2a3c 100644
+--- a/nptl/tst-cancel7.c
++++ b/nptl/tst-cancel7.c
+@@ -38,6 +38,8 @@ static char *semfilename;
+
+ static sem_t *sem;
+
++static void do_cleanup (void);
++
+ static void *
+ tf (void *arg)
+ {
+@@ -108,6 +110,8 @@ do_prepare (int argc, char *argv[])
+
+   xwrite (fd, " ", 1);
+   xclose (fd);
++
++  atexit (do_cleanup);
+ }
+
+
+
+From 8b5d4be762419c4f6176261c6fea40ac559b88dc Mon Sep 17 00:00:00 2001
+From: Florian Weimer <fweimer@redhat.com>
+Date: Wed, 22 Jan 2025 17:22:02 +0100
+Subject: [PATCH] Fix underallocation of abort_msg_s struct (CVE-2025-0395)
+
+Include the space needed to store the length of the message itself, in
+addition to the message string.  This resolves BZ #32582.
+
+Signed-off-by: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Reviewed: Adhemerval Zanella  <adhemerval.zanella@linaro.org>
+(cherry picked from commit 68ee0f704cb81e9ad0a78c644a83e1e9cd2ee578)
+
+Conflict in sysdeps/posix/libc_fatal.c due to missing cleanup after
+backtrace removal.
+---
+ assert/assert.c            | 4 +++-
+ sysdeps/posix/libc_fatal.c | 5 +++--
+ 2 files changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/assert/assert.c b/assert/assert.c
+index 133a183bc3..9e55eeb473 100644
+--- a/assert/assert.c
++++ b/assert/assert.c
+@@ -18,6 +18,7 @@
+ #include <assert.h>
+ #include <atomic.h>
+ #include <ldsodefs.h>
++#include <libc-pointer-arith.h>
+ #include <libintl.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+@@ -64,7 +65,8 @@ __assert_fail_base (const char *fmt, const char *assertion, const char *file,
+       (void) __fxprintf (NULL, "%s", str);
+       (void) fflush (stderr);
+
+-      total = (total + 1 + GLRO(dl_pagesize) - 1) & ~(GLRO(dl_pagesize) - 1);
++      total = ALIGN_UP (total + sizeof (struct abort_msg_s) + 1,
++			GLRO(dl_pagesize));
+       struct abort_msg_s *buf = __mmap (NULL, total, PROT_READ | PROT_WRITE,
+ 					MAP_ANON | MAP_PRIVATE, -1, 0);
+       if (__glibc_likely (buf != MAP_FAILED))
+diff --git a/sysdeps/posix/libc_fatal.c b/sysdeps/posix/libc_fatal.c
+index 2ee0010b8d..dfa0780514 100644
+--- a/sysdeps/posix/libc_fatal.c
++++ b/sysdeps/posix/libc_fatal.c
+@@ -20,6 +20,7 @@
+ #include <errno.h>
+ #include <fcntl.h>
+ #include <ldsodefs.h>
++#include <libc-pointer-arith.h>
+ #include <paths.h>
+ #include <stdarg.h>
+ #include <stdbool.h>
+@@ -125,8 +126,8 @@ __libc_message (enum __libc_message_action action, const char *fmt, ...)
+
+       if ((action & do_abort))
+ 	{
+-	  total = ((total + 1 + GLRO(dl_pagesize) - 1)
+-		   & ~(GLRO(dl_pagesize) - 1));
++	  total = ALIGN_UP (total + sizeof (struct abort_msg_s) + 1,
++			    GLRO(dl_pagesize));
+ 	  struct abort_msg_s *buf = __mmap (NULL, total,
+ 					    PROT_READ | PROT_WRITE,
+ 					    MAP_ANON | MAP_PRIVATE, -1, 0);
+
+From 29d9b1e59e6bea6ae268e2c8ea3173e326288ab0 Mon Sep 17 00:00:00 2001
+From: Carlos O'Donell <carlos@redhat.com>
+Date: Thu, 18 May 2023 12:56:45 -0400
+Subject: [PATCH] assert: Reformat Makefile.
+
+Reflow all long lines adding comment terminators.
+Sort all reflowed text using scripts/sort-makefile-lines.py.
+
+No code generation changes observed in binary artifacts.
+No regressions on x86_64 and i686.
+
+(cherry picked from commit ebd928224a138d4560dc0be3ef162162d62a9e43)
+
+ # Conflicts:
+ #	assert/Makefile
+ (Missing __libc_assert_fail)
+---
+ assert/Makefile | 25 ++++++++++++++++++++-----
+ 1 file changed, 20 insertions(+), 5 deletions(-)
+
+diff --git a/assert/Makefile b/assert/Makefile
+index f7cf8e9b77..d2deec69a0 100644
+--- a/assert/Makefile
++++ b/assert/Makefile
+@@ -22,10 +22,22 @@ subdir	:= assert
+
+ include ../Makeconfig
+
+-headers	:= assert.h
+-
+-routines := assert assert-perr __assert
+-tests := test-assert test-assert-perr tst-assert-c++ tst-assert-g++
++headers := \
++  assert.h
++  # headers
++
++routines := \
++  __assert \
++  assert \
++  assert-perr \
++  # routines
++
++tests := \
++  test-assert \
++  test-assert-perr \
++  tst-assert-c++ \
++  tst-assert-g++ \
++  # tests
+
+ ifeq ($(have-cxx-thread_local),yes)
+ CFLAGS-tst-assert-c++.o = -std=c++11
+@@ -33,7 +45,10 @@ LDLIBS-tst-assert-c++ = -lstdc++
+ CFLAGS-tst-assert-g++.o = -std=gnu++11
+ LDLIBS-tst-assert-g++ = -lstdc++
+ else
+-tests-unsupported += tst-assert-c++ tst-assert-g++
++tests-unsupported += \
++  tst-assert-c++ \
++  tst-assert-g++ \
++  # tests-unsupported
+ endif
+
+ include ../Rules
+
+From 8b3d09dc0d350191985f9d291cc30ce96f034b49 Mon Sep 17 00:00:00 2001
+From: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Date: Fri, 31 Jan 2025 12:16:30 -0500
+Subject: [PATCH] assert: Add test for CVE-2025-0395
+
+Use the __progname symbol to override the program name to induce the
+failure that CVE-2025-0395 describes.
+
+This is related to BZ #32582
+
+Signed-off-by: Siddhesh Poyarekar <siddhesh@sourceware.org>
+Reviewed-by: Adhemerval Zanella  <adhemerval.zanella@linaro.org>
+(cherry picked from commit cdb9ba84191ce72e86346fb8b1d906e7cd930ea2)
+---
+ assert/Makefile                  |  1 +
+ assert/tst-assert-sa-2025-0001.c | 92 ++++++++++++++++++++++++++++++++
+ 2 files changed, 93 insertions(+)
+ create mode 100644 assert/tst-assert-sa-2025-0001.c
+
+diff --git a/assert/Makefile b/assert/Makefile
+index d2deec69a0..df5a8e6f10 100644
+--- a/assert/Makefile
++++ b/assert/Makefile
+@@ -37,6 +37,7 @@ tests := \
+   test-assert-perr \
+   tst-assert-c++ \
+   tst-assert-g++ \
++  tst-assert-sa-2025-0001 \
+   # tests
+
+ ifeq ($(have-cxx-thread_local),yes)
+diff --git a/assert/tst-assert-sa-2025-0001.c b/assert/tst-assert-sa-2025-0001.c
+new file mode 100644
+index 0000000000..102cb0078d
+--- /dev/null
++++ b/assert/tst-assert-sa-2025-0001.c
+@@ -0,0 +1,92 @@
++/* Test for CVE-2025-0395.
++   Copyright The GNU Toolchain Authors.
++   This file is part of the GNU C Library.
++
++   The GNU C Library is free software; you can redistribute it and/or
++   modify it under the terms of the GNU Lesser General Public
++   License as published by the Free Software Foundation; either
++   version 2.1 of the License, or (at your option) any later version.
++
++   The GNU C Library is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   Lesser General Public License for more details.
++
++   You should have received a copy of the GNU Lesser General Public
++   License along with the GNU C Library; if not, see
++   <https://www.gnu.org/licenses/>.  */
++
++/* Test that a large enough __progname does not result in a buffer overflow
++   when printing an assertion failure.  This was CVE-2025-0395.  */
++#include <assert.h>
++#include <inttypes.h>
++#include <signal.h>
++#include <stdbool.h>
++#include <string.h>
++#include <sys/mman.h>
++#include <support/check.h>
++#include <support/support.h>
++#include <support/xstdio.h>
++#include <support/xunistd.h>
++
++extern const char *__progname;
++
++int
++do_test (int argc, char **argv)
++{
++
++  support_need_proc ("Reads /proc/self/maps to add guards to writable maps.");
++  ignore_stderr ();
++
++  /* XXX assumes that the assert is on a 2 digit line number.  */
++  const char *prompt = ": %s:99: do_test: Assertion `argc < 1' failed.\n";
++
++  int ret = fprintf (stderr, prompt, __FILE__);
++  if (ret < 0)
++    FAIL_EXIT1 ("fprintf failed: %m\n");
++
++  size_t pagesize = getpagesize ();
++  size_t namesize = pagesize - 1 - ret;
++
++  /* Alter the progname so that the assert message fills the entire page.  */
++  char progname[namesize];
++  memset (progname, 'A', namesize - 1);
++  progname[namesize - 1] = '\0';
++  __progname = progname;
++
++  FILE *f = xfopen ("/proc/self/maps", "r");
++  char *line = NULL;
++  size_t len = 0;
++  uintptr_t prev_to = 0;
++
++  /* Pad the beginning of every writable mapping with a PROT_NONE map.  This
++     ensures that the mmap in the assert_fail path never ends up below a
++     writable map and will terminate immediately in case of a buffer
++     overflow.  */
++  while (xgetline (&line, &len, f))
++    {
++      uintptr_t from, to;
++      char perm[4];
++
++      sscanf (line, "%" SCNxPTR "-%" SCNxPTR " %c%c%c%c ",
++	      &from, &to,
++	      &perm[0], &perm[1], &perm[2], &perm[3]);
++
++      bool writable = (memchr (perm, 'w', 4) != NULL);
++
++      if (prev_to != 0 && from - prev_to > pagesize && writable)
++	xmmap ((void *) from - pagesize, pagesize, PROT_NONE,
++	       MAP_ANONYMOUS | MAP_PRIVATE, 0);
++
++      prev_to = to;
++    }
++
++  xfclose (f);
++
++  assert (argc < 1);
++  return 0;
++}
++
++#define EXPECTED_SIGNAL SIGABRT
++#define TEST_FUNCTION_ARGV do_test
++#include <support/test-driver.c>
+
+From 621c65ccf12ddd415ceeb2234423bd1acd0fabb3 Mon Sep 17 00:00:00 2001
+From: Adhemerval Zanella <adhemerval.zanella@linaro.org>
+Date: Mon, 6 Nov 2023 17:25:49 -0300
+Subject: [PATCH] elf: Ignore LD_LIBRARY_PATH and debug env var for setuid for
+ static
+
+It mimics the ld.so behavior.
+
+Checked on x86_64-linux-gnu.
+Reviewed-by: Siddhesh Poyarekar <siddhesh@sourceware.org>
+
+(cherry picked from commit 5451fa962cd0a90a0e2ec1d8910a559ace02bba0)
+
+Changes:
+	Keep EXTRA_UNSECURE_ENVVARS support.
+	Use __rawmemchr instead of strchr.
+	Keep LD_PROFILE_OUTPUT support.
+	Make tunables support optional via HAVE_TUNABLES.
+---
+ elf/dl-support.c | 46 +++++++++++++++++++++++-----------------------
+ 1 file changed, 23 insertions(+), 23 deletions(-)
+
+diff --git a/elf/dl-support.c b/elf/dl-support.c
+index 09079c124d..c2baed694d 100644
+--- a/elf/dl-support.c
++++ b/elf/dl-support.c
+@@ -272,8 +272,6 @@ _dl_non_dynamic_init (void)
+   _dl_main_map.l_phdr = GL(dl_phdr);
+   _dl_main_map.l_phnum = GL(dl_phnum);
+
+-  _dl_verbose = *(getenv ("LD_WARN") ?: "") == '\0' ? 0 : 1;
+-
+   /* Set up the data structures for the system-supplied DSO early,
+      so they can influence _dl_init_paths.  */
+   setup_vdso (NULL, NULL);
+@@ -281,27 +279,6 @@ _dl_non_dynamic_init (void)
+   /* With vDSO setup we can initialize the function pointers.  */
+   setup_vdso_pointers ();
+
+-  /* Initialize the data structures for the search paths for shared
+-     objects.  */
+-  _dl_init_paths (getenv ("LD_LIBRARY_PATH"), "LD_LIBRARY_PATH",
+-		  /* No glibc-hwcaps selection support in statically
+-		     linked binaries.  */
+-		  NULL, NULL);
+-
+-  /* Remember the last search directory added at startup.  */
+-  _dl_init_all_dirs = GL(dl_all_dirs);
+-
+-  _dl_lazy = *(getenv ("LD_BIND_NOW") ?: "") == '\0';
+-
+-  _dl_bind_not = *(getenv ("LD_BIND_NOT") ?: "") != '\0';
+-
+-  _dl_dynamic_weak = *(getenv ("LD_DYNAMIC_WEAK") ?: "") == '\0';
+-
+-  _dl_profile_output = getenv ("LD_PROFILE_OUTPUT");
+-  if (_dl_profile_output == NULL || _dl_profile_output[0] == '\0')
+-    _dl_profile_output
+-      = &"/var/tmp\0/var/profile"[__libc_enable_secure ? 9 : 0];
+-
+   if (__libc_enable_secure)
+     {
+       static const char unsecure_envvars[] =
+@@ -324,6 +301,29 @@ _dl_non_dynamic_init (void)
+ #endif
+     }
+
++  _dl_verbose = *(getenv ("LD_WARN") ?: "") == '\0' ? 0 : 1;
++
++  /* Initialize the data structures for the search paths for shared
++     objects.  */
++  _dl_init_paths (getenv ("LD_LIBRARY_PATH"), "LD_LIBRARY_PATH",
++		  /* No glibc-hwcaps selection support in statically
++		     linked binaries.  */
++		  NULL, NULL);
++
++  /* Remember the last search directory added at startup.  */
++  _dl_init_all_dirs = GL(dl_all_dirs);
++
++  _dl_lazy = *(getenv ("LD_BIND_NOW") ?: "") == '\0';
++
++  _dl_bind_not = *(getenv ("LD_BIND_NOT") ?: "") != '\0';
++
++  _dl_dynamic_weak = *(getenv ("LD_DYNAMIC_WEAK") ?: "") == '\0';
++
++  _dl_profile_output = getenv ("LD_PROFILE_OUTPUT");
++  if (_dl_profile_output == NULL || _dl_profile_output[0] == '\0')
++    _dl_profile_output
++      = &"/var/tmp\0/var/profile"[__libc_enable_secure ? 9 : 0];
++
+ #ifdef DL_PLATFORM_INIT
+   DL_PLATFORM_INIT;
+ #endif
+
+From a66bc3941ff298e474d5f02d0c3303401951141f Mon Sep 17 00:00:00 2001
+From: Florian Weimer <fweimer@redhat.com>
+Date: Mon, 21 Jul 2025 21:43:49 +0200
+Subject: [PATCH] posix: Fix double-free after allocation failure in regcomp
+ (bug 33185)
+
+If a memory allocation failure occurs during bracket expression
+parsing in regcomp, a double-free error may result.
+
+Reported-by: Anastasia Belova <abelova@astralinux.ru>
+Co-authored-by: Paul Eggert <eggert@cs.ucla.edu>
+Reviewed-by: Andreas K. Huettel <dilfridge@gentoo.org>
+(cherry picked from commit 7ea06e994093fa0bcca0d0ee2c1db271d8d7885d)
+---
+ posix/Makefile                   |   2 +-
+ posix/regcomp.c                  |   4 +-
+ posix/tst-regcomp-bracket-free.c | 176 +++++++++++++++++++++++++++++++
+ 4 files changed, 181 insertions(+), 2 deletions(-)
+ create mode 100644 posix/tst-regcomp-bracket-free.c
+
+diff --git a/posix/Makefile b/posix/Makefile
+index 9b30b53a7c..fcb82a780a 100644
+--- a/posix/Makefile
++++ b/posix/Makefile
+@@ -109,7 +109,7 @@ tests		:= test-errno tstgetopt testfnm runtests runptests \
+ 		   tst-glob-tilde test-ssize-max tst-spawn4 bug-regex37 \
+ 		   bug-regex38 tst-regcomp-truncated tst-spawn-chdir \
+ 		   tst-wordexp-nocmd tst-execveat tst-spawn5 \
+-		   tst-sched_getaffinity tst-spawn6
++		   tst-sched_getaffinity tst-spawn6 tst-regcomp-bracket-free
+
+ # Test for the glob symbol version that was replaced in glibc 2.27.
+ ifeq ($(have-GLIBC_2.26)$(build-shared),yesyes)
+diff --git a/posix/regcomp.c b/posix/regcomp.c
+index 84fc1cc82b..7bd0beeafe 100644
+--- a/posix/regcomp.c
++++ b/posix/regcomp.c
+@@ -3383,6 +3383,7 @@ parse_bracket_exp (re_string_t *regexp, re_dfa_t *dfa, re_token_t *token,
+     {
+ #ifdef RE_ENABLE_I18N
+       free_charset (mbcset);
++      mbcset = NULL;
+ #endif
+       /* Build a tree for simple bracket.  */
+       br_token.type = SIMPLE_BRACKET;
+@@ -3398,7 +3399,8 @@ parse_bracket_exp (re_string_t *regexp, re_dfa_t *dfa, re_token_t *token,
+  parse_bracket_exp_free_return:
+   re_free (sbcset);
+ #ifdef RE_ENABLE_I18N
+-  free_charset (mbcset);
++  if (__glibc_likely (mbcset != NULL))
++    free_charset (mbcset);
+ #endif /* RE_ENABLE_I18N */
+   return NULL;
+ }
+diff --git a/posix/tst-regcomp-bracket-free.c b/posix/tst-regcomp-bracket-free.c
+new file mode 100644
+index 0000000000..3c091d8c44
+--- /dev/null
++++ b/posix/tst-regcomp-bracket-free.c
+@@ -0,0 +1,176 @@
++/* Test regcomp bracket parsing with injected allocation failures (bug 33185).
++   Copyright (C) 2025 Free Software Foundation, Inc.
++   This file is part of the GNU C Library.
++
++   The GNU C Library is free software; you can redistribute it and/or
++   modify it under the terms of the GNU Lesser General Public
++   License as published by the Free Software Foundation; either
++   version 2.1 of the License, or (at your option) any later version.
++
++   The GNU C Library is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   Lesser General Public License for more details.
++
++   You should have received a copy of the GNU Lesser General Public
++   License along with the GNU C Library; if not, see
++   <https://www.gnu.org/licenses/>.  */
++
++/* This test invokes regcomp multiple times, failing one memory
++   allocation in each call.  The function call should fail with
++   REG_ESPACE (or succeed if it can recover from the allocation
++   failure).  Previously, there was double-free bug.  */
++
++#include <errno.h>
++#include <regex.h>
++#include <stdio.h>
++#include <string.h>
++#include <support/check.h>
++#include <support/namespace.h>
++#include <support/support.h>
++
++/* Data structure allocated via MAP_SHARED, so that writes from the
++   subprocess are visible.  */
++struct shared_data
++{
++  /* Number of tracked allocations performed so far.  */
++  volatile unsigned int allocation_count;
++
++  /* If this number is reached, one allocation fails.  */
++  volatile unsigned int failing_allocation;
++
++  /* The subprocess stores the expected name here.  */
++  char name[100];
++};
++
++/* Allocation count in shared mapping.  */
++static struct shared_data *shared;
++
++/* Returns true if a failure should be injected for this allocation.  */
++static bool
++fail_this_allocation (void)
++{
++  if (shared != NULL)
++    {
++      unsigned int count = shared->allocation_count;
++      shared->allocation_count = count + 1;
++      return count == shared->failing_allocation;
++    }
++  else
++    return false;
++}
++
++/* Failure-injecting wrappers for allocation functions used by glibc.  */
++
++void *
++malloc (size_t size)
++{
++  if (fail_this_allocation ())
++    {
++      errno = ENOMEM;
++      return NULL;
++    }
++  extern __typeof (malloc) __libc_malloc;
++  return __libc_malloc (size);
++}
++
++void *
++calloc (size_t a, size_t b)
++{
++  if (fail_this_allocation ())
++    {
++      errno = ENOMEM;
++      return NULL;
++    }
++  extern __typeof (calloc) __libc_calloc;
++  return __libc_calloc (a, b);
++}
++
++void *
++realloc (void *ptr, size_t size)
++{
++  if (fail_this_allocation ())
++    {
++      errno = ENOMEM;
++      return NULL;
++    }
++  extern __typeof (realloc) __libc_realloc;
++  return __libc_realloc (ptr, size);
++}
++
++/* No-op subprocess to verify that support_isolate_in_subprocess does
++   not perform any heap allocations.  */
++static void
++no_op (void *ignored)
++{
++}
++
++/* Perform a regcomp call in a subprocess.  Used to count its
++   allocations.  */
++static void
++initialize (void *regexp1)
++{
++  const char *regexp = regexp1;
++
++  shared->allocation_count = 0;
++
++  regex_t reg;
++  TEST_COMPARE (regcomp (&reg, regexp, 0), 0);
++}
++
++/* Perform regcomp in a subprocess with fault injection.  */
++static void
++test_in_subprocess (void *regexp1)
++{
++  const char *regexp = regexp1;
++  unsigned int inject_at = shared->failing_allocation;
++
++  regex_t reg;
++  int ret = regcomp (&reg, regexp, 0);
++
++  if (ret != 0)
++    {
++      TEST_COMPARE (ret, REG_ESPACE);
++      printf ("info: allocation %u failure results in return value %d,"
++              " error %s (%d)\n",
++              inject_at, ret, strerrorname_np (errno), errno);
++    }
++}
++
++static int
++do_test (void)
++{
++  char regexp[] = "[:alpha:]";
++
++  shared = support_shared_allocate (sizeof (*shared));
++
++  /* Disable fault injection.  */
++  shared->failing_allocation = ~0U;
++
++  support_isolate_in_subprocess (no_op, NULL);
++  TEST_COMPARE (shared->allocation_count, 0);
++
++  support_isolate_in_subprocess (initialize, regexp);
++
++  /* The number of allocations in the successful case, plus some
++     slack.  Once the number of expected allocations is exceeded,
++     injecting further failures does not make a difference.  */
++  unsigned int maximum_allocation_count = shared->allocation_count;
++  printf ("info: successful call performs %u allocations\n",
++          maximum_allocation_count);
++  maximum_allocation_count += 10;
++
++  for (unsigned int inject_at = 0; inject_at <= maximum_allocation_count;
++       ++inject_at)
++    {
++      shared->allocation_count = 0;
++      shared->failing_allocation = inject_at;
++      support_isolate_in_subprocess (test_in_subprocess, regexp);
++    }
++
++  support_shared_free (shared);
++
++  return 0;
++}
++
++#include <support/test-driver.c>
+
+From e3622a8f391deea3b75a577dce70d023dfa3f1c7 Mon Sep 17 00:00:00 2001
+From: Adhemerval Zanella <adhemerval.zanella@linaro.org>
+Date: Fri, 2 Jun 2023 14:02:09 -0300
+Subject: [PATCH] time: Also check for EPERM while trying to clock_settime
+
+Container management default seccomp filter [1] only accepts
+clock_settime if process has also CAP_SYS_TIME.  So also handle
+EPERM as well.
+
+Also adapt the test to libsupport and add a proper Copyright header.
+
+Checked on aarch64-linux-gnu.
+Reviewed-by: Carlos O'Donell <carlos@redhat.com>
+---
+ time/tst-clock2.c | 59 ++++++++++++++++++++++++-----------------------
+ 1 file changed, 30 insertions(+), 29 deletions(-)
+
+diff --git a/time/tst-clock2.c b/time/tst-clock2.c
+index 4c8fb9f247..9d1980e858 100644
+--- a/time/tst-clock2.c
++++ b/time/tst-clock2.c
+@@ -1,43 +1,44 @@
+-/* Test setting the monotonic clock.  */
++/* Test setting the monotonic clock.
++   Copyright (C) 2007-2023 Free Software Foundation, Inc.
++   This file is part of the GNU C Library.
+ 
+-#include <time.h>
+-#include <unistd.h>
++   The GNU C Library is free software; you can redistribute it and/or
++   modify it under the terms of the GNU Lesser General Public
++   License as published by the Free Software Foundation; either
++   version 2.1 of the License, or (at your option) any later version.
+ 
+-#if defined CLOCK_MONOTONIC && defined _POSIX_MONOTONIC_CLOCK
++   The GNU C Library is distributed in the hope that it will be useful,
++   but WITHOUT ANY WARRANTY; without even the implied warranty of
++   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++   Lesser General Public License for more details.
+ 
+-# include <errno.h>
+-# include <stdio.h>
++   You should have received a copy of the GNU Lesser General Public
++   License along with the GNU C Library; if not, see
++   <https://www.gnu.org/licenses/>.  */
++
++#include <errno.h>
++#include <support/check.h>
++#include <time.h>
++#include <unistd.h>
+ 
+-static int
++int
+ do_test (void)
+ {
++#if defined CLOCK_MONOTONIC && defined _POSIX_MONOTONIC_CLOCK
+   if (sysconf (_SC_MONOTONIC_CLOCK) <= 0)
+-    return 0;
++    FAIL_UNSUPPORTED ("_SC_MONOTONIC_CLOCK not supported");
+ 
+   struct timespec ts;
+-  if (clock_gettime (CLOCK_MONOTONIC, &ts) != 0)
+-    {
+-      puts ("clock_gettime(CLOCK_MONOTONIC) failed");
+-      return 1;
+-    }
++  TEST_COMPARE (clock_gettime (CLOCK_MONOTONIC, &ts), 0);
+ 
+   /* Setting the monotonic clock must fail.  */
+-  if (clock_settime (CLOCK_MONOTONIC, &ts) != -1)
+-    {
+-      puts ("clock_settime(CLOCK_MONOTONIC) did not fail");
+-      return 1;
+-    }
+-  if (errno != EINVAL)
+-    {
+-      printf ("clock_settime(CLOCK_MONOTONIC) set errno to %d, expected %d\n",
+-	      errno, EINVAL);
+-      return 1;
+-    }
+-  return 0;
+-}
+-# define TEST_FUNCTION do_test ()
++  TEST_VERIFY (clock_settime (CLOCK_MONOTONIC, &ts) == -1);
++  TEST_VERIFY (errno == EINVAL || errno == EPERM);
+ 
++  return 0;
+ #else
+-# define TEST_FUNCTION	0
++  return EXIT_UNSUPPORTED;
+ #endif
+-#include "../test-skeleton.c"
++}
++
++#include <support/test-driver.c>
+
+From d4963a844dc72c4ac14da3395cf511f3d191d689 Mon Sep 17 00:00:00 2001
+From: Adhemerval Zanella <adhemerval.zanella@linaro.org>
+Date: Fri, 2 Jun 2023 10:19:48 -0300
+Subject: [PATCH] linux: Fail as unsupported if personality call is filtered
+
+Container management default seccomp filter [1] only accepts
+personality(2) with PER_LINUX, (0x0), UNAME26 (0x20000),
+PER_LINUX32 (0x8), UNAME26 | PER_LINUX32, and 0xffffffff (to query
+current personality)
+
+Although the documentation only state it is blocked to prevent
+'enabling BSD emulation' (PER_BSD, not implemented by Linux), checking
+on repository log the real reason is to block ASLR disable flag
+(ADDR_NO_RANDOMIZE) and other poorly support emulations.
+
+So handle EPERM and fail as UNSUPPORTED if we can really check for
+BZ#19408.
+
+Checked on aarch64-linux-gnu.
+
+[1] https://github.com/moby/moby/blob/master/profiles/seccomp/default.json
+
+Reviewed-by: Florian Weimer <fweimer@redhat.com>
+---
+ sysdeps/unix/sysv/linux/tst-personality.c | 33 ++++++++++++++---------
+ 1 file changed, 21 insertions(+), 12 deletions(-)
+
+diff --git a/sysdeps/unix/sysv/linux/tst-personality.c b/sysdeps/unix/sysv/linux/tst-personality.c
+index e730650e5b..5e59627826 100644
+--- a/sysdeps/unix/sysv/linux/tst-personality.c
++++ b/sysdeps/unix/sysv/linux/tst-personality.c
+@@ -19,27 +19,36 @@
+ 
+ #include <errno.h>
+ #include <sys/personality.h>
++#include <support/check.h>
+ 
+ static int
+ do_test (void)
+ {
+-  int rc = 0;
+   unsigned int test_persona = -EINVAL;
+   unsigned int saved_persona;
+ 
+   errno = 0xdefaced;
+   saved_persona = personality (0xffffffff);
+ 
+-  if (personality (test_persona) != saved_persona
+-      || personality (0xffffffff) == -1
+-      || personality (PER_LINUX) == -1
+-      || personality (0xffffffff) != PER_LINUX
+-      || 0xdefaced != errno)
+-    rc = 1;
+-
+-  (void) personality (saved_persona);
+-  return rc;
++  unsigned int r = personality (test_persona);
++  if (r == -1)
++    {
++      /* The syscall argument might be filtered by kernel, so the
++        test can not check for the bug issue.  */
++      if (errno == EPERM)
++       FAIL_UNSUPPORTED ("personality syscall argument are filtered");
++      FAIL_EXIT1 ("personality (%#x) failed: %m", test_persona);
++    }
++
++  TEST_COMPARE (r, saved_persona);
++  TEST_VERIFY (personality (0xffffffff) != -1);
++  TEST_VERIFY (personality (PER_LINUX) != -1);
++  TEST_COMPARE (personality (0xffffffff), PER_LINUX);
++  TEST_COMPARE (0xdefaced, errno);
++
++  personality (saved_persona);
++
++  return 0;
+ }
+ 
+-#define TEST_FUNCTION do_test ()
+-#include "../test-skeleton.c"
++#include <support/test-driver.c>
+
+From e369114462d4340d1b90e25a2475ed5d7b45d373 Mon Sep 17 00:00:00 2001
+From: Stafford Horne <shorne@gmail.com>
+Date: Wed, 3 Apr 2024 06:40:37 +0100
+Subject: [PATCH] misc: Add support for Linux uio.h RWF_NOAPPEND flag
+
+In Linux 6.9 a new flag is added to allow for Per-io operations to
+disable append mode even if a file was opened with the flag O_APPEND.
+This is done with the new RWF_NOAPPEND flag.
+
+This caused two test failures as these tests expected the flag 0x00000020
+to be unused.  Adding the flag definition now fixes these tests on Linux
+6.9 (v6.9-rc1).
+
+  FAIL: misc/tst-preadvwritev2
+  FAIL: misc/tst-preadvwritev64v2
+
+This patch adds the flag, adjusts the test and adds details to
+documentation.
+
+Link: https://lore.kernel.org/all/20200831153207.GO3265@brightrain.aerifal.cx/
+Reviewed-by: Adhemerval Zanella  <adhemerval.zanella@linaro.org>
+(cherry picked from commit 3db9d208dd5f30b12900989c6d2214782b8e2011)
+---
+ manual/llio.texi                       | 4 ++++
+ misc/tst-preadvwritev2-common.c        | 5 ++++-
+ sysdeps/unix/sysv/linux/bits/uio-ext.h | 1 +
+ 3 files changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/manual/llio.texi b/manual/llio.texi
+index 9ed1437aee..17dabd159e 100644
+--- a/manual/llio.texi
++++ b/manual/llio.texi
+@@ -1339,6 +1339,10 @@ will fail and set @code{errno} to @code{EAGAIN} if the operation would block.
+ 
+ @item RWF_APPEND
+ Per-IO synchronization as if the file was opened with @code{O_APPEND} flag.
++
++@item RWF_NOAPPEND
++This flag allows an offset to be honored, even if the file was opened with
++@code{O_APPEND} flag.
+ @end vtable
+ 
+ When the source file is compiled with @code{_FILE_OFFSET_BITS == 64} the
+diff --git a/misc/tst-preadvwritev2-common.c b/misc/tst-preadvwritev2-common.c
+index 40b527bdcb..ed3dc04eeb 100644
+--- a/misc/tst-preadvwritev2-common.c
++++ b/misc/tst-preadvwritev2-common.c
+@@ -34,8 +34,11 @@
+ #ifndef RWF_APPEND
+ # define RWF_APPEND 0
+ #endif
++#ifndef RWF_NOAPPEND
++# define RWF_NOAPPEND 0
++#endif
+ #define RWF_SUPPORTED	(RWF_HIPRI | RWF_DSYNC | RWF_SYNC | RWF_NOWAIT \
+-			 | RWF_APPEND)
++			 | RWF_APPEND | RWF_NOAPPEND)
+ 
+ /* Generic uio_lim.h does not define IOV_MAX.  */
+ #ifndef IOV_MAX
+diff --git a/sysdeps/unix/sysv/linux/bits/uio-ext.h b/sysdeps/unix/sysv/linux/bits/uio-ext.h
+index 5b0dba08c5..e49b66facd 100644
+--- a/sysdeps/unix/sysv/linux/bits/uio-ext.h
++++ b/sysdeps/unix/sysv/linux/bits/uio-ext.h
+@@ -47,6 +47,7 @@ extern ssize_t process_vm_writev (pid_t __pid, const struct iovec *__lvec,
+ #define RWF_SYNC	0x00000004 /* per-IO O_SYNC.  */
+ #define RWF_NOWAIT	0x00000008 /* per-IO nonblocking mode.  */
+ #define RWF_APPEND	0x00000010 /* per-IO O_APPEND.  */
++#define RWF_NOAPPEND	0x00000020 /* per-IO negation of O_APPEND */
+ 
+ __END_DECLS
+ 
+From 5ffc903216901914dc2ad9715088d3fe9d1ef205 Mon Sep 17 00:00:00 2001
+From: Adhemerval Zanella <adhemerval.zanella@linaro.org>
+Date: Tue, 8 Oct 2024 15:45:29 -0300
+Subject: [PATCH] misc: Add support for Linux uio.h RWF_ATOMIC flag
+
+Linux 6.11 adds the new flag for pwritev2 (commit
+c34fc6f26ab86d03a2d47446f42b6cd492dfdc56).
+
+Checked on x86_64-linux-gnu on 6.11 kernel.
+
+Reviewed-by: H.J. Lu <hjl.tools@gmail.com>
+---
+ manual/llio.texi                       | 13 +++++++++++++
+ misc/tst-preadvwritev2-common.c        |  5 ++++-
+ sysdeps/unix/sysv/linux/bits/uio-ext.h |  2 ++
+ 3 files changed, 19 insertions(+), 1 deletion(-)
+
+diff --git a/manual/llio.texi b/manual/llio.texi
+index 05ab44c6e7..0eb336f70b 100644
+--- a/manual/llio.texi
++++ b/manual/llio.texi
+@@ -1381,6 +1381,19 @@ Per-IO synchronization as if the file was opened with @code{O_APPEND} flag.
+ @item RWF_NOAPPEND
+ This flag allows an offset to be honored, even if the file was opened with
+ @code{O_APPEND} flag.
++
++@item RWF_ATOMIC
++Indicate that the write is to be issued with torn-write prevention.  The
++input buffer should follow some contraints: the total length should be
++power-of-2 in size and also sizes between @code{atomic_write_unit_min}
++and @code{atomic_write_unit_max}, the @code{struct iovec} count should be
++up to @code{atomic_write_segments_max}, and the offset should be
++naturally-aligned with regard to total write length.
++
++The @code{atomic_*} values can be obtained with @code{statx} along with
++@code{STATX_WRITE_ATOMIC} flag.
++
++This is a Linux-specific extension.
+ @end vtable
+ 
+ When the source file is compiled with @code{_FILE_OFFSET_BITS == 64} the
+diff --git a/misc/tst-preadvwritev2-common.c b/misc/tst-preadvwritev2-common.c
+index 8e04ff7282..4556421a43 100644
+--- a/misc/tst-preadvwritev2-common.c
++++ b/misc/tst-preadvwritev2-common.c
+@@ -37,8 +37,11 @@
+ #ifndef RWF_NOAPPEND
+ # define RWF_NOAPPEND 0
+ #endif
++#ifndef RWF_ATOMIC
++# define RWF_ATOMIC 0
++#endif
+ #define RWF_SUPPORTED	(RWF_HIPRI | RWF_DSYNC | RWF_SYNC | RWF_NOWAIT \
+-			 | RWF_APPEND | RWF_NOAPPEND)
++			 | RWF_APPEND | RWF_NOAPPEND | RWF_ATOMIC)
+ 
+ /* Generic uio_lim.h does not define IOV_MAX.  */
+ #ifndef IOV_MAX
+diff --git a/sysdeps/unix/sysv/linux/bits/uio-ext.h b/sysdeps/unix/sysv/linux/bits/uio-ext.h
+index ead7a09156..85ed21bac5 100644
+--- a/sysdeps/unix/sysv/linux/bits/uio-ext.h
++++ b/sysdeps/unix/sysv/linux/bits/uio-ext.h
+@@ -48,6 +48,8 @@ extern ssize_t process_vm_writev (pid_t __pid, const struct iovec *__lvec,
+ #define RWF_NOWAIT	0x00000008 /* per-IO nonblocking mode.  */
+ #define RWF_APPEND	0x00000010 /* per-IO O_APPEND.  */
+ #define RWF_NOAPPEND	0x00000020 /* per-IO negation of O_APPEND */
++#define RWF_ATOMIC	0x00000040 /* Write is to be issued with torn-write
++				      prevention.  */
+ 
+ __END_DECLS
+ 
+From 3b39822a82a2415f92ddbc1503e4a55597034573 Mon Sep 17 00:00:00 2001
+From: Xi Ruoyao <xry111@xry111.site>
+Date: Thu, 28 Aug 2025 13:56:40 +0800
+Subject: [PATCH] misc: Add support for Linux uio.h RWF_DONTCACHE flag
+
+Linux 6.14 adds the new flag for uncached buffered IO on a filesystem
+supporting it.
+
+This caused two test failures as these tests expected the flag
+0x00000080 is unused.  Add the flag definition to fix these tests on
+Linux >= 6.14:
+
+    FAIL: misc/tst-preadvwritev2
+    FAIL: misc/tst-preadvwritev64v2
+
+The test failures were not detected in routine test suite runs because
+normally we create the test file in /tmp, where a tmpfs is usually
+mounted, and tmpfs does not support this flag.  But it can be reproduced
+with TMPDIR set to some directory in an ext4 file system.
+
+Link: https://git.kernel.org/torvalds/c/af6505e5745b
+Signed-off-by: Xi Ruoyao <xry111@xry111.site>
+Reviewed-by: Adhemerval Zanella  <adhemerval.zanella@linaro.org>
+---
+ manual/llio.texi                       | 4 ++++
+ misc/tst-preadvwritev2-common.c        | 6 +++++-
+ sysdeps/unix/sysv/linux/bits/uio-ext.h | 1 +
+ 3 files changed, 10 insertions(+), 1 deletion(-)
+
+diff --git a/manual/llio.texi b/manual/llio.texi
+index e7fd6ca0e9..806ff0a27d 100644
+--- a/manual/llio.texi
++++ b/manual/llio.texi
+@@ -1414,6 +1414,10 @@ naturally-aligned with regard to total write length.
+ The @code{atomic_*} values can be obtained with @code{statx} along with
+ @code{STATX_WRITE_ATOMIC} flag.
+ 
++@item RWF_DONTCACHE
++Use uncached buffered IO.  If the file system does not support it, the
++call will fail and set @code{errno} to @code{EOPNOTSUPP}.
++
+ This is a Linux-specific extension.
+ @end vtable
+ 
+diff --git a/misc/tst-preadvwritev2-common.c b/misc/tst-preadvwritev2-common.c
+index ff1007d6d2..8a59ff2f9d 100644
+--- a/misc/tst-preadvwritev2-common.c
++++ b/misc/tst-preadvwritev2-common.c
+@@ -40,8 +40,12 @@
+ #ifndef RWF_ATOMIC
+ # define RWF_ATOMIC 0
+ #endif
++#ifndef RWF_DONTCACHE
++# define RWF_DONTCACHE 0
++#endif
+ #define RWF_SUPPORTED	(RWF_HIPRI | RWF_DSYNC | RWF_SYNC | RWF_NOWAIT \
+-			 | RWF_APPEND | RWF_NOAPPEND | RWF_ATOMIC)
++			 | RWF_APPEND | RWF_NOAPPEND | RWF_ATOMIC \
++			 | RWF_DONTCACHE)
+ 
+ /* Generic uio_lim.h does not define IOV_MAX.  */
+ #ifndef IOV_MAX
+diff --git a/sysdeps/unix/sysv/linux/bits/uio-ext.h b/sysdeps/unix/sysv/linux/bits/uio-ext.h
+index 040cb8dd48..1b7ab4b495 100644
+--- a/sysdeps/unix/sysv/linux/bits/uio-ext.h
++++ b/sysdeps/unix/sysv/linux/bits/uio-ext.h
+@@ -50,6 +50,7 @@ extern ssize_t process_vm_writev (pid_t __pid, const struct iovec *__lvec,
+ #define RWF_NOAPPEND	0x00000020 /* per-IO negation of O_APPEND */
+ #define RWF_ATOMIC	0x00000040 /* Write is to be issued with torn-write
+ 				      prevention.  */
++#define RWF_DONTCACHE	0x00000080 /* Uncached buffered IO.  */
+ 
+ __END_DECLS
+ 
+
+From 1dd783fafdbc30bd82e078ccab42b9539d3274a5 Mon Sep 17 00:00:00 2001
+From: "H.J. Lu" <hjl.tools@gmail.com>
+Date: Tue, 15 Feb 2022 06:57:11 -0800
+Subject: [PATCH] elf: Check invalid hole in PT_LOAD segments [BZ #28838]
+
+Changes in v2:
+
+1. Update commit log.
+
+commit 163f625cf9becbb82dfec63a29e566324129c0cd
+Author: H.J. Lu <hjl.tools@gmail.com>
+Date:   Tue Dec 21 12:35:47 2021 -0800
+
+    elf: Remove excessive p_align check on PT_LOAD segments [BZ #28688]
+
+removed the p_align check against the page size.  It caused the loader
+error or crash on elf/tst-p_align3 when loading elf/tst-p_alignmod3.so,
+which has the invalid p_align in PT_LOAD segments, added by
+
+commit d8d94863ef125a392b929732b37e07dc927fbcd1
+Author: H.J. Lu <hjl.tools@gmail.com>
+Date:   Tue Dec 21 13:42:28 2021 -0800
+
+The loader failure caused by a negative length passed to __mprotect is
+random, depending on architecture and toolchain.  Update _dl_map_segments
+to detect invalid holes.  This fixes BZ #28838.
+
+Reviewed-by: Florian Weimer <fweimer@redhat.com>
+(cherry picked from commit 2c0915cbf570cb9c8a65f1d20a55c5a7238e5b63)
+---
+ elf/dl-map-segments.h | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/elf/dl-map-segments.h b/elf/dl-map-segments.h
+index 172692b120..fd24cf5d01 100644
+--- a/elf/dl-map-segments.h
++++ b/elf/dl-map-segments.h
+@@ -113,6 +113,9 @@ _dl_map_segments (struct link_map *l, int fd,
+              unallocated.  Then jump into the normal segment-mapping loop to
+              handle the portion of the segment past the end of the file
+              mapping.  */
++	  if (__glibc_unlikely (loadcmds[nloadcmds - 1].mapstart <
++				c->mapend))
++	    return N_("ELF load command address/offset not page-aligned");
+           if (__glibc_unlikely
+               (__mprotect ((caddr_t) (l->l_addr + c->mapend),
+                            loadcmds[nloadcmds - 1].mapstart - c->mapend,


### PR DESCRIPTION
Various CVE fixes since 2.35's release and now.

Plus various test suite patches so that we can run that now in our bottle builds.